### PR TITLE
feat: add provider abstraction layer with base interfaces and registry

### DIFF
--- a/packages/creator-provider/__init__.py
+++ b/packages/creator-provider/__init__.py
@@ -1,1 +1,15 @@
-"""creator-provider package scaffold."""
+from .base import AudioResult, ImageProvider, ImageResult, LLMProvider, STTProvider, SubtitleResult, TTSProvider
+from .registry import ModelCatalogEntry, ProviderCategory, ProviderRegistry
+
+__all__ = [
+    "LLMProvider",
+    "ImageProvider",
+    "TTSProvider",
+    "STTProvider",
+    "ImageResult",
+    "AudioResult",
+    "SubtitleResult",
+    "ProviderRegistry",
+    "ProviderCategory",
+    "ModelCatalogEntry",
+]

--- a/packages/creator-provider/base.py
+++ b/packages/creator-provider/base.py
@@ -1,1 +1,61 @@
-"""Placeholder for base."""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ImageResult:
+    image_path: str
+    width: int
+    height: int
+    model_key: str
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass
+class AudioResult:
+    audio_path: str
+    duration_seconds: float
+    model_key: str
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass
+class SubtitleResult:
+    segments: list[dict[str, Any]]
+    full_text: str
+    model_key: str
+    metadata: dict[str, Any] | None = None
+
+
+class LLMProvider(ABC):
+    @abstractmethod
+    async def generate(self, prompt: str, params: dict[str, Any] | None = None) -> str:
+        ...
+
+
+class ImageProvider(ABC):
+    @abstractmethod
+    async def generate(self, prompt: str, params: dict[str, Any] | None = None) -> ImageResult:
+        ...
+
+
+class TTSProvider(ABC):
+    @abstractmethod
+    async def generate(
+        self,
+        text: str,
+        voice: str = "default",
+        params: dict[str, Any] | None = None,
+    ) -> AudioResult:
+        ...
+
+
+class STTProvider(ABC):
+    @abstractmethod
+    async def transcribe(
+        self,
+        audio_path: str,
+        params: dict[str, Any] | None = None,
+    ) -> SubtitleResult:
+        ...

--- a/packages/creator-provider/registry.py
+++ b/packages/creator-provider/registry.py
@@ -1,1 +1,96 @@
-"""Placeholder for registry."""
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class ProviderCategory(Enum):
+    LLM = "llm"
+    IMAGE = "image"
+    TTS = "tts"
+    STT = "stt"
+
+
+@dataclass
+class ModelCatalogEntry:
+    model_key: str
+    provider_type: str
+    endpoint: str
+    category: ProviderCategory
+    requires_gpu: bool = True
+    is_local: bool = True
+    default_params: dict[str, Any] | None = None
+
+
+class ProviderRegistry:
+    def __init__(self):
+        self._catalog: dict[str, ModelCatalogEntry] = {}
+        self._providers: dict[str, Any] = {}
+
+    def register_model(self, entry: ModelCatalogEntry) -> None:
+        self._catalog[entry.model_key] = entry
+
+    def register_provider(self, provider_type: str, provider_class: type) -> None:
+        self._providers[provider_type] = provider_class
+
+    def resolve(self, model_key: str) -> ModelCatalogEntry:
+        if model_key not in self._catalog:
+            raise KeyError(f"Model '{model_key}' not found in catalog")
+        return self._catalog[model_key]
+
+    def get_provider(self, model_key: str) -> Any:
+        entry = self.resolve(model_key)
+        provider_class = self._providers.get(entry.provider_type)
+        if provider_class is None:
+            raise KeyError(f"Provider type '{entry.provider_type}' not registered")
+        return provider_class(endpoint=entry.endpoint, model_key=model_key)
+
+    def list_models(self, category: ProviderCategory | None = None) -> list[ModelCatalogEntry]:
+        entries = list(self._catalog.values())
+        if category:
+            entries = [entry for entry in entries if entry.category == category]
+        return entries
+
+    @classmethod
+    def create_default(cls) -> "ProviderRegistry":
+        registry = cls()
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="qwen3-4b",
+                provider_type="ollama",
+                endpoint="http://ollama:11434",
+                category=ProviderCategory.LLM,
+                requires_gpu=True,
+                is_local=True,
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="sd15",
+                provider_type="sd_local",
+                endpoint="http://stable-diffusion:7860",
+                category=ProviderCategory.IMAGE,
+                requires_gpu=True,
+                is_local=True,
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="qwen-tts",
+                provider_type="qwen_tts",
+                endpoint="http://tts-qwen3:9880",
+                category=ProviderCategory.TTS,
+                requires_gpu=True,
+                is_local=True,
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="whisper-medium",
+                provider_type="whisper",
+                endpoint="http://stt-whisper:9000",
+                category=ProviderCategory.STT,
+                requires_gpu=True,
+                is_local=True,
+            )
+        )
+        return registry

