### PR TITLE
feat: add Docker Compose for all services (infra + apps + model serving)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,13 @@ build:
 	@if [ -d apps/studio-web/node_modules ]; then npm --prefix apps/studio-web run build; else echo "Skipping studio-web build (run make install first)"; fi
 
 docker-up:
-	@echo "docker-compose is planned in Issue #7"
+	docker compose up -d
 
 docker-down:
-	@echo "docker-compose is planned in Issue #7"
+	docker compose down
+
+docker-up-all:
+	docker compose --profile monitoring up -d
+
+docker-logs:
+	docker compose logs -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,180 @@
+services:
+  postgres:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      target: dev
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./apps/api/src:/app/src
+      - ./packages:/app/packages
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  worker:
+    build:
+      context: .
+      dockerfile: apps/worker-orchestrator/Dockerfile
+      target: dev
+    volumes:
+      - ./apps/worker-orchestrator/tasks:/app/tasks
+      - ./apps/worker-orchestrator/celery_app.py:/app/celery_app.py
+      - ./packages:/app/packages
+      - ./data/artifacts:/app/data/artifacts
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  studio-web:
+    build:
+      context: .
+      dockerfile: apps/studio-web/Dockerfile
+      target: dev
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./apps/studio-web/src:/app/src
+      - ./apps/studio-web/index.html:/app/index.html
+    depends_on:
+      api:
+        condition: service_started
+    restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  stable-diffusion:
+    image: shorts-automation-stable-diffusion:latest
+    ports:
+      - "7860:7860"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7860/sdapi/v1/options"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  tts-qwen3:
+    image: shorts-automation-tts-qwen3:latest
+    ports:
+      - "9880:9880"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    # TODO: replace placeholder when tts-qwen3 health endpoint is finalized.
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  stt-whisper:
+    image: shorts-automation-stt-whisper:latest
+    ports:
+      - "9000:9000"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    # TODO: replace placeholder when stt-whisper health endpoint is finalized.
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  flower:
+    image: mher/flower:2.0
+    ports:
+      - "5555:5555"
+    environment:
+      CELERY_BROKER_URL: redis://redis:6379/0
+    depends_on:
+      redis:
+        condition: service_healthy
+    profiles:
+      - monitoring
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  ollama_data:


### PR DESCRIPTION
## Summary
- Add root `docker-compose.yml` that brings up infra, app, model-serving, and optional monitoring services in one command.
- Wire app service build targets/volume mounts for dev hot-reload and add healthchecks/depends_on sequencing.
- Update Makefile Docker targets to use `docker compose` and include monitoring profile convenience target.

Closes #7