--- a/packages/creator-provider/tests/test_registry.py
+++ b/packages/creator-provider/tests/test_registry.py
@@ -1,0 +1,98 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from registry import ModelCatalogEntry, ProviderCategory, ProviderRegistry
+
+
+class ProviderRegistryTests(unittest.TestCase):
+    def test_register_model_and_resolve_for_all_categories(self) -> None:
+        registry = ProviderRegistry()
+        entries = [
+            ModelCatalogEntry(
+                model_key="test-llm",
+                provider_type="ollama",
+                endpoint="http://ollama:11434",
+                category=ProviderCategory.LLM,
+            ),
+            ModelCatalogEntry(
+                model_key="test-image",
+                provider_type="sd_local",
+                endpoint="http://stable-diffusion:7860",
+                category=ProviderCategory.IMAGE,
+            ),
+            ModelCatalogEntry(
+                model_key="test-tts",
+                provider_type="qwen_tts",
+                endpoint="http://tts-qwen3:9880",
+                category=ProviderCategory.TTS,
+            ),
+            ModelCatalogEntry(
+                model_key="test-stt",
+                provider_type="whisper",
+                endpoint="http://stt-whisper:9000",
+                category=ProviderCategory.STT,
+            ),
+        ]
+
+        for entry in entries:
+            with self.subTest(model_key=entry.model_key):
+                registry.register_model(entry)
+                resolved = registry.resolve(entry.model_key)
+                self.assertEqual(resolved, entry)
+
+    def test_resolve_raises_key_error_for_unknown_model(self) -> None:
+        registry = ProviderRegistry()
+
+        with self.assertRaises(KeyError):
+            registry.resolve("unknown-model")
+
+    def test_list_models_with_category_filter(self) -> None:
+        registry = ProviderRegistry()
+        llm_entry = ModelCatalogEntry(
+            model_key="test-llm",
+            provider_type="ollama",
+            endpoint="http://ollama:11434",
+            category=ProviderCategory.LLM,
+        )
+        image_entry = ModelCatalogEntry(
+            model_key="test-image",
+            provider_type="sd_local",
+            endpoint="http://stable-diffusion:7860",
+            category=ProviderCategory.IMAGE,
+        )
+
+        registry.register_model(llm_entry)
+        registry.register_model(image_entry)
+
+        llm_models = registry.list_models(category=ProviderCategory.LLM)
+
+        self.assertEqual(llm_models, [llm_entry])
+
+    def test_create_default_returns_registry_with_default_entries(self) -> None:
+        registry = ProviderRegistry.create_default()
+
+        self.assertEqual(len(registry.list_models()), 4)
+        self.assertEqual(registry.resolve("qwen3-4b").category, ProviderCategory.LLM)
+        self.assertEqual(registry.resolve("sd15").category, ProviderCategory.IMAGE)
+        self.assertEqual(registry.resolve("qwen-tts").category, ProviderCategory.TTS)
+        self.assertEqual(registry.resolve("whisper-medium").category, ProviderCategory.STT)
+
+    def test_get_provider_raises_key_error_for_unregistered_provider_type(self) -> None:
+        registry = ProviderRegistry()
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="test-llm",
+                provider_type="unregistered",
+                endpoint="http://localhost:9999",
+                category=ProviderCategory.LLM,
+            )
+        )
+
+        with self.assertRaises(KeyError):
+            registry.get_provider("test-llm")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #75

## Summary
- add abstract base interfaces and result dataclasses for LLM, Image, TTS, and STT providers
- add provider registry with model catalog entries, category filtering, provider resolution, and default local model mappings
- add unit tests covering model registration/resolution, category listing, default catalog entries, and provider resolution failures