### PR TITLE
feat(worker): add generate_script Celery task (#25)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Python dependencies
+        run: python3 -m pip install -r apps/api/requirements.txt -r apps/worker-orchestrator/requirements.txt
+      - name: Install Node dependencies
+        run: npm --prefix apps/studio-web install
+      - name: Lint Python
+        run: |
+          ruff check apps packages
+          python3 -m compileall apps packages
+      - name: Lint TypeScript
+        run: npm --prefix apps/studio-web run lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Python dependencies
+        run: python3 -m pip install -r apps/api/requirements.txt -r apps/worker-orchestrator/requirements.txt
+      - name: Install Node dependencies
+        run: npm --prefix apps/studio-web install
+      - name: Test API
+        run: cd apps/api && python3 -m pytest tests/ -v
+      - name: Test Worker
+        run: cd apps/worker-orchestrator && python3 -m pytest tests/ -v
+      - name: Test Frontend
+        run: npm --prefix apps/studio-web run test

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,13 @@ dev:
 	@echo "- Web: npm --prefix apps/studio-web run dev"
 
 lint:
+	ruff check apps packages
 	python3 -m compileall apps packages
 	@if [ -d apps/studio-web/node_modules ]; then npm --prefix apps/studio-web run lint; else echo "Skipping studio-web lint (run make install first)"; fi
+
+format:
+	ruff format apps packages
+	@if [ -d apps/studio-web/node_modules ]; then npm --prefix apps/studio-web run format; else echo "Skipping studio-web format (run make install first)"; fi
 
 test:
 	@echo "No tests scaffolded yet."

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ format:
 	@if [ -d apps/studio-web/node_modules ]; then npm --prefix apps/studio-web run format; else echo "Skipping studio-web format (run make install first)"; fi
 
 test:
-	@echo "No tests scaffolded yet."
+	cd apps/api && python3 -m pytest tests/ -v
+	cd apps/worker-orchestrator && python3 -m pytest tests/ -v
+	@if [ -d apps/studio-web/node_modules ]; then npm --prefix apps/studio-web run test; else echo "Skipping studio-web tests (run make install first)"; fi
 
 build:
 	python3 -m compileall apps packages

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -10,6 +10,8 @@ FROM python:3.12-slim AS runtime
 WORKDIR /app
 COPY --from=builder /install /usr/local
 COPY apps/api/src ./src
+COPY apps/api/alembic.ini ./alembic.ini
+COPY apps/api/migrations ./migrations
 COPY packages ./packages
 ENV PYTHONPATH=/app/src:/app
 EXPOSE 8000

--- a/apps/api/alembic.ini
+++ b/apps/api/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = postgresql://short_form_user:short_form_password@postgres:5432/short_form_pipeline
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/apps/api/migrations/env.py
+++ b/apps/api/migrations/env.py
@@ -1,0 +1,43 @@
+"""Alembic environment configuration."""
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+import os
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Override URL from environment if available
+db_url = os.getenv("DATABASE_URL")
+if not db_url:
+    user = os.getenv("POSTGRES_USER", "short_form_user")
+    password = os.getenv("POSTGRES_PASSWORD", "short_form_password")
+    host = os.getenv("POSTGRES_HOST", "postgres")
+    port = os.getenv("POSTGRES_PORT", "5432")
+    db = os.getenv("POSTGRES_DB", "short_form_pipeline")
+    db_url = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+if db_url:
+    config.set_main_option("sqlalchemy.url", db_url)
+
+target_metadata = None
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    section = config.get_section(config.config_ini_section) or {}
+    connectable = engine_from_config(section, prefix="sqlalchemy.", poolclass=pool.NullPool)
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/apps/api/migrations/script.py.mako
+++ b/apps/api/migrations/script.py.mako
@@ -1,0 +1,22 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/apps/api/migrations/versions/001_create_creator_projects.py
+++ b/apps/api/migrations/versions/001_create_creator_projects.py
@@ -1,0 +1,66 @@
+"""Create creator_projects table.
+
+Revision ID: 001
+Revises: None
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_projects",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("source_type", sa.String(length=50), nullable=False, server_default="idea"),
+        sa.Column("idea_brief", sa.Text(), nullable=True),
+        sa.Column("markdown_source", sa.Text(), nullable=True),
+        sa.Column("url_source", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="draft"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_check_constraint(
+        "ck_creator_projects_source_type",
+        "creator_projects",
+        "source_type IN ('idea', 'markdown', 'url')",
+    )
+    op.create_check_constraint(
+        "ck_creator_projects_status",
+        "creator_projects",
+        "status IN ('draft', 'active', 'completed', 'archived')",
+    )
+
+    op.execute(
+        """
+    CREATE OR REPLACE FUNCTION update_updated_at_column()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        NEW.updated_at = NOW();
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    """
+    )
+    op.execute(
+        """
+    CREATE TRIGGER set_updated_at
+    BEFORE UPDATE ON creator_projects
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+    """
+    )
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS set_updated_at ON creator_projects")
+    op.execute("DROP FUNCTION IF EXISTS update_updated_at_column()")
+    op.drop_constraint("ck_creator_projects_source_type", "creator_projects")
+    op.drop_constraint("ck_creator_projects_status", "creator_projects")
+    op.drop_table("creator_projects")

--- a/apps/api/migrations/versions/002_create_creator_runs.py
+++ b/apps/api/migrations/versions/002_create_creator_runs.py
@@ -1,0 +1,58 @@
+"""Create creator_runs table.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_runs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_id", sa.Integer(), sa.ForeignKey("creator_projects.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("current_stage", sa.String(length=50), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="pending"),
+        sa.Column("review_stage", sa.String(length=50), nullable=True),
+        sa.Column("restart_from", sa.String(length=50), nullable=True),
+        sa.Column("model_defaults_json", sa.Text(), nullable=True),
+        sa.Column("metadata_json", sa.Text(), nullable=True),
+        sa.Column("style_preset", sa.String(length=100), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    # CHECK constraint for status
+    op.create_check_constraint(
+        "ck_creator_runs_status",
+        "creator_runs",
+        "status IN ('pending', 'running', 'paused', 'completed', 'failed', 'cancelled')",
+    )
+
+    # Index on project_id for FK lookups
+    op.create_index("ix_creator_runs_project_id", "creator_runs", ["project_id"])
+
+    # Reuse the update_updated_at_column() function from migration 001
+    op.execute(
+        """
+    CREATE TRIGGER set_updated_at_creator_runs
+    BEFORE UPDATE ON creator_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+    """
+    )
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS set_updated_at_creator_runs ON creator_runs")
+    op.drop_constraint("ck_creator_runs_status", "creator_runs")
+    op.drop_index("ix_creator_runs_project_id")
+    op.drop_table("creator_runs")

--- a/apps/api/migrations/versions/003_create_creator_stage_reviews.py
+++ b/apps/api/migrations/versions/003_create_creator_stage_reviews.py
@@ -1,0 +1,45 @@
+"""Create creator_stage_reviews table.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "003"
+down_revision: Union[str, None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_stage_reviews",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("creator_runs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("stage_name", sa.String(length=50), nullable=False),
+        sa.Column("review_status", sa.String(length=50), nullable=False, server_default="pending"),
+        sa.Column("reviewer", sa.String(length=100), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    # CHECK constraint for review_status
+    op.create_check_constraint(
+        "ck_creator_stage_reviews_review_status",
+        "creator_stage_reviews",
+        "review_status IN ('pending', 'approved', 'rejected', 'skipped')",
+    )
+
+    # Composite index for lookups by run + stage
+    op.create_index(
+        "ix_creator_stage_reviews_run_stage",
+        "creator_stage_reviews",
+        ["run_id", "stage_name"],
+    )
+
+def downgrade() -> None:
+    op.drop_index("ix_creator_stage_reviews_run_stage")
+    op.drop_constraint("ck_creator_stage_reviews_review_status", "creator_stage_reviews")
+    op.drop_table("creator_stage_reviews")

--- a/apps/api/migrations/versions/004_create_creator_scene_assets.py
+++ b/apps/api/migrations/versions/004_create_creator_scene_assets.py
@@ -1,0 +1,66 @@
+"""Create creator_scene_assets table.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_scene_assets",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("creator_runs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("scene_id", sa.String(length=100), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("asset_path", sa.Text(), nullable=False),
+        sa.Column("prompt_snapshot", sa.Text(), nullable=True),
+        sa.Column("model_used", sa.String(length=100), nullable=True),
+        sa.Column("provider", sa.String(length=50), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    # Index for lookups by run + scene
+    op.create_index(
+        "ix_creator_scene_assets_run_scene",
+        "creator_scene_assets",
+        ["run_id", "scene_id"],
+    )
+
+    # Index for active asset lookups
+    op.create_index(
+        "ix_creator_scene_assets_active",
+        "creator_scene_assets",
+        ["run_id", "scene_id", "is_active"],
+    )
+
+    # Unique constraint: no duplicate version per scene
+    op.create_unique_constraint(
+        "uq_creator_scene_assets_run_scene_version",
+        "creator_scene_assets",
+        ["run_id", "scene_id", "version"],
+    )
+
+    # Partial unique index: only one active asset per scene
+    op.execute(
+        """
+    CREATE UNIQUE INDEX uq_creator_scene_assets_active
+    ON creator_scene_assets (run_id, scene_id)
+    WHERE is_active = true;
+    """
+    )
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_creator_scene_assets_active")
+    op.drop_constraint("uq_creator_scene_assets_run_scene_version", "creator_scene_assets")
+    op.drop_index("ix_creator_scene_assets_active")
+    op.drop_index("ix_creator_scene_assets_run_scene")
+    op.drop_table("creator_scene_assets")

--- a/apps/api/migrations/versions/005_expand_artifact_typing_and_indexes.py
+++ b/apps/api/migrations/versions/005_expand_artifact_typing_and_indexes.py
@@ -55,6 +55,13 @@ def upgrade() -> None:
         ")",
     )
 
+    # Conditional CHECK: visual_asset requires scene_id
+    op.create_check_constraint(
+        "ck_creator_artifacts_visual_asset_scene_id",
+        "creator_artifacts",
+        "artifact_type <> 'visual_asset' OR scene_id IS NOT NULL",
+    )
+
     # updated_at trigger (reuses function from migration 001)
     op.execute(
         """
@@ -99,6 +106,8 @@ def upgrade() -> None:
         "creator_runs",
         ["current_stage"],
     )
+    # Drop redundant single-column index from 002 — superseded by composite above
+    op.drop_index("ix_creator_runs_project_id", "creator_runs")
 
 
 def downgrade() -> None:
@@ -106,6 +115,8 @@ def downgrade() -> None:
     op.drop_index("ix_creator_runs_current_stage", "creator_runs")
     op.drop_index("ix_creator_runs_project_created_desc", "creator_runs")
     op.drop_index("ix_creator_projects_created_at_desc", "creator_projects")
+    # Re-create the single-column index that was dropped in upgrade
+    op.create_index("ix_creator_runs_project_id", "creator_runs", ["project_id"])
 
     # Drop creator_artifacts indexes, trigger, constraint, table
     op.drop_index("ix_creator_artifacts_run_type_created", "creator_artifacts")
@@ -113,5 +124,6 @@ def downgrade() -> None:
     op.execute(
         "DROP TRIGGER IF EXISTS set_updated_at_creator_artifacts ON creator_artifacts"
     )
+    op.drop_constraint("ck_creator_artifacts_visual_asset_scene_id", "creator_artifacts")
     op.drop_constraint("ck_creator_artifacts_artifact_type", "creator_artifacts")
     op.drop_table("creator_artifacts")

--- a/apps/api/migrations/versions/005_expand_artifact_typing_and_indexes.py
+++ b/apps/api/migrations/versions/005_expand_artifact_typing_and_indexes.py
@@ -1,0 +1,117 @@
+"""Expand artifact typing and add creator indexes.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "005"
+down_revision: Union[str, None] = "004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- 1. Create creator_artifacts table ---
+    op.create_table(
+        "creator_artifacts",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "run_id",
+            sa.Integer(),
+            sa.ForeignKey("creator_runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("artifact_type", sa.String(length=50), nullable=False),
+        sa.Column("scene_id", sa.String(length=100), nullable=True),
+        sa.Column("file_path", sa.Text(), nullable=False),
+        sa.Column("file_size_bytes", sa.BigInteger(), nullable=True),
+        sa.Column("mime_type", sa.String(length=100), nullable=True),
+        sa.Column("metadata_json", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    # CHECK constraint for artifact_type
+    op.create_check_constraint(
+        "ck_creator_artifacts_artifact_type",
+        "creator_artifacts",
+        "artifact_type IN ("
+        "'idea', 'script', 'visual_plan', 'visual_asset', "
+        "'audio', 'subtitle', 'video', 'render_manifest'"
+        ")",
+    )
+
+    # updated_at trigger (reuses function from migration 001)
+    op.execute(
+        """
+    CREATE TRIGGER set_updated_at_creator_artifacts
+    BEFORE UPDATE ON creator_artifacts
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+    """
+    )
+
+    # --- 2. Indexes on creator_artifacts (from DB_MIGRATION.md §6) ---
+    op.create_index(
+        "ix_creator_artifacts_run_type",
+        "creator_artifacts",
+        ["run_id", "artifact_type"],
+    )
+    op.execute(
+        """
+    CREATE INDEX ix_creator_artifacts_run_type_created
+    ON creator_artifacts (run_id, artifact_type, created_at DESC);
+    """
+    )
+
+    # --- 3. Missing indexes on existing creator tables (from DB_MIGRATION.md §6) ---
+    # creator_projects: sort by newest first
+    op.execute(
+        """
+    CREATE INDEX ix_creator_projects_created_at_desc
+    ON creator_projects (created_at DESC);
+    """
+    )
+    # creator_runs: lookup by project sorted by newest first
+    op.execute(
+        """
+    CREATE INDEX ix_creator_runs_project_created_desc
+    ON creator_runs (project_id, created_at DESC);
+    """
+    )
+    # creator_runs: filter by current_stage
+    op.create_index(
+        "ix_creator_runs_current_stage",
+        "creator_runs",
+        ["current_stage"],
+    )
+
+
+def downgrade() -> None:
+    # Drop indexes on existing tables (reverse order)
+    op.drop_index("ix_creator_runs_current_stage", "creator_runs")
+    op.drop_index("ix_creator_runs_project_created_desc", "creator_runs")
+    op.drop_index("ix_creator_projects_created_at_desc", "creator_projects")
+
+    # Drop creator_artifacts indexes, trigger, constraint, table
+    op.drop_index("ix_creator_artifacts_run_type_created", "creator_artifacts")
+    op.drop_index("ix_creator_artifacts_run_type", "creator_artifacts")
+    op.execute(
+        "DROP TRIGGER IF EXISTS set_updated_at_creator_artifacts ON creator_artifacts"
+    )
+    op.drop_constraint("ck_creator_artifacts_artifact_type", "creator_artifacts")
+    op.drop_table("creator_artifacts")

--- a/apps/api/pytest.ini
+++ b/apps/api/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+pythonpath = src

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -6,3 +6,6 @@ redis
 
 # Dev dependencies
 ruff
+pytest
+httpx
+pytest-asyncio

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,3 +2,7 @@ fastapi
 uvicorn
 celery
 redis
+
+
+# Dev dependencies
+ruff

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,6 +2,9 @@ fastapi
 uvicorn
 celery
 redis
+alembic
+sqlalchemy
+psycopg2-binary
 
 
 # Dev dependencies

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     from logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
+from shorts_api.routes.creator_projects import router as projects_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="short-form-pipeline API")
 app.include_router(models_router, prefix="/api/creator")
+app.include_router(projects_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     from logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
+from shorts_api.routes.creator_runs import router as runs_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="short-form-pipeline API")
 app.include_router(models_router, prefix="/api/creator")
+app.include_router(runs_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -10,12 +10,14 @@ from fastapi import FastAPI
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
 
 from creator_service.logging_config import setup_json_logging
+from shorts_api.routes.creator_models import router as models_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="short-form-pipeline API")
+app.include_router(models_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -1,4 +1,5 @@
 """FastAPI entrypoint for shorts_api."""
+# pyright: reportMissingImports=false
 
 import logging
 import os
@@ -7,9 +8,15 @@ import sys
 from fastapi import FastAPI
 
 # Add packages to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
 
-from creator_service.logging_config import setup_json_logging
+try:
+    from creator_service.logging_config import setup_json_logging
+except ImportError:
+    from logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
 
 # Configure structured JSON logging

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -1,6 +1,19 @@
 """FastAPI entrypoint for shorts_api."""
 
+import logging
+import os
+import sys
+
 from fastapi import FastAPI
+
+# Add packages to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
+
+from creator_service.logging_config import setup_json_logging
+
+# Configure structured JSON logging
+setup_json_logging(service_name="api", level="INFO")
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="short-form-pipeline API")
 

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -20,6 +20,7 @@ except ImportError:
 from shorts_api.routes.creator_models import router as models_router
 from shorts_api.routes.creator_projects import router as projects_router
 from shorts_api.routes.creator_runs import router as runs_router
+from shorts_api.routes.creator_script import router as script_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
@@ -29,6 +30,7 @@ app = FastAPI(title="short-form-pipeline API")
 app.include_router(models_router, prefix="/api/creator")
 app.include_router(projects_router, prefix="/api/creator")
 app.include_router(runs_router, prefix="/api/creator")
+app.include_router(script_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/routes/creator_models.py
+++ b/apps/api/src/shorts_api/routes/creator_models.py
@@ -1,43 +1,51 @@
 """Routes for creator model management."""
+# pyright: reportMissingImports=false
 
 import logging
-import sys
 import os
-from fastapi import APIRouter
+import sys
+
+from fastapi import APIRouter, HTTPException, Query
 
 # Add packages to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
 
-from creator_service.model_health_service import ModelHealthService, ModelHealthResult
+try:
+    from creator_provider.registry import ProviderRegistry
+    from creator_service.model_catalog_service import ModelCatalogService
+    from creator_service.model_health_service import ModelHealthService
+except ImportError:
+    from model_catalog_service import ModelCatalogService
+    from model_health_service import ModelHealthService
+    from registry import ProviderRegistry
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/models", tags=["models"])
 
+VALID_CATEGORIES = {"script", "image", "tts", "stt"}
+model_catalog_service = ModelCatalogService(
+    registry=ProviderRegistry.create_default(),
+    health_service=ModelHealthService(),
+)
+
+
+@router.get("")
+async def list_models(category: str | None = Query(default=None)) -> dict[str, list[dict[str, object]]]:
+    """List available creator models by category."""
+    if category is not None and category not in VALID_CATEGORIES:
+        raise HTTPException(status_code=400, detail="Invalid category")
+
+    return await model_catalog_service.list_models(category=category)
+
 
 @router.get("/status")
-async def get_model_status() -> dict:
-    """Get health status of all model serving containers.
-    
-    Returns:
-        Dictionary containing list of model health results.
-    """
+async def get_model_status() -> dict[str, object]:
+    """Return provider-level status and GPU lock state."""
     logger.info("Model status check requested")
-    
-    health_service = ModelHealthService()
-    results = await health_service.check_all()
-    
-    # Convert enum values to strings for JSON serialization
-    results_dict = [
-        {
-            "model_name": result.model_name,
-            "endpoint": result.endpoint,
-            "status": result.status.value,
-            "response_time_ms": result.response_time_ms,
-            "error": result.error,
-        }
-        for result in results
-    ]
-    
-    logger.info(f"Model status check completed with {len(results)} models checked")
-    return {"models": results_dict}
+    status = await model_catalog_service.get_status()
+    logger.info("Model status check completed")
+    return status

--- a/apps/api/src/shorts_api/routes/creator_models.py
+++ b/apps/api/src/shorts_api/routes/creator_models.py
@@ -1,1 +1,43 @@
-"""Placeholder for creator_models."""
+"""Routes for creator model management."""
+
+import logging
+import sys
+import os
+from fastapi import APIRouter
+
+# Add packages to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
+
+from creator_service.model_health_service import ModelHealthService, ModelHealthResult
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/models", tags=["models"])
+
+
+@router.get("/status")
+async def get_model_status() -> dict:
+    """Get health status of all model serving containers.
+    
+    Returns:
+        Dictionary containing list of model health results.
+    """
+    logger.info("Model status check requested")
+    
+    health_service = ModelHealthService()
+    results = await health_service.check_all()
+    
+    # Convert enum values to strings for JSON serialization
+    results_dict = [
+        {
+            "model_name": result.model_name,
+            "endpoint": result.endpoint,
+            "status": result.status.value,
+            "response_time_ms": result.response_time_ms,
+            "error": result.error,
+        }
+        for result in results
+    ]
+    
+    logger.info(f"Model status check completed with {len(results)} models checked")
+    return {"models": results_dict}

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -6,7 +6,7 @@ import sys
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 # Add packages to path for imports
 _PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
@@ -31,12 +31,7 @@ class CreateProjectRequest(BaseModel):
 
 
 @router.post("", status_code=201)
-async def create_project(payload: dict[str, object]) -> dict[str, object]:
-    try:
-        request = CreateProjectRequest.model_validate(payload)
-    except ValidationError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
+async def create_project(request: CreateProjectRequest) -> dict[str, object]:
     try:
         project = await project_service.create_project(
             title=request.title,
@@ -66,7 +61,8 @@ async def list_projects(
     offset: int = Query(default=0, ge=0),
 ) -> dict[str, object]:
     projects = await project_service.list_projects(limit=limit, offset=offset)
+    total = await project_service.count_projects()
     return {
         "projects": [project.model_dump(mode="json") for project in projects],
-        "total": len(projects),
+        "total": total,
     }

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -1,1 +1,72 @@
-"""Placeholder for creator_projects."""
+"""Routes for creator project management."""
+# pyright: reportMissingImports=false
+
+import os
+import sys
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, ValidationError
+
+# Add packages to path for imports
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
+
+try:
+    from creator_service.project_service import project_service
+except ImportError:
+    from project_service import project_service
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+class CreateProjectRequest(BaseModel):
+    title: str
+    source_type: Literal["idea", "markdown", "url"]
+    idea_brief: str | None = None
+    markdown_source: str | None = None
+    url_source: str | None = None
+
+
+@router.post("", status_code=201)
+async def create_project(payload: dict[str, object]) -> dict[str, object]:
+    try:
+        request = CreateProjectRequest.model_validate(payload)
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        project = await project_service.create_project(
+            title=request.title,
+            source_type=request.source_type,
+            idea_brief=request.idea_brief,
+            markdown_source=request.markdown_source,
+            url_source=request.url_source,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return project.model_dump(mode="json")
+
+
+@router.get("/{project_id}")
+async def get_project_detail(project_id: int) -> dict[str, object]:
+    project = await project_service.get_project(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    return project.model_dump(mode="json")
+
+
+@router.get("")
+async def list_projects(
+    limit: int = Query(default=20, ge=0),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, object]:
+    projects = await project_service.list_projects(limit=limit, offset=offset)
+    return {
+        "projects": [project.model_dump(mode="json") for project in projects],
+        "total": len(projects),
+    }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -1,1 +1,59 @@
-"""Placeholder for creator_runs."""
+"""Routes for creator run management."""
+# pyright: reportMissingImports=false
+
+import os
+import sys
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+# Add packages to path for imports
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+
+try:
+    from creator_service.run_service import run_service
+except ImportError:
+    from run_service import run_service
+
+router = APIRouter(tags=["runs"])
+
+
+class CreateRunRequest(BaseModel):
+    model_defaults: dict[str, str] | None = None
+    style_preset: str = "default"
+    metadata: dict[str, object] | None = None
+
+
+class RestartRunRequest(BaseModel):
+    stage: str
+
+
+@router.post("/projects/{project_id}/runs", status_code=201)
+async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
+    run = await run_service.create_run(
+        project_id=project_id,
+        model_defaults=request.model_defaults,
+        style_preset=request.style_preset,
+        metadata=request.metadata,
+    )
+    return run.model_dump(mode="json")
+
+
+@router.get("/runs/{run_id}")
+async def get_run_detail(run_id: int) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return run.model_dump(mode="json")
+
+
+@router.post("/runs/{run_id}/restart")
+async def restart_run(run_id: int, request: RestartRunRequest) -> dict[str, object]:
+    try:
+        run = await run_service.restart_run(run_id=run_id, from_stage=request.stage)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return run.model_dump(mode="json")

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -54,6 +54,9 @@ async def restart_run(run_id: int, request: RestartRunRequest) -> dict[str, obje
     try:
         run = await run_service.restart_run(run_id=run_id, from_stage=request.stage)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
 
     return run.model_dump(mode="json")

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -1,1 +1,67 @@
-"""Placeholder for creator_script."""
+"""Routes for creator script management."""
+# pyright: reportMissingImports=false
+
+import os
+import sys
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+# Add packages to path for imports
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
+
+try:
+    from creator_service.project_service import project_service
+except ImportError:
+    from project_service import project_service
+
+try:
+    from creator_service.run_service import run_service
+except ImportError:
+    from run_service import run_service
+
+try:
+    from creator_service.script_service import script_service
+except ImportError:
+    from script_service import script_service
+
+router = APIRouter(prefix="/projects/{project_id}/script", tags=["script"])
+
+
+class ImportMarkdownRequest(BaseModel):
+    markdown: str
+    model_defaults: dict[str, str] | None = None
+    style_preset: str = "default"
+
+
+@router.post("/import-markdown", status_code=201)
+async def import_markdown(project_id: int, request: ImportMarkdownRequest) -> dict[str, object]:
+    if not request.markdown.strip():
+        raise HTTPException(status_code=400, detail="markdown content must not be empty")
+
+    project = await project_service.get_project(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    try:
+        run = await run_service.create_run(
+            project_id=project_id,
+            model_defaults=request.model_defaults,
+            style_preset=request.style_preset,
+        )
+        draft = await script_service.save_draft(
+            run_id=run.id,
+            source_type="pasted_markdown",
+            markdown_content=request.markdown,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "project_id": project_id,
+        "run_id": run.id,
+        "draft": draft.model_dump(mode="json"),
+    }

--- a/apps/api/tests/__init__.py
+++ b/apps/api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test module for shorts_api."""

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest fixtures for API tests."""
+import pytest
+from httpx import AsyncClient, ASGITransport
+from shorts_api.main import app
+
+
+@pytest.fixture
+async def client():
+    """AsyncClient fixture for testing FastAPI app."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac

--- a/apps/api/tests/test_creator_models.py
+++ b/apps/api/tests/test_creator_models.py
@@ -1,0 +1,139 @@
+# pyright: reportMissingImports=false
+
+import pytest
+from shorts_api.main import models_router
+
+
+class StubModelCatalogService:
+    def __init__(self) -> None:
+        self.list_models_calls: list[str | None] = []
+        self.status_calls = 0
+
+    async def list_models(self, category: str | None = None) -> dict[str, list[dict[str, object]]]:
+        self.list_models_calls.append(category)
+        base = {
+            "script_models": [
+                {
+                    "key": "qwen3-4b",
+                    "label": "Qwen3 4B (Local)",
+                    "provider_type": "ollama",
+                    "is_local": True,
+                    "requires_gpu": True,
+                    "status": "available",
+                }
+            ],
+            "image_models": [
+                {
+                    "key": "sd15",
+                    "label": "Stable Diffusion 1.5 (Local)",
+                    "provider_type": "sd_local",
+                    "is_local": True,
+                    "requires_gpu": True,
+                    "status": "available",
+                }
+            ],
+            "tts_models": [
+                {
+                    "key": "qwen-tts",
+                    "label": "Qwen TTS (Local)",
+                    "provider_type": "qwen_tts",
+                    "is_local": True,
+                    "requires_gpu": True,
+                    "status": "available",
+                }
+            ],
+            "stt_models": [
+                {
+                    "key": "whisper-medium",
+                    "label": "Whisper Medium (Local)",
+                    "provider_type": "whisper",
+                    "is_local": True,
+                    "requires_gpu": True,
+                    "status": "available",
+                }
+            ],
+        }
+
+        if category == "script":
+            return {
+                "script_models": base["script_models"],
+                "image_models": [],
+                "tts_models": [],
+                "stt_models": [],
+            }
+
+        return base
+
+    async def get_status(self) -> dict[str, object]:
+        self.status_calls += 1
+        return {
+            "providers": [
+                {
+                    "name": "ollama",
+                    "endpoint": "http://ollama:11434",
+                    "healthy": True,
+                    "loaded_model": "qwen3-4b",
+                    "gpu_locked": False,
+                }
+            ],
+            "gpu_lock": {
+                "active": False,
+                "holder": None,
+                "ttl_remaining": None,
+            },
+        }
+
+
+@pytest.fixture
+def stub_catalog_service(monkeypatch: pytest.MonkeyPatch) -> StubModelCatalogService:
+    service = StubModelCatalogService()
+
+    for route in models_router.routes:
+        if route.name in {"list_models", "get_model_status"}:
+            monkeypatch.setitem(route.endpoint.__globals__, "model_catalog_service", service)
+
+    return service
+
+
+@pytest.mark.asyncio
+async def test_list_models_returns_all_categories(client, stub_catalog_service: StubModelCatalogService):
+    response = await client.get("/api/creator/models")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body) == {"script_models", "image_models", "tts_models", "stt_models"}
+    assert stub_catalog_service.list_models_calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_list_models_filters_by_script_category(client, stub_catalog_service: StubModelCatalogService):
+    response = await client.get("/api/creator/models?category=script")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["script_models"]) == 1
+    assert body["image_models"] == []
+    assert body["tts_models"] == []
+    assert body["stt_models"] == []
+    assert stub_catalog_service.list_models_calls == ["script"]
+
+
+@pytest.mark.asyncio
+async def test_list_models_rejects_invalid_category(client, stub_catalog_service: StubModelCatalogService):
+    response = await client.get("/api/creator/models?category=invalid")
+
+    assert response.status_code == 400
+    assert stub_catalog_service.list_models_calls == []
+
+
+@pytest.mark.asyncio
+async def test_model_status_returns_provider_and_gpu_lock(client, stub_catalog_service: StubModelCatalogService):
+    response = await client.get("/api/creator/models/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "providers" in body
+    assert "gpu_lock" in body
+    assert isinstance(body["providers"], list)
+    assert isinstance(body["gpu_lock"], dict)
+    assert stub_catalog_service.status_calls == 1

--- a/apps/api/tests/test_creator_projects.py
+++ b/apps/api/tests/test_creator_projects.py
@@ -108,6 +108,9 @@ class StubProjectService:
         return ordered[offset : offset + limit]
 
 
+    async def count_projects(self) -> int:
+        return len(self._projects)
+
 @pytest.fixture
 def stub_project_service(monkeypatch: pytest.MonkeyPatch) -> StubProjectService:
     service = StubProjectService()
@@ -154,12 +157,11 @@ async def test_create_project_invalid_source_type(client):
         json={"title": "Bad", "source_type": "invalid", "idea_brief": "Bad source"},
     )
 
-    assert response.status_code == 400
-    assert "Input should be 'idea', 'markdown' or 'url'" in response.json()["detail"]
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio
-async def test_create_project_missing_required_field(client):
+async def test_create_project_missing_required_field(client, stub_project_service: StubProjectService):
     response = await client.post(
         "/api/creator/projects",
         json={"title": "Missing", "source_type": "idea"},
@@ -207,5 +209,5 @@ async def test_list_projects_with_pagination(client, stub_project_service: StubP
     assert response.status_code == 200
     body = response.json()
     assert len(body["projects"]) == 1
-    assert body["total"] == 1
+    assert body["total"] == 2  # total count, not page size
     assert stub_project_service.list_projects_calls == [(1, 1)]

--- a/apps/api/tests/test_creator_projects.py
+++ b/apps/api/tests/test_creator_projects.py
@@ -1,0 +1,211 @@
+# pyright: reportMissingImports=false
+
+from datetime import datetime, timezone
+from typing import Literal, cast
+
+import pytest
+from pydantic import BaseModel
+from shorts_api.main import projects_router
+
+
+class StubProject(BaseModel):
+    id: int
+    title: str
+    source_type: Literal["idea", "markdown", "url"]
+    idea_brief: str | None = None
+    markdown_source: str | None = None
+    url_source: str | None = None
+    status: str = "draft"
+    created_at: datetime
+    updated_at: datetime
+    latest_run: dict[str, int | str | None] | None = None
+
+
+class StubProjectService:
+    def __init__(self) -> None:
+        self.create_project_calls: list[dict[str, object]] = []
+        self.get_project_calls: list[int] = []
+        self.list_projects_calls: list[tuple[int, int]] = []
+
+        now = datetime.now(timezone.utc)
+        self._projects = {
+            1: StubProject(
+                id=1,
+                title="Idea Project",
+                source_type="idea",
+                idea_brief="Build a daily shorts workflow",
+                status="draft",
+                created_at=now,
+                updated_at=now,
+                latest_run={"run_id": 11, "current_stage": "script", "status": "completed"},
+            ),
+            2: StubProject(
+                id=2,
+                title="Markdown Project",
+                source_type="markdown",
+                markdown_source="# Notes",
+                status="draft",
+                created_at=now,
+                updated_at=now,
+                latest_run=None,
+            ),
+        }
+        self._next_id = 3
+
+    async def create_project(
+        self,
+        title: str,
+        source_type: str,
+        idea_brief: str | None = None,
+        markdown_source: str | None = None,
+        url_source: str | None = None,
+    ) -> StubProject:
+        self.create_project_calls.append(
+            {
+                "title": title,
+                "source_type": source_type,
+                "idea_brief": idea_brief,
+                "markdown_source": markdown_source,
+                "url_source": url_source,
+            }
+        )
+
+        if source_type not in {"idea", "markdown", "url"}:
+            raise ValueError(f"Unsupported source_type '{source_type}'")
+        if source_type == "idea" and idea_brief is None:
+            raise ValueError("source_type='idea' requires idea_brief to be provided")
+        if source_type == "markdown" and markdown_source is None:
+            raise ValueError("source_type='markdown' requires markdown_source to be provided")
+        if source_type == "url" and url_source is None:
+            raise ValueError("source_type='url' requires url_source to be provided")
+
+        resolved_source_type = cast(Literal["idea", "markdown", "url"], source_type)
+
+        now = datetime.now(timezone.utc)
+        project = StubProject(
+            id=self._next_id,
+            title=title,
+            source_type=resolved_source_type,
+            idea_brief=idea_brief,
+            markdown_source=markdown_source,
+            url_source=url_source,
+            status="draft",
+            created_at=now,
+            updated_at=now,
+            latest_run=None,
+        )
+        self._projects[self._next_id] = project
+        self._next_id += 1
+        return project
+
+    async def get_project(self, project_id: int) -> StubProject | None:
+        self.get_project_calls.append(project_id)
+        return self._projects.get(project_id)
+
+    async def list_projects(self, limit: int = 20, offset: int = 0) -> list[StubProject]:
+        self.list_projects_calls.append((limit, offset))
+        ordered = sorted(self._projects.values(), key=lambda project: project.id)
+        return ordered[offset : offset + limit]
+
+
+@pytest.fixture
+def stub_project_service(monkeypatch: pytest.MonkeyPatch) -> StubProjectService:
+    service = StubProjectService()
+
+    for route in projects_router.routes:
+        if route.name in {"create_project", "get_project_detail", "list_projects"}:
+            monkeypatch.setitem(route.endpoint.__globals__, "project_service", service)
+
+    return service
+
+
+@pytest.mark.asyncio
+async def test_create_project_idea(client, stub_project_service: StubProjectService):
+    response = await client.post(
+        "/api/creator/projects",
+        json={"title": "Idea", "source_type": "idea", "idea_brief": "Use hooks"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["source_type"] == "idea"
+    assert body["idea_brief"] == "Use hooks"
+    assert stub_project_service.create_project_calls[0]["source_type"] == "idea"
+
+
+@pytest.mark.asyncio
+async def test_create_project_markdown(client, stub_project_service: StubProjectService):
+    response = await client.post(
+        "/api/creator/projects",
+        json={"title": "Doc", "source_type": "markdown", "markdown_source": "# Script"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["source_type"] == "markdown"
+    assert body["markdown_source"] == "# Script"
+    assert stub_project_service.create_project_calls[0]["source_type"] == "markdown"
+
+
+@pytest.mark.asyncio
+async def test_create_project_invalid_source_type(client):
+    response = await client.post(
+        "/api/creator/projects",
+        json={"title": "Bad", "source_type": "invalid", "idea_brief": "Bad source"},
+    )
+
+    assert response.status_code == 400
+    assert "Input should be 'idea', 'markdown' or 'url'" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_project_missing_required_field(client):
+    response = await client.post(
+        "/api/creator/projects",
+        json={"title": "Missing", "source_type": "idea"},
+    )
+
+    assert response.status_code == 400
+    assert "requires idea_brief" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_project_found(client, stub_project_service: StubProjectService):
+    response = await client.get("/api/creator/projects/1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 1
+    assert body["latest_run"]["run_id"] == 11
+    assert stub_project_service.get_project_calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_get_project_not_found(client, stub_project_service: StubProjectService):
+    response = await client.get("/api/creator/projects/999")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Project not found"}
+    assert stub_project_service.get_project_calls == [999]
+
+
+@pytest.mark.asyncio
+async def test_list_projects_default(client, stub_project_service: StubProjectService):
+    response = await client.get("/api/creator/projects")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body["projects"], list)
+    assert body["total"] == 2
+    assert stub_project_service.list_projects_calls == [(20, 0)]
+
+
+@pytest.mark.asyncio
+async def test_list_projects_with_pagination(client, stub_project_service: StubProjectService):
+    response = await client.get("/api/creator/projects?limit=1&offset=1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["projects"]) == 1
+    assert body["total"] == 1
+    assert stub_project_service.list_projects_calls == [(1, 1)]

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -1,0 +1,252 @@
+# pyright: reportMissingImports=false
+
+from datetime import datetime, timezone
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from shorts_api.main import runs_router
+
+
+class StubPipelineRun(BaseModel):
+    id: int
+    project_id: int
+    current_stage: str | None = None
+    status: Literal["pending", "running", "paused", "completed", "failed", "cancelled"] = "pending"
+    review_stage: str | None = None
+    restart_from: str | None = None
+    model_defaults: dict[str, str] | None = None
+    metadata: dict[str, object] | None = None
+    style_preset: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class StubRunService:
+    def __init__(self) -> None:
+        self.create_run_calls: list[dict[str, object]] = []
+        self.get_run_calls: list[int] = []
+        self.restart_run_calls: list[dict[str, object]] = []
+        self.runs: dict[int, StubPipelineRun] = {}
+        self._next_id = 1
+
+    async def create_run(
+        self,
+        project_id: int,
+        model_defaults: dict[str, str] | None,
+        style_preset: str,
+        metadata: dict[str, object] | None,
+    ) -> StubPipelineRun:
+        self.create_run_calls.append(
+            {
+                "project_id": project_id,
+                "model_defaults": model_defaults,
+                "style_preset": style_preset,
+                "metadata": metadata,
+            }
+        )
+
+        now = datetime.now(timezone.utc)
+        run = StubPipelineRun(
+            id=self._next_id,
+            project_id=project_id,
+            current_stage="IDEA_READY",
+            status="pending",
+            review_stage=None,
+            restart_from=None,
+            model_defaults=model_defaults,
+            metadata=metadata,
+            style_preset=style_preset,
+            started_at=None,
+            finished_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        self.runs[self._next_id] = run
+        self._next_id += 1
+        return run
+
+    async def get_run(self, run_id: int) -> StubPipelineRun | None:
+        self.get_run_calls.append(run_id)
+        return self.runs.get(run_id)
+
+    async def restart_run(self, run_id: int, from_stage: str) -> StubPipelineRun:
+        self.restart_run_calls.append({"run_id": run_id, "from_stage": from_stage})
+
+        run = self.runs.get(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        if from_stage not in {"SCRIPT_GENERATING", "VISUAL_PLAN_GENERATING"}:
+            raise ValueError(f"Invalid stage '{from_stage}'")
+
+        updated = run.model_copy(update={"restart_from": from_stage, "current_stage": from_stage})
+        self.runs[run_id] = updated
+        return updated
+
+
+@pytest.fixture
+def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
+    service = StubRunService()
+
+    for route in runs_router.routes:
+        if route.name in {"create_run", "get_run_detail", "restart_run"}:
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
+
+    return service
+
+
+@pytest.mark.asyncio
+async def test_create_run(client, stub_run_service: StubRunService):
+    response = await client.post(
+        "/api/creator/projects/7/runs",
+        json={
+            "model_defaults": {
+                "script_model": "qwen3-4b",
+                "image_model": "sd15",
+            },
+            "style_preset": "cinematic",
+            "metadata": {"episode": 1},
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["project_id"] == 7
+    assert body["model_defaults"] == {"script_model": "qwen3-4b", "image_model": "sd15"}
+    assert body["style_preset"] == "cinematic"
+    assert body["metadata"] == {"episode": 1}
+    assert stub_run_service.create_run_calls == [
+        {
+            "project_id": 7,
+            "model_defaults": {"script_model": "qwen3-4b", "image_model": "sd15"},
+            "style_preset": "cinematic",
+            "metadata": {"episode": 1},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_run_minimal(client, stub_run_service: StubRunService):
+    _ = stub_run_service
+    response = await client.post(
+        "/api/creator/projects/8/runs",
+        json={"style_preset": "default"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["project_id"] == 8
+    assert body["model_defaults"] is None
+    assert body["metadata"] is None
+    assert body["style_preset"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_get_run_found(client, stub_run_service: StubRunService):
+    now = datetime.now(timezone.utc)
+    stub_run_service.runs[33] = StubPipelineRun(
+        id=33,
+        project_id=3,
+        current_stage="SCRIPT_REVIEW",
+        status="running",
+        review_stage="SCRIPT_REVIEW",
+        restart_from="SCRIPT_GENERATING",
+        model_defaults={"script_model": "qwen3-4b", "image_model": "sd15"},
+        metadata={"attempt": 2},
+        style_preset="dynamic",
+        started_at=now,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    response = await client.get("/api/creator/runs/33")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 33
+    assert body["project_id"] == 3
+    assert body["current_stage"] == "SCRIPT_REVIEW"
+    assert body["status"] == "running"
+    assert body["review_stage"] == "SCRIPT_REVIEW"
+    assert body["restart_from"] == "SCRIPT_GENERATING"
+    assert body["model_defaults"] == {"script_model": "qwen3-4b", "image_model": "sd15"}
+    assert body["metadata"] == {"attempt": 2}
+    assert body["style_preset"] == "dynamic"
+    assert "created_at" in body
+    assert "updated_at" in body
+
+
+@pytest.mark.asyncio
+async def test_get_run_not_found(client, stub_run_service: StubRunService):
+    _ = stub_run_service
+    response = await client.get("/api/creator/runs/999")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run not found"}
+
+
+@pytest.mark.asyncio
+async def test_restart_run_valid(client, stub_run_service: StubRunService):
+    now = datetime.now(timezone.utc)
+    stub_run_service.runs[4] = StubPipelineRun(
+        id=4,
+        project_id=1,
+        current_stage="IDEA_READY",
+        status="pending",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=None,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    response = await client.post("/api/creator/runs/4/restart", json={"stage": "SCRIPT_GENERATING"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 4
+    assert body["current_stage"] == "SCRIPT_GENERATING"
+    assert body["restart_from"] == "SCRIPT_GENERATING"
+    assert stub_run_service.restart_run_calls == [{"run_id": 4, "from_stage": "SCRIPT_GENERATING"}]
+
+
+@pytest.mark.asyncio
+async def test_restart_run_invalid_stage(client, stub_run_service: StubRunService):
+    now = datetime.now(timezone.utc)
+    stub_run_service.runs[5] = StubPipelineRun(
+        id=5,
+        project_id=2,
+        current_stage="IDEA_READY",
+        status="pending",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=None,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    response = await client.post("/api/creator/runs/5/restart", json={"stage": "INVALID_STAGE"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid stage 'INVALID_STAGE'"}
+
+
+@pytest.mark.asyncio
+async def test_restart_run_not_found(client, stub_run_service: StubRunService):
+    _ = stub_run_service
+    response = await client.post("/api/creator/runs/4242/restart", json={"stage": "SCRIPT_GENERATING"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Run 4242 not found"}

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -248,5 +248,5 @@ async def test_restart_run_not_found(client, stub_run_service: StubRunService):
     _ = stub_run_service
     response = await client.post("/api/creator/runs/4242/restart", json={"stage": "SCRIPT_GENERATING"})
 
-    assert response.status_code == 400
+    assert response.status_code == 404
     assert response.json() == {"detail": "Run 4242 not found"}

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -1,0 +1,248 @@
+# pyright: reportMissingImports=false
+
+from datetime import datetime, timezone
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from shorts_api.main import script_router
+
+
+class StubProject(BaseModel):
+    id: int
+    title: str = "Test Project"
+
+
+class StubPipelineRun(BaseModel):
+    id: int
+    project_id: int
+
+
+class StubScriptDraft(BaseModel):
+    id: int
+    run_id: int
+    source_type: Literal[
+        "generated_by_model",
+        "pasted_markdown",
+        "uploaded_markdown",
+        "edited_manually",
+    ]
+    markdown_content: str | None = None
+    structured_script: list[dict[str, object]] | None = None
+    version: int = 1
+    created_at: datetime
+
+
+class StubProjectService:
+    def __init__(self) -> None:
+        self.get_project_calls: list[int] = []
+        self.projects: dict[int, StubProject] = {}
+
+    async def get_project(self, project_id: int) -> StubProject | None:
+        self.get_project_calls.append(project_id)
+        return self.projects.get(project_id)
+
+
+class StubRunService:
+    def __init__(self) -> None:
+        self.create_run_calls: list[dict[str, object]] = []
+        self.next_run_id = 1
+
+    async def create_run(
+        self,
+        project_id: int,
+        model_defaults: dict[str, str] | None,
+        style_preset: str,
+        metadata: dict[str, object] | None = None,
+    ) -> StubPipelineRun:
+        self.create_run_calls.append(
+            {
+                "project_id": project_id,
+                "model_defaults": model_defaults,
+                "style_preset": style_preset,
+                "metadata": metadata,
+            }
+        )
+        run = StubPipelineRun(id=self.next_run_id, project_id=project_id)
+        self.next_run_id += 1
+        return run
+
+
+class StubScriptService:
+    def __init__(self) -> None:
+        self.save_draft_calls: list[dict[str, object]] = []
+        self.raise_error_message: str | None = None
+        self.next_draft_id = 1
+
+    async def save_draft(self, run_id: int, source_type: str, markdown_content: str) -> StubScriptDraft:
+        if self.raise_error_message is not None:
+            raise ValueError(self.raise_error_message)
+
+        self.save_draft_calls.append(
+            {
+                "run_id": run_id,
+                "source_type": source_type,
+                "markdown_content": markdown_content,
+            }
+        )
+        draft = StubScriptDraft(
+            id=self.next_draft_id,
+            run_id=run_id,
+            source_type="pasted_markdown",
+            markdown_content=markdown_content,
+            structured_script=None,
+            version=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        self.next_draft_id += 1
+        return draft
+
+
+@pytest.fixture
+def stub_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubProjectService, StubRunService, StubScriptService]:
+    project = StubProjectService()
+    run = StubRunService()
+    script = StubScriptService()
+
+    for route in script_router.routes:
+        monkeypatch.setitem(route.endpoint.__globals__, "project_service", project)
+        monkeypatch.setitem(route.endpoint.__globals__, "run_service", run)
+        monkeypatch.setitem(route.endpoint.__globals__, "script_service", script)
+
+    return project, run, script
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_success(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[11] = StubProject(id=11, title="Project 11")
+
+    response = await client.post(
+        "/api/creator/projects/11/script/import-markdown",
+        json={"markdown": "# My script\n\nHello world"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["project_id"] == 11
+    assert body["run_id"] == 1
+    assert body["draft"]["run_id"] == 1
+    assert body["draft"]["source_type"] == "pasted_markdown"
+    assert body["draft"]["markdown_content"] == "# My script\n\nHello world"
+    assert project_service.get_project_calls == [11]
+    assert run_service.create_run_calls == [
+        {
+            "project_id": 11,
+            "model_defaults": None,
+            "style_preset": "default",
+            "metadata": None,
+        }
+    ]
+    assert script_service.save_draft_calls == [
+        {
+            "run_id": 1,
+            "source_type": "pasted_markdown",
+            "markdown_content": "# My script\n\nHello world",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_project_not_found(client, stub_services):
+    _project_service, run_service, script_service = stub_services
+
+    response = await client.post(
+        "/api/creator/projects/404/script/import-markdown",
+        json={"markdown": "# Missing project"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Project not found"}
+    assert run_service.create_run_calls == []
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_empty_markdown(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[7] = StubProject(id=7, title="Project 7")
+
+    response = await client.post(
+        "/api/creator/projects/7/script/import-markdown",
+        json={"markdown": ""},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "markdown content must not be empty"}
+    assert run_service.create_run_calls == []
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_with_model_defaults(client, stub_services):
+    project_service, run_service, _script_service = stub_services
+    project_service.projects[21] = StubProject(id=21, title="Project 21")
+
+    response = await client.post(
+        "/api/creator/projects/21/script/import-markdown",
+        json={
+            "markdown": "# Styled script",
+            "model_defaults": {
+                "script_model": "manual",
+                "image_model": "sdxl-base",
+                "tts_model": "edge-alloy",
+            },
+            "style_preset": "cinematic",
+        },
+    )
+
+    assert response.status_code == 201
+    assert run_service.create_run_calls == [
+        {
+            "project_id": 21,
+            "model_defaults": {
+                "script_model": "manual",
+                "image_model": "sdxl-base",
+                "tts_model": "edge-alloy",
+            },
+            "style_preset": "cinematic",
+            "metadata": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_missing_markdown_field(client, stub_services):
+    project_service, _run_service, _script_service = stub_services
+    project_service.projects[9] = StubProject(id=9, title="Project 9")
+
+    response = await client.post(
+        "/api/creator/projects/9/script/import-markdown",
+        json={"style_preset": "default"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_service_error(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[15] = StubProject(id=15, title="Project 15")
+    script_service.raise_error_message = "Invalid markdown structure"
+
+    response = await client.post(
+        "/api/creator/projects/15/script/import-markdown",
+        json={"markdown": "# Broken"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid markdown structure"}
+    assert run_service.create_run_calls == [
+        {
+            "project_id": 15,
+            "model_defaults": None,
+            "style_preset": "default",
+            "metadata": None,
+        }
+    ]

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -47,6 +47,7 @@ class StubProjectService:
 class StubRunService:
     def __init__(self) -> None:
         self.create_run_calls: list[dict[str, object]] = []
+        self.raise_error_message: str | None = None
         self.next_run_id = 1
 
     async def create_run(
@@ -56,6 +57,9 @@ class StubRunService:
         style_preset: str,
         metadata: dict[str, object] | None = None,
     ) -> StubPipelineRun:
+        if self.raise_error_message is not None:
+            raise ValueError(self.raise_error_message)
+
         self.create_run_calls.append(
             {
                 "project_id": project_id,
@@ -246,3 +250,35 @@ async def test_import_markdown_service_error(client, stub_services):
             "metadata": None,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_whitespace_only(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[7] = StubProject(id=7, title="Project 7")
+
+    response = await client.post(
+        "/api/creator/projects/7/script/import-markdown",
+        json={"markdown": "   \n  \t  "},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "markdown content must not be empty"}
+    assert run_service.create_run_calls == []
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_create_run_failure(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[20] = StubProject(id=20, title="Project 20")
+    run_service.raise_error_message = "Duplicate run not allowed"
+
+    response = await client.post(
+        "/api/creator/projects/20/script/import-markdown",
+        json={"markdown": "# Valid content"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Duplicate run not allowed"}
+    assert script_service.save_draft_calls == []

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -1,0 +1,10 @@
+"""Tests for health endpoint."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_health_returns_ok(client):
+    """Test that /health endpoint returns 200 with ok status."""
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/apps/studio-web/.eslintrc.cjs
+++ b/apps/studio-web/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react', 'react-hooks', '@typescript-eslint'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+  },
+};

--- a/apps/studio-web/.prettierrc
+++ b/apps/studio-web/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/apps/studio-web/package-lock.json
+++ b/apps/studio-web/package-lock.json
@@ -1,0 +1,7225 @@
+{
+  "name": "studio-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "studio-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.1"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.1.0",
+        "@testing-library/react": "^14.0.0",
+        "@types/react": "^18.3.5",
+        "@types/react-dom": "^18.3.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "@vitejs/plugin-react": "^4.2.0",
+        "eslint": "^8.0.0",
+        "eslint-plugin-react": "^7.33.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "jsdom": "^23.0.0",
+        "prettier": "^3.0.0",
+        "typescript": "^5.5.4",
+        "vite": "^5.4.2",
+        "vitest": "^1.0.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+      "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001782",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
+      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
+      "integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.1",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^2.0.1",
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/apps/studio-web/package.json
+++ b/apps/studio-web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write src",
-    "test": "echo \"No tests yet\""
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -19,7 +19,12 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.4",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "jsdom": "^23.0.0",
     "eslint": "^8.0.0",
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/apps/studio-web/package.json
+++ b/apps/studio-web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx",
+    "format": "prettier --write src",
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
@@ -19,5 +20,12 @@
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.4",
     "vite": "^5.4.2"
+    "eslint": "^8.0.0",
+    "eslint-plugin-react": "^7.33.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "prettier": "^3.0.0"
   }
+
 }

--- a/apps/studio-web/src/__tests__/App.test.tsx
+++ b/apps/studio-web/src/__tests__/App.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import CreatePage from '../pages/CreatePage';
+
+describe('App', () => {
+  it('renders CreatePage without crashing', () => {
+    render(
+      <MemoryRouter>
+        <CreatePage />
+      </MemoryRouter>
+    );
+    // Verify CreatePage renders
+    expect(screen.getByText('CreatePage')).toBeTruthy();
+  });
+
+  it('App module exports default function', async () => {
+    const mod = await import('../App');
+    expect(typeof mod.default).toBe('function');
+  });
+});

--- a/apps/studio-web/src/__tests__/ModelSelector.test.tsx
+++ b/apps/studio-web/src/__tests__/ModelSelector.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import ModelSelector from "../components/creator/ModelSelector";
@@ -153,7 +154,7 @@ describe("ModelSelector", () => {
     expect(screen.getByText("unknown")).toBeTruthy();
   });
 
-  it("keyboard navigation works via native radio inputs", async () => {
+  it("radio click fires onSelectionChange with correct category and key", async () => {
     mockFetchSuccess();
     const onChange = vi.fn();
     render(<ModelSelector onSelectionChange={onChange} />);
@@ -164,10 +165,8 @@ describe("ModelSelector", () => {
 
     onChange.mockClear();
 
-    // Native radios support keyboard by default; simulate click on radio
     const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
     fireEvent.click(gptRadio);
-    // The onChange handler fires through the radio onChange
     expect(onChange).toHaveBeenCalledWith("script", "gpt-4o-mini");
   });
 
@@ -256,5 +255,35 @@ describe("ModelSelector", () => {
     // The manually selected gpt-4o-mini should still be checked, not overwritten by default
     const gptRadioAfter = screen.getByRole("radio", { name: /GPT-4o Mini/ });
     expect(gptRadioAfter).toBeChecked();
+  });
+
+  it("default callbacks fire exactly once under StrictMode", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(
+      <React.StrictMode>
+        <ModelSelector onSelectionChange={onChange} />
+      </React.StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Each category default should fire exactly once, not doubled by StrictMode
+    const scriptCalls = onChange.mock.calls.filter(
+      ([cat, key]: [string, string]) => cat === "script" && key === "qwen3-4b",
+    );
+    expect(scriptCalls.length).toBe(1);
+
+    const imageCalls = onChange.mock.calls.filter(
+      ([cat, key]: [string, string]) => cat === "image" && key === "sd15",
+    );
+    expect(imageCalls.length).toBe(1);
+
+    const ttsCalls = onChange.mock.calls.filter(
+      ([cat, key]: [string, string]) => cat === "tts" && key === "qwen-tts",
+    );
+    expect(ttsCalls.length).toBe(1);
   });
 });

--- a/apps/studio-web/src/__tests__/ModelSelector.test.tsx
+++ b/apps/studio-web/src/__tests__/ModelSelector.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ModelSelector from "../components/creator/ModelSelector";
+
+const MOCK_RESPONSE = {
+  script_models: [
+    { key: "qwen3-4b", label: "Qwen3 4B (Local)", provider_type: "ollama", is_local: true, requires_gpu: true, status: "available" as const },
+    { key: "gpt-4o-mini", label: "GPT-4o Mini (Remote)", provider_type: "openai", is_local: false, requires_gpu: false, status: "unavailable" as const },
+  ],
+  image_models: [
+    { key: "sd15", label: "Stable Diffusion 1.5 (Local)", provider_type: "stable-diffusion", is_local: true, requires_gpu: true, status: "available" as const },
+  ],
+  tts_models: [
+    { key: "qwen-tts", label: "Qwen TTS (Local)", provider_type: "qwen-tts", is_local: true, requires_gpu: true, status: "unknown" as const },
+  ],
+  stt_models: [],
+};
+
+function mockFetchSuccess() {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(MOCK_RESPONSE),
+  } as Response);
+}
+
+function mockFetchError() {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: () => Promise.resolve({}),
+  } as Response);
+}
+
+describe("ModelSelector", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders loading state initially", () => {
+    // Never resolve fetch
+    vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise(() => {}));
+    render(<ModelSelector />);
+    expect(screen.getByTestId("model-selector-loading")).toBeTruthy();
+  });
+
+  it("renders model lists after fetch", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Qwen3 4B (Local)")).toBeTruthy();
+    expect(screen.getByText("GPT-4o Mini (Remote)")).toBeTruthy();
+    expect(screen.getByText("Stable Diffusion 1.5 (Local)")).toBeTruthy();
+    expect(screen.getByText("Qwen TTS (Local)")).toBeTruthy();
+  });
+
+  it("calls onSelectionChange when model clicked", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(<ModelSelector onSelectionChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("GPT-4o Mini (Remote)"));
+    expect(onChange).toHaveBeenCalledWith("script", "gpt-4o-mini");
+  });
+
+  it("handles fetch error gracefully", async () => {
+    mockFetchError();
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector-error")).toBeTruthy();
+    });
+
+    expect(screen.getByText(/Failed to fetch models: 500/)).toBeTruthy();
+  });
+
+  it("default selection mode selects first available model", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(<ModelSelector onSelectionChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // qwen3-4b should be auto-selected (first available in script)
+    const qwenItem = screen.getByText("Qwen3 4B (Local)").closest("li");
+    expect(qwenItem?.getAttribute("aria-selected")).toBe("true");
+
+    // gpt-4o-mini should NOT be selected
+    const gptItem = screen.getByText("GPT-4o Mini (Remote)").closest("li");
+    expect(gptItem?.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("respects override mode with selectedModels prop", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector selectedModels={{ script: "gpt-4o-mini" }} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // In override mode, gpt-4o-mini should be selected
+    const gptItem = screen.getByText("GPT-4o Mini (Remote)").closest("li");
+    expect(gptItem?.getAttribute("aria-selected")).toBe("true");
+
+    const qwenItem = screen.getByText("Qwen3 4B (Local)").closest("li");
+    expect(qwenItem?.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("shows only specified categories", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector categories={["script"]} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Script Model")).toBeTruthy();
+    expect(screen.queryByText("Image Model")).toBeNull();
+    expect(screen.queryByText("TTS Model")).toBeNull();
+  });
+
+  it("shows status badges for each model", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Check status badges exist
+    const availableBadges = screen.getAllByText("available");
+    expect(availableBadges.length).toBe(2); // qwen3-4b + sd15
+
+    expect(screen.getByText("unavailable")).toBeTruthy();
+    expect(screen.getByText("unknown")).toBeTruthy();
+  });
+});

--- a/apps/studio-web/src/__tests__/ModelSelector.test.tsx
+++ b/apps/studio-web/src/__tests__/ModelSelector.test.tsx
@@ -57,7 +57,7 @@ describe("ModelSelector", () => {
     expect(screen.getByText("Qwen TTS (Local)")).toBeTruthy();
   });
 
-  it("calls onSelectionChange when model clicked", async () => {
+  it("calls onSelectionChange when model selected via radio", async () => {
     mockFetchSuccess();
     const onChange = vi.fn();
     render(<ModelSelector onSelectionChange={onChange} />);
@@ -66,7 +66,11 @@ describe("ModelSelector", () => {
       expect(screen.getByTestId("model-selector")).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByText("GPT-4o Mini (Remote)"));
+    // Clear default-notification calls
+    onChange.mockClear();
+
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    fireEvent.click(gptRadio);
     expect(onChange).toHaveBeenCalledWith("script", "gpt-4o-mini");
   });
 
@@ -81,7 +85,7 @@ describe("ModelSelector", () => {
     expect(screen.getByText(/Failed to fetch models: 500/)).toBeTruthy();
   });
 
-  it("default selection mode selects first available model", async () => {
+  it("default selection mode selects first available model and notifies parent", async () => {
     mockFetchSuccess();
     const onChange = vi.fn();
     render(<ModelSelector onSelectionChange={onChange} />);
@@ -90,16 +94,21 @@ describe("ModelSelector", () => {
       expect(screen.getByTestId("model-selector")).toBeTruthy();
     });
 
-    // qwen3-4b should be auto-selected (first available in script)
-    const qwenItem = screen.getByText("Qwen3 4B (Local)").closest("li");
-    expect(qwenItem?.getAttribute("aria-selected")).toBe("true");
+    // qwen3-4b radio should be checked (first available in script)
+    const qwenRadio = screen.getByRole("radio", { name: /Qwen3 4B/ });
+    expect(qwenRadio).toBeChecked();
 
-    // gpt-4o-mini should NOT be selected
-    const gptItem = screen.getByText("GPT-4o Mini (Remote)").closest("li");
-    expect(gptItem?.getAttribute("aria-selected")).toBe("false");
+    // gpt-4o-mini radio should NOT be checked
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    expect(gptRadio).not.toBeChecked();
+
+    // Parent should have been notified of default selections
+    expect(onChange).toHaveBeenCalledWith("script", "qwen3-4b");
+    expect(onChange).toHaveBeenCalledWith("image", "sd15");
+    expect(onChange).toHaveBeenCalledWith("tts", "qwen-tts");
   });
 
-  it("respects override mode with selectedModels prop", async () => {
+  it("respects controlled mode with selectedModels prop", async () => {
     mockFetchSuccess();
     render(<ModelSelector selectedModels={{ script: "gpt-4o-mini" }} />);
 
@@ -107,12 +116,12 @@ describe("ModelSelector", () => {
       expect(screen.getByTestId("model-selector")).toBeTruthy();
     });
 
-    // In override mode, gpt-4o-mini should be selected
-    const gptItem = screen.getByText("GPT-4o Mini (Remote)").closest("li");
-    expect(gptItem?.getAttribute("aria-selected")).toBe("true");
+    // In controlled mode, gpt-4o-mini should be checked
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    expect(gptRadio).toBeChecked();
 
-    const qwenItem = screen.getByText("Qwen3 4B (Local)").closest("li");
-    expect(qwenItem?.getAttribute("aria-selected")).toBe("false");
+    const qwenRadio = screen.getByRole("radio", { name: /Qwen3 4B/ });
+    expect(qwenRadio).not.toBeChecked();
   });
 
   it("shows only specified categories", async () => {
@@ -142,5 +151,50 @@ describe("ModelSelector", () => {
 
     expect(screen.getByText("unavailable")).toBeTruthy();
     expect(screen.getByText("unknown")).toBeTruthy();
+  });
+
+  it("keyboard navigation works via native radio inputs", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(<ModelSelector onSelectionChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    onChange.mockClear();
+
+    // Native radios support keyboard by default; simulate click on radio
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    fireEvent.click(gptRadio);
+    // The onChange handler fires through the radio onChange
+    expect(onChange).toHaveBeenCalledWith("script", "gpt-4o-mini");
+  });
+
+  it("uses radiogroup role with proper aria-label per category", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Each category should have a radiogroup
+    expect(screen.getByRole("radiogroup", { name: "Script Model" })).toBeTruthy();
+    expect(screen.getByRole("radiogroup", { name: "Image Model" })).toBeTruthy();
+    expect(screen.getByRole("radiogroup", { name: "TTS Model" })).toBeTruthy();
+  });
+
+  it("does not notify parent of defaults in controlled mode", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(<ModelSelector selectedModels={{ script: "qwen3-4b" }} onSelectionChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // In controlled mode, onSelectionChange should NOT be called with defaults
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/studio-web/src/__tests__/ModelSelector.test.tsx
+++ b/apps/studio-web/src/__tests__/ModelSelector.test.tsx
@@ -197,4 +197,64 @@ describe("ModelSelector", () => {
     // In controlled mode, onSelectionChange should NOT be called with defaults
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("does not fire duplicate default callbacks when categories array identity changes", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <ModelSelector categories={["script", "image"]} onSelectionChange={onChange} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Initial defaults should have fired for script + image
+    expect(onChange).toHaveBeenCalledWith("script", "qwen3-4b");
+    expect(onChange).toHaveBeenCalledWith("image", "sd15");
+    const initialCallCount = onChange.mock.calls.length;
+    onChange.mockClear();
+
+    // Rerender with a NEW array reference but same content
+    rerender(
+      <ModelSelector categories={["script", "image"]} onSelectionChange={onChange} />,
+    );
+
+    // Allow any effects to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    // No duplicate callbacks should have fired — selections already exist
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("manual uncontrolled selection survives parent rerender", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <ModelSelector onSelectionChange={onChange} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Manually select gpt-4o-mini (overriding the default qwen3-4b)
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    fireEvent.click(gptRadio);
+    expect(gptRadio).toBeChecked();
+
+    onChange.mockClear();
+
+    // Rerender with new categories array identity (same content)
+    rerender(
+      <ModelSelector categories={["script", "image", "tts", "stt"]} onSelectionChange={onChange} />,
+    );
+
+    // Allow effects to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The manually selected gpt-4o-mini should still be checked, not overwritten by default
+    const gptRadioAfter = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    expect(gptRadioAfter).toBeChecked();
+  });
 });

--- a/apps/studio-web/src/components/creator/ModelSelector.tsx
+++ b/apps/studio-web/src/components/creator/ModelSelector.tsx
@@ -67,6 +67,10 @@ export default function ModelSelector({
   const onChangeRef = useRef(onSelectionChange);
   onChangeRef.current = onSelectionChange;
 
+  // Ref to stage newly-computed defaults for notification in a follow-up effect.
+  // Keeping notification out of the setLocalSelection updater keeps it pure.
+  const pendingDefaultsRef = useRef<Array<[string, string]>>([]);
+
   // Effect 1: Fetch model catalog when apiBase changes
   useEffect(() => {
     let cancelled = false;
@@ -106,6 +110,7 @@ export default function ModelSelector({
   // Effect 2: Derive default selections when data or visible categories change (uncontrolled mode only).
   // Only initializes selections for categories that don't already have a user-chosen value,
   // so manual selections survive parent re-renders and categories changes.
+  // The updater is kept pure — side-effect notification is staged via ref.
   useEffect(() => {
     if (!data || selectedModels) return;
 
@@ -115,9 +120,8 @@ export default function ModelSelector({
       const newDefaults: Array<[string, string]> = [];
 
       for (const cat of cats) {
-        // Skip categories that already have a selection
+        // Skip categories that already have a selection whose model still exists
         if (next[cat]) {
-          // Verify the selected model still exists in the catalog
           const meta = CATEGORY_MAP[cat];
           if (meta) {
             const models = data[meta.responseKey];
@@ -136,20 +140,29 @@ export default function ModelSelector({
         }
       }
 
-      // Notify parent only for newly defaulted categories
-      if (newDefaults.length > 0) {
-        const cb = onChangeRef.current;
-        if (cb) {
-          // Schedule notification after state update to avoid calling setState during render
-          queueMicrotask(() => {
-            for (const [c, k] of newDefaults) cb(c, k);
-          });
-        }
-      }
+      // If nothing changed, return prev to avoid unnecessary re-render
+      if (newDefaults.length === 0) return prev;
 
+      // Stage defaults for notification in Effect 3
+      pendingDefaultsRef.current = newDefaults;
       return next;
     });
   }, [data, categoriesKey, selectedModels]);
+
+  // Effect 3: Notify parent of newly-computed defaults after state has settled.
+  // Runs after localSelection changes; checks the staged ref to avoid duplicate calls.
+  useEffect(() => {
+    const pending = pendingDefaultsRef.current;
+    if (pending.length === 0) return;
+    pendingDefaultsRef.current = [];
+
+    const cb = onChangeRef.current;
+    if (cb) {
+      for (const [cat, key] of pending) {
+        cb(cat, key);
+      }
+    }
+  }, [localSelection]);
 
   const handleSelect = useCallback(
     (category: string, modelKey: string) => {

--- a/apps/studio-web/src/components/creator/ModelSelector.tsx
+++ b/apps/studio-web/src/components/creator/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 
 /** Shape of a single model entry returned by GET /api/creator/models. */
 interface ModelEntry {
@@ -61,7 +61,7 @@ export default function ModelSelector({
   const [loading, setLoading] = useState(true);
   const [localSelection, setLocalSelection] = useState<Record<string, string>>({});
 
-  const visibleCategories = useMemo(() => categories ?? ALL_CATEGORIES, [categories]);
+  const visibleCategories = categories ?? ALL_CATEGORIES;
 
   // Stable ref for onSelectionChange to avoid effect re-fires when callback identity changes
   const onChangeRef = useRef(onSelectionChange);
@@ -100,31 +100,56 @@ export default function ModelSelector({
     };
   }, [apiBase]);
 
+  // Stable string key for categories to avoid re-triggering effect on array identity changes.
+  const categoriesKey = visibleCategories.join(",");
+
   // Effect 2: Derive default selections when data or visible categories change (uncontrolled mode only).
-  // Also notifies parent of defaults so UI and parent state stay in sync.
+  // Only initializes selections for categories that don't already have a user-chosen value,
+  // so manual selections survive parent re-renders and categories changes.
   useEffect(() => {
     if (!data || selectedModels) return;
 
-    const defaults: Record<string, string> = {};
-    for (const cat of visibleCategories) {
-      const meta = CATEGORY_MAP[cat];
-      if (!meta) continue;
-      const models = data[meta.responseKey];
-      const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
-      if (firstAvailable) {
-        defaults[cat] = firstAvailable.key;
-      }
-    }
-    setLocalSelection(defaults);
+    const cats = categoriesKey.split(",");
+    setLocalSelection((prev) => {
+      const next = { ...prev };
+      const newDefaults: Array<[string, string]> = [];
 
-    // Notify parent of computed defaults
-    const cb = onChangeRef.current;
-    if (cb) {
-      for (const [cat, key] of Object.entries(defaults)) {
-        cb(cat, key);
+      for (const cat of cats) {
+        // Skip categories that already have a selection
+        if (next[cat]) {
+          // Verify the selected model still exists in the catalog
+          const meta = CATEGORY_MAP[cat];
+          if (meta) {
+            const models = data[meta.responseKey];
+            const stillExists = models.some((m) => m.key === next[cat]);
+            if (stillExists) continue;
+          }
+        }
+
+        const meta = CATEGORY_MAP[cat];
+        if (!meta) continue;
+        const models = data[meta.responseKey];
+        const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
+        if (firstAvailable) {
+          next[cat] = firstAvailable.key;
+          newDefaults.push([cat, firstAvailable.key]);
+        }
       }
-    }
-  }, [data, visibleCategories, selectedModels]);
+
+      // Notify parent only for newly defaulted categories
+      if (newDefaults.length > 0) {
+        const cb = onChangeRef.current;
+        if (cb) {
+          // Schedule notification after state update to avoid calling setState during render
+          queueMicrotask(() => {
+            for (const [c, k] of newDefaults) cb(c, k);
+          });
+        }
+      }
+
+      return next;
+    });
+  }, [data, categoriesKey, selectedModels]);
 
   const handleSelect = useCallback(
     (category: string, modelKey: string) => {

--- a/apps/studio-web/src/components/creator/ModelSelector.tsx
+++ b/apps/studio-web/src/components/creator/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 
 /** Shape of a single model entry returned by GET /api/creator/models. */
 interface ModelEntry {
@@ -34,9 +34,9 @@ const CATEGORY_MAP: Record<string, CategoryMeta> = {
 const ALL_CATEGORIES = Object.keys(CATEGORY_MAP);
 
 export interface ModelSelectorProps {
-  /** Explicit selection map: category → model key. Enables override mode. */
+  /** Explicit selection map: category → model key. Enables controlled mode. */
   selectedModels?: Record<string, string>;
-  /** Called when the user selects a model. */
+  /** Called when the user selects a model, or when defaults are computed on load. */
   onSelectionChange?: (category: string, modelKey: string) => void;
   /** Subset of categories to display. Defaults to all. */
   categories?: string[];
@@ -61,8 +61,13 @@ export default function ModelSelector({
   const [loading, setLoading] = useState(true);
   const [localSelection, setLocalSelection] = useState<Record<string, string>>({});
 
-  const visibleCategories = categories ?? ALL_CATEGORIES;
+  const visibleCategories = useMemo(() => categories ?? ALL_CATEGORIES, [categories]);
 
+  // Stable ref for onSelectionChange to avoid effect re-fires when callback identity changes
+  const onChangeRef = useRef(onSelectionChange);
+  onChangeRef.current = onSelectionChange;
+
+  // Effect 1: Fetch model catalog when apiBase changes
   useEffect(() => {
     let cancelled = false;
 
@@ -77,19 +82,6 @@ export default function ModelSelector({
         const json: ModelsResponse = await res.json();
         if (!cancelled) {
           setData(json);
-
-          // Default-selection mode: pick first available model per category
-          const defaults: Record<string, string> = {};
-          for (const cat of visibleCategories) {
-            const meta = CATEGORY_MAP[cat];
-            if (!meta) continue;
-            const models = json[meta.responseKey];
-            const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
-            if (firstAvailable) {
-              defaults[cat] = firstAvailable.key;
-            }
-          }
-          setLocalSelection(defaults);
         }
       } catch (err) {
         if (!cancelled) {
@@ -106,8 +98,33 @@ export default function ModelSelector({
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiBase]);
+
+  // Effect 2: Derive default selections when data or visible categories change (uncontrolled mode only).
+  // Also notifies parent of defaults so UI and parent state stay in sync.
+  useEffect(() => {
+    if (!data || selectedModels) return;
+
+    const defaults: Record<string, string> = {};
+    for (const cat of visibleCategories) {
+      const meta = CATEGORY_MAP[cat];
+      if (!meta) continue;
+      const models = data[meta.responseKey];
+      const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
+      if (firstAvailable) {
+        defaults[cat] = firstAvailable.key;
+      }
+    }
+    setLocalSelection(defaults);
+
+    // Notify parent of computed defaults
+    const cb = onChangeRef.current;
+    if (cb) {
+      for (const [cat, key] of Object.entries(defaults)) {
+        cb(cat, key);
+      }
+    }
+  }, [data, visibleCategories, selectedModels]);
 
   const handleSelect = useCallback(
     (category: string, modelKey: string) => {
@@ -139,6 +156,7 @@ export default function ModelSelector({
         const meta = CATEGORY_MAP[cat];
         if (!meta) return null;
         const models = data[meta.responseKey];
+        const groupName = `model-${cat}`;
 
         return (
           <fieldset key={cat} style={{ marginBottom: 16, border: "1px solid #ddd", borderRadius: 6, padding: 12 }}>
@@ -146,15 +164,14 @@ export default function ModelSelector({
             {models.length === 0 ? (
               <div style={{ color: "#888", fontSize: 13 }}>No models available</div>
             ) : (
-              <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              <div role="radiogroup" aria-label={meta.displayName}>
                 {models.map((model) => {
                   const isSelected = activeSelection[cat] === model.key;
+                  const inputId = `${groupName}-${model.key}`;
                   return (
-                    <li
+                    <label
                       key={model.key}
-                      role="option"
-                      aria-selected={isSelected}
-                      onClick={() => handleSelect(cat, model.key)}
+                      htmlFor={inputId}
                       style={{
                         display: "flex",
                         alignItems: "center",
@@ -167,6 +184,15 @@ export default function ModelSelector({
                         marginBottom: 4,
                       }}
                     >
+                      <input
+                        type="radio"
+                        id={inputId}
+                        name={groupName}
+                        value={model.key}
+                        checked={isSelected}
+                        onChange={() => handleSelect(cat, model.key)}
+                        style={{ margin: 0 }}
+                      />
                       <span style={{ flex: 1, fontSize: 13 }}>{model.label}</span>
                       <span style={STATUS_STYLES[model.status] ?? STATUS_STYLES.unknown}>
                         {model.status}
@@ -176,10 +202,10 @@ export default function ModelSelector({
                           local
                         </span>
                       )}
-                    </li>
+                    </label>
                   );
                 })}
-              </ul>
+              </div>
             )}
           </fieldset>
         );

--- a/apps/studio-web/src/components/creator/ModelSelector.tsx
+++ b/apps/studio-web/src/components/creator/ModelSelector.tsx
@@ -1,3 +1,189 @@
-export default function ModelSelector() {
-  return <div>ModelSelector</div>;
+import { useEffect, useState, useCallback } from "react";
+
+/** Shape of a single model entry returned by GET /api/creator/models. */
+interface ModelEntry {
+  key: string;
+  label: string;
+  provider_type: string;
+  is_local: boolean;
+  requires_gpu: boolean;
+  status: "available" | "unavailable" | "unknown";
+}
+
+/** Full response shape from the models endpoint. */
+interface ModelsResponse {
+  script_models: ModelEntry[];
+  image_models: ModelEntry[];
+  tts_models: ModelEntry[];
+  stt_models: ModelEntry[];
+}
+
+/** Category metadata for rendering. */
+interface CategoryMeta {
+  responseKey: keyof ModelsResponse;
+  displayName: string;
+}
+
+const CATEGORY_MAP: Record<string, CategoryMeta> = {
+  script: { responseKey: "script_models", displayName: "Script Model" },
+  image: { responseKey: "image_models", displayName: "Image Model" },
+  tts: { responseKey: "tts_models", displayName: "TTS Model" },
+  stt: { responseKey: "stt_models", displayName: "STT Model" },
+};
+
+const ALL_CATEGORIES = Object.keys(CATEGORY_MAP);
+
+export interface ModelSelectorProps {
+  /** Explicit selection map: category → model key. Enables override mode. */
+  selectedModels?: Record<string, string>;
+  /** Called when the user selects a model. */
+  onSelectionChange?: (category: string, modelKey: string) => void;
+  /** Subset of categories to display. Defaults to all. */
+  categories?: string[];
+  /** API base URL override (for testing). Defaults to "" (relative). */
+  apiBase?: string;
+}
+
+const STATUS_STYLES: Record<string, React.CSSProperties> = {
+  available: { background: "#d4edda", color: "#155724", borderRadius: 4, padding: "2px 6px", fontSize: 11 },
+  unavailable: { background: "#f8d7da", color: "#721c24", borderRadius: 4, padding: "2px 6px", fontSize: 11 },
+  unknown: { background: "#fff3cd", color: "#856404", borderRadius: 4, padding: "2px 6px", fontSize: 11 },
+};
+
+export default function ModelSelector({
+  selectedModels,
+  onSelectionChange,
+  categories,
+  apiBase = "",
+}: ModelSelectorProps) {
+  const [data, setData] = useState<ModelsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [localSelection, setLocalSelection] = useState<Record<string, string>>({});
+
+  const visibleCategories = categories ?? ALL_CATEGORIES;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchModels() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`${apiBase}/api/creator/models`);
+        if (!res.ok) {
+          throw new Error(`Failed to fetch models: ${res.status}`);
+        }
+        const json: ModelsResponse = await res.json();
+        if (!cancelled) {
+          setData(json);
+
+          // Default-selection mode: pick first available model per category
+          const defaults: Record<string, string> = {};
+          for (const cat of visibleCategories) {
+            const meta = CATEGORY_MAP[cat];
+            if (!meta) continue;
+            const models = json[meta.responseKey];
+            const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
+            if (firstAvailable) {
+              defaults[cat] = firstAvailable.key;
+            }
+          }
+          setLocalSelection(defaults);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Unknown error");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchModels();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiBase]);
+
+  const handleSelect = useCallback(
+    (category: string, modelKey: string) => {
+      if (!selectedModels) {
+        setLocalSelection((prev) => ({ ...prev, [category]: modelKey }));
+      }
+      onSelectionChange?.(category, modelKey);
+    },
+    [selectedModels, onSelectionChange],
+  );
+
+  const activeSelection = selectedModels ?? localSelection;
+
+  if (loading) {
+    return <div data-testid="model-selector-loading">Loading models…</div>;
+  }
+
+  if (error) {
+    return <div data-testid="model-selector-error" style={{ color: "#721c24" }}>Error: {error}</div>;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <div data-testid="model-selector">
+      {visibleCategories.map((cat) => {
+        const meta = CATEGORY_MAP[cat];
+        if (!meta) return null;
+        const models = data[meta.responseKey];
+
+        return (
+          <fieldset key={cat} style={{ marginBottom: 16, border: "1px solid #ddd", borderRadius: 6, padding: 12 }}>
+            <legend style={{ fontWeight: 600, fontSize: 14 }}>{meta.displayName}</legend>
+            {models.length === 0 ? (
+              <div style={{ color: "#888", fontSize: 13 }}>No models available</div>
+            ) : (
+              <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+                {models.map((model) => {
+                  const isSelected = activeSelection[cat] === model.key;
+                  return (
+                    <li
+                      key={model.key}
+                      role="option"
+                      aria-selected={isSelected}
+                      onClick={() => handleSelect(cat, model.key)}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        padding: "6px 8px",
+                        cursor: "pointer",
+                        borderRadius: 4,
+                        background: isSelected ? "#e8f0fe" : "transparent",
+                        border: isSelected ? "1px solid #4285f4" : "1px solid transparent",
+                        marginBottom: 4,
+                      }}
+                    >
+                      <span style={{ flex: 1, fontSize: 13 }}>{model.label}</span>
+                      <span style={STATUS_STYLES[model.status] ?? STATUS_STYLES.unknown}>
+                        {model.status}
+                      </span>
+                      {model.is_local && (
+                        <span style={{ fontSize: 10, color: "#666", background: "#eee", borderRadius: 3, padding: "1px 4px" }}>
+                          local
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </fieldset>
+        );
+      })}
+    </div>
+  );
 }

--- a/apps/studio-web/src/test-setup.ts
+++ b/apps/studio-web/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/apps/studio-web/vitest.config.ts
+++ b/apps/studio-web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});

--- a/apps/studio-web/vitest.config.ts
+++ b/apps/studio-web/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/test-setup.ts'],
   },
 });

--- a/apps/worker-orchestrator/celery_app.py
+++ b/apps/worker-orchestrator/celery_app.py
@@ -1,11 +1,25 @@
 # pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false
-"""Minimal Celery app configuration."""
+"""Minimal Celery app configuration with structured JSON logging."""
 
+import logging
 import os
+import sys
 
 from celery import Celery
+from celery.signals import after_setup_logger
+
+# Add packages to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../..", "packages"))
+
+from creator_service.logging_config import setup_json_logging
 
 redis_url = os.getenv("REDIS_URL", "redis://redis:6379/0")
 
 celery_app = Celery("worker-orchestrator", broker=redis_url, backend=redis_url)
 celery_app.conf.task_default_queue = "creator"
+
+
+@after_setup_logger.connect
+def setup_celery_logger(logger: logging.Logger, **kwargs: object) -> None:
+    """Configure Celery logger with JSON formatting."""
+    setup_json_logging(service_name="worker", level="INFO")

--- a/apps/worker-orchestrator/requirements.txt
+++ b/apps/worker-orchestrator/requirements.txt
@@ -1,3 +1,7 @@
 celery
 redis
 watchfiles
+
+
+# Dev dependencies
+ruff

--- a/apps/worker-orchestrator/requirements.txt
+++ b/apps/worker-orchestrator/requirements.txt
@@ -5,3 +5,4 @@ watchfiles
 
 # Dev dependencies
 ruff
+pytest

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -48,6 +48,9 @@ logger = logging.getLogger(__name__)
 
 _ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 
+# Stages where marking FAILED is safe — the run hasn't advanced past generation.
+_FAIL_SAFE_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
+
 
 class _StageGuardError(ValueError):
     """Raised when a run is not in an acceptable stage for generation.
@@ -186,16 +189,34 @@ def generate_script(
         # A stale/duplicate task should not downgrade a run already past generation.
         raise
     except Exception:
+        # Only mark FAILED if the run is still in a generating-compatible stage.
+        # A competing task may have already advanced the run (e.g. to SCRIPT_REVIEW);
+        # unconditionally writing FAILED would downgrade it.
         try:
-            asyncio.run(
-                _run_service.storage.update_run(
+            async def _conditional_fail() -> None:
+                run = await _run_service.storage.get_run(run_id)
+                if run is None:
+                    return
+                try:
+                    current = RunStage(run["current_stage"])
+                except ValueError:
+                    return  # Corrupted stage — don't make it worse
+                if current not in _FAIL_SAFE_STAGES:
+                    logger.info(
+                        "Run %d is in stage %s — skipping FAILED transition",
+                        run_id,
+                        current.value,
+                    )
+                    return
+                await _run_service.storage.update_run(
                     run_id,
                     {
                         "current_stage": RunStage.FAILED.value,
                         "status": "failed",
                     },
                 )
-            )
+
+            asyncio.run(_conditional_fail())
         except Exception:
             logger.exception("Failed to mark run %d as FAILED after task error", run_id)
 

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -49,6 +49,14 @@ logger = logging.getLogger(__name__)
 _ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 
 
+class _StageGuardError(ValueError):
+    """Raised when a run is not in an acceptable stage for generation.
+
+    This is a validation/rejection error — the run state must NOT be mutated
+    to FAILED because the run may already be in a later stage (e.g. SCRIPT_REVIEW).
+    """
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -96,11 +104,16 @@ def generate_script(
         # Stage guard: verify run is in an acceptable stage
         run = await _run_service.storage.get_run(run_id)
         if run is None:
-            raise ValueError(f"Run {run_id} not found")
+            raise _StageGuardError(f"Run {run_id} not found")
 
-        current = RunStage(run["current_stage"])
+        try:
+            current = RunStage(run["current_stage"])
+        except ValueError as exc:
+            raise _StageGuardError(
+                f"Run {run_id} has invalid stage {run['current_stage']!r}"
+            ) from exc
         if current not in _ALLOWED_STAGES:
-            raise ValueError(
+            raise _StageGuardError(
                 f"Run {run_id} is in stage {current.value}, "
                 f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
             )
@@ -164,6 +177,11 @@ def generate_script(
             "status": "success",
             "error": None,
         }
+    except _StageGuardError:
+        # Validation rejection — do NOT mutate run state to FAILED.
+        # A stale/duplicate task should not downgrade a run already past generation.
+        raise
+
     except Exception:
         try:
             asyncio.run(

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -99,8 +99,11 @@ def generate_script(
     redis_client: Any | None = None
     lock_acquired = False
 
-    async def _check_stage_guard() -> None:
-        """Validate run stage BEFORE any provider/GPU setup."""
+    async def _run_task() -> dict[str, object]:
+        nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
+        nonlocal redis_client, lock_acquired
+
+        # 1. Stage guard — reject before any side effects.
         run = await _run_service.storage.get_run(run_id)
         if run is None:
             raise _StageGuardError(f"Run {run_id} not found")
@@ -117,29 +120,7 @@ def generate_script(
                 f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
             )
 
-    async def _run_generation() -> str:
-        """Execute generation, save draft, advance stage."""
-        params = dict(entry.default_params or {})
-        generated = await provider.generate(prompt, params)
-        await _script_service.save_draft(
-            run_id=run_id,
-            source_type="generated_by_model",
-            markdown_content=generated,
-        )
-        await _run_service.storage.update_run(
-            run_id,
-            {
-                "current_stage": RunStage.SCRIPT_REVIEW.value,
-                "status": "running",
-            },
-        )
-        return generated
-
-    try:
-        # Stage guard FIRST — before any provider resolution or GPU lock.
-        # If the run is not in an allowed stage, reject immediately.
-        asyncio.run(_check_stage_guard())
-
+        # 2. Provider resolution (sync — blocks briefly, fine in Celery worker).
         registry = ProviderRegistry.create_default()
         entry = registry.resolve(model_key)
         provider = registry.get_provider(model_key)
@@ -147,6 +128,7 @@ def generate_script(
         provider_type = entry.provider_type
         endpoint = entry.endpoint
 
+        # 3. GPU lock acquisition (sync).
         if entry.requires_gpu:
             redis_client = _get_redis_client()
             if redis_client is None:
@@ -156,7 +138,21 @@ def generate_script(
             gpu_lock_acquired_at = _utc_now_iso()
 
         try:
-            asyncio.run(_run_generation())
+            # 4. Generation, save, advance stage.
+            params = dict(entry.default_params or {})
+            generated = await provider.generate(prompt, params)
+            await _script_service.save_draft(
+                run_id=run_id,
+                source_type="generated_by_model",
+                markdown_content=generated,
+            )
+            await _run_service.storage.update_run(
+                run_id,
+                {
+                    "current_stage": RunStage.SCRIPT_REVIEW.value,
+                    "status": "running",
+                },
+            )
         finally:
             if lock_acquired:
                 try:
@@ -182,11 +178,13 @@ def generate_script(
             "status": "success",
             "error": None,
         }
+
+    try:
+        return asyncio.run(_run_task())
     except _StageGuardError:
         # Validation rejection — do NOT mutate run state to FAILED.
         # A stale/duplicate task should not downgrade a run already past generation.
         raise
-
     except Exception:
         try:
             asyncio.run(

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 from datetime import datetime, timezone
@@ -42,6 +43,10 @@ try:
     from creator_service.script_service import script_service as _script_service
 except ImportError:
     from script_service import script_service as _script_service
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 
 
 def _utc_now_iso() -> str:
@@ -86,6 +91,36 @@ def generate_script(
     redis_client: Any | None = None
     lock_acquired = False
 
+    async def _run_generation() -> str:
+        """Single async coroutine wrapping all async operations."""
+        # Stage guard: verify run is in an acceptable stage
+        run = await _run_service.storage.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        current = RunStage(run["current_stage"])
+        if current not in _ALLOWED_STAGES:
+            raise ValueError(
+                f"Run {run_id} is in stage {current.value}, "
+                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+            )
+
+        params = dict(entry.default_params or {})
+        generated = await provider.generate(prompt, params)
+        await _script_service.save_draft(
+            run_id=run_id,
+            source_type="generated_by_model",
+            markdown_content=generated,
+        )
+        await _run_service.storage.update_run(
+            run_id,
+            {
+                "current_stage": RunStage.SCRIPT_REVIEW.value,
+                "status": "running",
+            },
+        )
+        return generated
+
     try:
         registry = ProviderRegistry.create_default()
         entry = registry.resolve(model_key)
@@ -103,28 +138,14 @@ def generate_script(
             gpu_lock_acquired_at = _utc_now_iso()
 
         try:
-            params = dict(entry.default_params or {})
-            generated_script = asyncio.run(provider.generate(prompt, params))
-            asyncio.run(
-                _script_service.save_draft(
-                    run_id=run_id,
-                    source_type="generated_by_model",
-                    markdown_content=generated_script,
-                )
-            )
-            asyncio.run(
-                _run_service.storage.update_run(
-                    run_id,
-                    {
-                        "current_stage": RunStage.SCRIPT_REVIEW.value,
-                        "status": "running",
-                    },
-                )
-            )
+            asyncio.run(_run_generation())
         finally:
             if lock_acquired:
-                release_gpu_lock(redis_client, task_id)
-                gpu_lock_released_at = _utc_now_iso()
+                try:
+                    release_gpu_lock(redis_client, task_id)
+                    gpu_lock_released_at = _utc_now_iso()
+                except Exception:
+                    logger.exception("Failed to release GPU lock for task %s", task_id)
 
         end_time = datetime.now(timezone.utc)
         duration_seconds = (end_time - start_time).total_seconds()
@@ -143,7 +164,7 @@ def generate_script(
             "status": "success",
             "error": None,
         }
-    except Exception as exc:
+    except Exception:
         try:
             asyncio.run(
                 _run_service.storage.update_run(
@@ -155,22 +176,6 @@ def generate_script(
                 )
             )
         except Exception:
-            pass
+            logger.exception("Failed to mark run %d as FAILED after task error", run_id)
 
-        end_time = datetime.now(timezone.utc)
-        duration_seconds = (end_time - start_time).total_seconds()
-        return {
-            "task_id": task_id,
-            "run_id": run_id,
-            "model_key": model_key,
-            "provider_type": provider_type,
-            "endpoint": endpoint,
-            "gpu_lock_acquired_at": gpu_lock_acquired_at,
-            "gpu_lock_released_at": gpu_lock_released_at,
-            "prompt_summary": idea_brief[:200],
-            "start_time": start_iso,
-            "end_time": end_time.isoformat(),
-            "duration_seconds": duration_seconds,
-            "status": "failed",
-            "error": str(exc),
-        }
+        raise

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -99,9 +99,8 @@ def generate_script(
     redis_client: Any | None = None
     lock_acquired = False
 
-    async def _run_generation() -> str:
-        """Single async coroutine wrapping all async operations."""
-        # Stage guard: verify run is in an acceptable stage
+    async def _check_stage_guard() -> None:
+        """Validate run stage BEFORE any provider/GPU setup."""
         run = await _run_service.storage.get_run(run_id)
         if run is None:
             raise _StageGuardError(f"Run {run_id} not found")
@@ -118,6 +117,8 @@ def generate_script(
                 f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
             )
 
+    async def _run_generation() -> str:
+        """Execute generation, save draft, advance stage."""
         params = dict(entry.default_params or {})
         generated = await provider.generate(prompt, params)
         await _script_service.save_draft(
@@ -135,6 +136,10 @@ def generate_script(
         return generated
 
     try:
+        # Stage guard FIRST — before any provider resolution or GPU lock.
+        # If the run is not in an allowed stage, reject immediately.
+        asyncio.run(_check_stage_guard())
+
         registry = ProviderRegistry.create_default()
         entry = registry.resolve(model_key)
         provider = registry.get_provider(model_key)

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -149,13 +149,29 @@ def generate_script(
                 source_type="generated_by_model",
                 markdown_content=generated,
             )
-            await _run_service.storage.update_run(
-                run_id,
-                {
-                    "current_stage": RunStage.SCRIPT_REVIEW.value,
-                    "status": "running",
-                },
-            )
+            # Conditional success transition: only advance if run is still in a
+            # generating-compatible stage. A competing task may have already
+            # advanced the run past generation.
+            current_run = await _run_service.storage.get_run(run_id)
+            if current_run is not None:
+                try:
+                    cur_stage = RunStage(current_run["current_stage"])
+                except ValueError:
+                    cur_stage = None
+                if cur_stage in _FAIL_SAFE_STAGES:
+                    await _run_service.storage.update_run(
+                        run_id,
+                        {
+                            "current_stage": RunStage.SCRIPT_REVIEW.value,
+                            "status": "running",
+                        },
+                    )
+                else:
+                    logger.info(
+                        "Run %d is in stage %s after generation -- skipping SCRIPT_REVIEW transition",
+                        run_id,
+                        current_run["current_stage"],
+                    )
         finally:
             if lock_acquired:
                 try:

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -1,1 +1,176 @@
-"""Placeholder for generate_script."""
+# pyright: reportMissingImports=false
+"""Celery task for script generation via model providers."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
+
+try:
+    import redis
+except ImportError:
+    redis = None  # type: ignore[assignment]
+
+from celery_app import celery_app
+
+try:
+    from creator_domain.models.stage import RunStage
+except ImportError:
+    from models.stage import RunStage
+
+try:
+    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from creator_provider.registry import ProviderRegistry
+except ImportError:
+    from gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from registry import ProviderRegistry
+
+try:
+    from creator_service.run_service import run_service as _run_service
+except ImportError:
+    from run_service import run_service as _run_service
+
+try:
+    from creator_service.script_service import script_service as _script_service
+except ImportError:
+    from script_service import script_service as _script_service
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _build_prompt(idea_brief: str, instructions: str | None) -> str:
+    idea = idea_brief.strip()
+    if not instructions:
+        return idea
+
+    extra = instructions.strip()
+    if not extra:
+        return idea
+
+    return f"{idea}\n\nAdditional instructions:\n{extra}"
+
+
+def _get_redis_client() -> Any | None:
+    if redis is None:
+        return None
+    return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+@celery_app.task(bind=True, name="generate_script")
+def generate_script(
+    self,
+    run_id: int,
+    idea_brief: str,
+    model_key: str = "qwen3-4b",
+    instructions: str | None = None,
+) -> dict[str, object]:
+    start_time = datetime.now(timezone.utc)
+    start_iso = start_time.isoformat()
+    task_id = str(getattr(getattr(self, "request", None), "id", None) or f"run-{run_id}")
+    prompt = _build_prompt(idea_brief, instructions)
+
+    provider_type: str | None = None
+    endpoint: str | None = None
+    gpu_lock_acquired_at: str | None = None
+    gpu_lock_released_at: str | None = None
+    redis_client: Any | None = None
+    lock_acquired = False
+
+    try:
+        registry = ProviderRegistry.create_default()
+        entry = registry.resolve(model_key)
+        provider = registry.get_provider(model_key)
+
+        provider_type = entry.provider_type
+        endpoint = entry.endpoint
+
+        if entry.requires_gpu:
+            redis_client = _get_redis_client()
+            if redis_client is None:
+                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+            acquire_gpu_lock(redis_client, task_id)
+            lock_acquired = True
+            gpu_lock_acquired_at = _utc_now_iso()
+
+        try:
+            params = dict(entry.default_params or {})
+            generated_script = asyncio.run(provider.generate(prompt, params))
+            asyncio.run(
+                _script_service.save_draft(
+                    run_id=run_id,
+                    source_type="generated_by_model",
+                    markdown_content=generated_script,
+                )
+            )
+            asyncio.run(
+                _run_service.storage.update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.SCRIPT_REVIEW.value,
+                        "status": "running",
+                    },
+                )
+            )
+        finally:
+            if lock_acquired:
+                release_gpu_lock(redis_client, task_id)
+                gpu_lock_released_at = _utc_now_iso()
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "model_key": model_key,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+            "gpu_lock_released_at": gpu_lock_released_at,
+            "prompt_summary": idea_brief[:200],
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "success",
+            "error": None,
+        }
+    except Exception as exc:
+        try:
+            asyncio.run(
+                _run_service.storage.update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.FAILED.value,
+                        "status": "failed",
+                    },
+                )
+            )
+        except Exception:
+            pass
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "model_key": model_key,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+            "gpu_lock_released_at": gpu_lock_released_at,
+            "prompt_summary": idea_brief[:200],
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "failed",
+            "error": str(exc),
+        }

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -48,8 +48,10 @@ logger = logging.getLogger(__name__)
 
 _ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 
-# Stages where marking FAILED is safe — the run hasn't advanced past generation.
-_FAIL_SAFE_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
+# Stages where writing SCRIPT_REVIEW or FAILED is safe — the run hasn't
+# advanced past generation.  Used as the expected_stages argument to
+# conditional_update_run for atomic compare-and-set.
+_SAFE_STAGES = frozenset({RunStage.IDEA_READY.value, RunStage.SCRIPT_GENERATING.value})
 
 
 class _StageGuardError(ValueError):
@@ -149,29 +151,22 @@ def generate_script(
                 source_type="generated_by_model",
                 markdown_content=generated,
             )
-            # Conditional success transition: only advance if run is still in a
-            # generating-compatible stage. A competing task may have already
-            # advanced the run past generation.
-            current_run = await _run_service.storage.get_run(run_id)
-            if current_run is not None:
-                try:
-                    cur_stage = RunStage(current_run["current_stage"])
-                except ValueError:
-                    cur_stage = None
-                if cur_stage in _FAIL_SAFE_STAGES:
-                    await _run_service.storage.update_run(
-                        run_id,
-                        {
-                            "current_stage": RunStage.SCRIPT_REVIEW.value,
-                            "status": "running",
-                        },
-                    )
-                else:
-                    logger.info(
-                        "Run %d is in stage %s after generation -- skipping SCRIPT_REVIEW transition",
-                        run_id,
-                        current_run["current_stage"],
-                    )
+            # Atomic success transition: only advance if run is still in a
+            # generating-compatible stage. Uses compare-and-set at the storage
+            # layer — no TOCTOU gap.
+            applied, _ = await _run_service.storage.conditional_update_run(
+                run_id,
+                {
+                    "current_stage": RunStage.SCRIPT_REVIEW.value,
+                    "status": "running",
+                },
+                expected_stages=_SAFE_STAGES,
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during generation -- skipping SCRIPT_REVIEW transition",
+                    run_id,
+                )
         finally:
             if lock_acquired:
                 try:
@@ -205,34 +200,24 @@ def generate_script(
         # A stale/duplicate task should not downgrade a run already past generation.
         raise
     except Exception:
-        # Only mark FAILED if the run is still in a generating-compatible stage.
-        # A competing task may have already advanced the run (e.g. to SCRIPT_REVIEW);
-        # unconditionally writing FAILED would downgrade it.
+        # Atomic conditional fail: only mark FAILED if run is still in a
+        # generating-compatible stage. Uses compare-and-set — no TOCTOU gap.
         try:
-            async def _conditional_fail() -> None:
-                run = await _run_service.storage.get_run(run_id)
-                if run is None:
-                    return
-                try:
-                    current = RunStage(run["current_stage"])
-                except ValueError:
-                    return  # Corrupted stage — don't make it worse
-                if current not in _FAIL_SAFE_STAGES:
-                    logger.info(
-                        "Run %d is in stage %s — skipping FAILED transition",
-                        run_id,
-                        current.value,
-                    )
-                    return
-                await _run_service.storage.update_run(
+            applied, _ = asyncio.run(
+                _run_service.storage.conditional_update_run(
                     run_id,
                     {
                         "current_stage": RunStage.FAILED.value,
                         "status": "failed",
                     },
+                    expected_stages=_SAFE_STAGES,
                 )
-
-            asyncio.run(_conditional_fail())
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during generation -- skipping FAILED transition",
+                    run_id,
+                )
         except Exception:
             logger.exception("Failed to mark run %d as FAILED after task error", run_id)
 

--- a/apps/worker-orchestrator/tests/__init__.py
+++ b/apps/worker-orchestrator/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test module for worker-orchestrator."""

--- a/apps/worker-orchestrator/tests/conftest.py
+++ b/apps/worker-orchestrator/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest fixtures for Celery app tests."""
+import pytest
+from celery_app import celery_app
+
+
+@pytest.fixture
+def celery_config():
+    """Celery configuration for testing."""
+    return {
+        "broker_url": "memory://",
+        "result_backend": "cache+memory://",
+    }
+
+
+@pytest.fixture
+def app(celery_config):
+    """Celery app fixture with test configuration."""
+    celery_app.conf.update(celery_config)
+    return celery_app

--- a/apps/worker-orchestrator/tests/test_celery_app.py
+++ b/apps/worker-orchestrator/tests/test_celery_app.py
@@ -1,0 +1,11 @@
+"""Tests for Celery app configuration."""
+
+
+def test_celery_app_loads(app):
+    """Test that Celery app loads correctly."""
+    assert app.main == "worker-orchestrator"
+
+
+def test_default_queue_is_creator(app):
+    """Test that default queue is set to 'creator'."""
+    assert app.conf.task_default_queue == "creator"

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -470,3 +470,29 @@ def test_stage_guard_invalid_stage_value(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert provider.calls == []
     assert storage.calls == []
+
+
+def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stage guard must reject BEFORE provider resolution, so a bad model_key
+    with a wrong-stage run does NOT mark the run as FAILED."""
+    # Registry that will raise on resolve — simulates bad model_key
+    registry = FakeRegistry(
+        entry=FakeEntry(),
+        provider=FakeProvider(),
+        resolve_error=KeyError("Model not found"),
+    )
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    # Run is already in SCRIPT_REVIEW — stale/duplicate task scenario
+    storage = _make_storage(run_id=800, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, storage)
+
+    # Stage guard fires first, KeyError from resolve never reached
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=800, idea_brief="Stale task with bad model")
+
+    # Run state must NOT be mutated — stage guard rejected before provider setup
+    assert storage.calls == []
+    run = storage._runs[800]
+    assert run["current_stage"] == "SCRIPT_REVIEW"

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -322,8 +322,8 @@ def test_stage_guard_rejects_wrong_stage(monkeypatch: pytest.MonkeyPatch) -> Non
     # Provider should never have been called
     assert provider.calls == []
     assert script_service.calls == []
-    # Should still mark run as FAILED
-    assert storage.calls == [(200, {"current_stage": "FAILED", "status": "failed"})]
+    # Run state must NOT be mutated — this is a validation rejection, not a failure
+    assert storage.calls == []
 
 
 def test_stage_guard_accepts_script_generating(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -358,7 +358,8 @@ def test_stage_guard_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
         _invoke_task(run_id=999, idea_brief="Ghost run")
 
     assert provider.calls == []
-
+    # Run state must NOT be mutated for a non-existent run
+    assert storage.calls == []
 
 # ──────────────────────────────────────────────────────────────────────
 # Oracle-requested: re-raise propagation
@@ -427,3 +428,45 @@ def test_update_run_failure_in_error_path_still_re_raises_original(monkeypatch: 
     # Original error must still propagate even if FAILED-stage update fails
     with pytest.raises(RuntimeError, match="original error"):
         _invoke_task(run_id=500, idea_brief="Double failure")
+
+
+def test_stage_guard_wrong_stage_preserves_run_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run in SCRIPT_REVIEW must stay in SCRIPT_REVIEW after stage guard rejection."""
+    provider = FakeProvider(result="Should not run")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=600, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=600, idea_brief="Stale duplicate task")
+
+    # The run must NOT have been mutated at all
+    assert storage.calls == []
+    assert provider.calls == []
+    # Verify the run still has its original stage
+    run = storage._runs[600]
+    assert run["current_stage"] == "SCRIPT_REVIEW"
+
+
+def test_stage_guard_invalid_stage_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed current_stage value in storage should raise without marking FAILED."""
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    # Simulate corrupted stage value in storage
+    storage = _make_storage(run_id=700, stage="BOGUS_STAGE")
+    _patch_services(monkeypatch, script_service, storage)
+
+    # RunStage("BOGUS_STAGE") will raise ValueError — should NOT mark run FAILED
+    with pytest.raises(ValueError):
+        _invoke_task(run_id=700, idea_brief="Corrupted stage")
+
+    assert provider.calls == []
+    assert storage.calls == []

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -496,3 +496,68 @@ def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.Monke
     assert storage.calls == []
     run = storage._runs[800]
     assert run["current_stage"] == "SCRIPT_REVIEW"
+
+
+class RaceConditionStorage(FakeStorage):
+    """Storage that simulates a competing task advancing the run between guard and error handler."""
+
+    def __init__(self, run_id: int, initial_stage: str, advanced_stage: str) -> None:
+        super().__init__(runs={run_id: {"id": run_id, "current_stage": initial_stage}})
+        self._target_id = run_id
+        self._advanced_stage = advanced_stage
+        self._get_count = 0
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        self._get_count += 1
+        if run_id == self._target_id and self._get_count > 1:
+            # Second get_run call (from _conditional_fail) sees the advanced stage
+            self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
+        return self._runs.get(run_id)
+
+
+def test_conditional_fail_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a competing task advances the run to SCRIPT_REVIEW before the error handler
+    runs, the error handler must NOT overwrite it to FAILED.
+
+    Scenario: two duplicate tasks both pass the stage guard. Task A succeeds and
+    advances the run to SCRIPT_REVIEW. Task B then fails during generation. Task B's
+    error handler re-checks the stage and sees SCRIPT_REVIEW -> skips FAILED write.
+    """
+    provider = FakeProvider(error=RuntimeError("task B generation failed"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    # First get_run (stage guard) returns IDEA_READY -> task passes guard.
+    # Second get_run (_conditional_fail) returns SCRIPT_REVIEW -> competing task advanced it.
+    storage = RaceConditionStorage(
+        run_id=900, initial_stage="IDEA_READY", advanced_stage="SCRIPT_REVIEW"
+    )
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(RuntimeError, match="task B generation failed"):
+        _invoke_task(run_id=900, idea_brief="Duplicate task scenario")
+
+    # Error handler must NOT have written FAILED -- run was already advanced
+    assert storage.calls == []
+    assert storage._runs[900]["current_stage"] == "SCRIPT_REVIEW"
+
+
+def test_conditional_fail_marks_failed_when_still_in_generating_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the run is still in IDEA_READY at error time, the error handler should
+    mark it as FAILED (normal failure path)."""
+    provider = FakeProvider(error=RuntimeError("generation error"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=901, stage="IDEA_READY")
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(RuntimeError, match="generation error"):
+        _invoke_task(run_id=901, idea_brief="Normal failure")
+
+    # Run was still in IDEA_READY -> FAILED write should happen
+    assert storage.calls == [(901, {"current_stage": "FAILED", "status": "failed"})]

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-
 from tasks import generate_script as generate_script_module
 
 
@@ -31,15 +30,29 @@ class FakeProvider:
 
 
 class FakeStorage:
-    def __init__(self, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        error: Exception | None = None,
+        runs: dict[int, dict[str, object]] | None = None,
+    ) -> None:
         self.error = error
         self.calls: list[tuple[int, dict[str, object]]] = []
+        self._runs: dict[int, dict[str, object]] = runs or {}
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        return self._runs.get(run_id)
 
     async def update_run(self, run_id: int, updates: dict[str, object]) -> dict[str, object]:
         self.calls.append((run_id, updates))
         if self.error is not None:
             raise self.error
         return {"id": run_id, **updates}
+
+
+def _make_storage(run_id: int = 101, stage: str = "IDEA_READY", **extra: Any) -> FakeStorage:
+    """Create a FakeStorage pre-populated with a single run in the given stage."""
+    run_row: dict[str, object] = {"id": run_id, "current_stage": stage, **extra}
+    return FakeStorage(runs={run_id: run_row})
 
 
 class FakeScriptService:
@@ -98,6 +111,10 @@ def _invoke_task(**kwargs: Any) -> dict[str, object]:
     return run_callable(**kwargs)
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Happy-path tests
+# ──────────────────────────────────────────────────────────────────────
+
 def test_generate_script_happy_path_local_model_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = FakeProvider(result="# Draft")
     entry = FakeEntry(requires_gpu=True, default_params={"temperature": 0.2})
@@ -114,7 +131,7 @@ def test_generate_script_happy_path_local_model_with_gpu_lock(monkeypatch: pytes
     monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda client, task_id: release_calls.append(task_id))
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=101, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
     result = _invoke_task(run_id=101, idea_brief="A city mystery", model_key="qwen3-4b")
@@ -127,6 +144,7 @@ def test_generate_script_happy_path_local_model_with_gpu_lock(monkeypatch: pytes
     assert lock_calls == ["run-101"]
     assert release_calls == ["run-101"]
     assert script_service.calls == [(101, "generated_by_model", "# Draft")]
+    # get_run (stage guard) + update_run (advance to SCRIPT_REVIEW)
     assert storage.calls == [(101, {"current_stage": "SCRIPT_REVIEW", "status": "running"})]
     assert provider.calls[0][1] == {"temperature": 0.2}
 
@@ -141,7 +159,7 @@ def test_generate_script_happy_path_external_model_without_gpu_lock(monkeypatch:
     monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=102, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
     result = _invoke_task(run_id=102, idea_brief="Ocean documentary", model_key="gpt-4.1")
@@ -153,6 +171,33 @@ def test_generate_script_happy_path_external_model_without_gpu_lock(monkeypatch:
     assert storage.calls == [(102, {"current_stage": "SCRIPT_REVIEW", "status": "running"})]
 
 
+def test_generate_script_appends_custom_instructions_to_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="Draft")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=108, stage="IDEA_READY")
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(
+        run_id=108,
+        idea_brief="Base idea",
+        instructions="Use energetic narration",
+    )
+
+    assert result["status"] == "success"
+    used_prompt = provider.calls[0][0]
+    assert "Base idea" in used_prompt
+    assert "Additional instructions:" in used_prompt
+    assert "Use energetic narration" in used_prompt
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Failure tests — task now re-raises, so pytest.raises is required
+# ──────────────────────────────────────────────────────────────────────
+
 def test_generate_script_provider_resolution_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     registry = FakeRegistry(
         entry=FakeEntry(),
@@ -162,13 +207,12 @@ def test_generate_script_provider_resolution_failure(monkeypatch: pytest.MonkeyP
     _patch_registry(monkeypatch, registry)
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=103, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=103, idea_brief="Unknown model", model_key="missing")
+    with pytest.raises(KeyError, match="Model not found"):
+        _invoke_task(run_id=103, idea_brief="Unknown model", model_key="missing")
 
-    assert result["status"] == "failed"
-    assert "Model not found" in str(result["error"])
     assert script_service.calls == []
     assert storage.calls == [(103, {"current_stage": "FAILED", "status": "failed"})]
 
@@ -180,13 +224,12 @@ def test_generate_script_llm_generation_failure_sets_failed_stage(monkeypatch: p
     _patch_registry(monkeypatch, registry)
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=104, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=104, idea_brief="Failing generation")
+    with pytest.raises(RuntimeError, match="generation failed"):
+        _invoke_task(run_id=104, idea_brief="Failing generation")
 
-    assert result["status"] == "failed"
-    assert result["error"] == "generation failed"
     assert script_service.calls == []
     assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
 
@@ -208,15 +251,12 @@ def test_generate_script_gpu_lock_timeout(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda *_: None)
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=105, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=105, idea_brief="Lock timeout")
+    with pytest.raises(TimeoutError, match="lock timeout"):
+        _invoke_task(run_id=105, idea_brief="Lock timeout")
 
-    assert result["status"] == "failed"
-    assert result["error"] == "lock timeout"
-    assert result["gpu_lock_acquired_at"] is None
-    assert result["gpu_lock_released_at"] is None
     assert script_service.calls == []
     assert storage.calls == [(105, {"current_stage": "FAILED", "status": "failed"})]
 
@@ -235,14 +275,13 @@ def test_generate_script_releases_gpu_lock_when_llm_fails(monkeypatch: pytest.Mo
     monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda _, task_id: released.append(task_id))
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=106, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=106, idea_brief="Failure with GPU")
+    with pytest.raises(RuntimeError, match="provider exploded"):
+        _invoke_task(run_id=106, idea_brief="Failure with GPU")
 
-    assert result["status"] == "failed"
     assert released == ["run-106"]
-    assert result["gpu_lock_released_at"] is not None
     assert storage.calls == [(106, {"current_stage": "FAILED", "status": "failed"})]
 
 
@@ -253,34 +292,138 @@ def test_generate_script_script_save_failure(monkeypatch: pytest.MonkeyPatch) ->
     _patch_registry(monkeypatch, registry)
 
     script_service = FakeScriptService(error=RuntimeError("save failed"))
-    storage = FakeStorage()
+    storage = _make_storage(run_id=107, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=107, idea_brief="Save failure")
+    with pytest.raises(RuntimeError, match="save failed"):
+        _invoke_task(run_id=107, idea_brief="Save failure")
 
-    assert result["status"] == "failed"
-    assert result["error"] == "save failed"
     assert storage.calls == [(107, {"current_stage": "FAILED", "status": "failed"})]
 
 
-def test_generate_script_appends_custom_instructions_to_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
-    provider = FakeProvider(result="Draft")
+# ──────────────────────────────────────────────────────────────────────
+# Oracle-requested: stage guard
+# ──────────────────────────────────────────────────────────────────────
+
+def test_stage_guard_rejects_wrong_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must refuse to run when the run is NOT in IDEA_READY or SCRIPT_GENERATING."""
+    provider = FakeProvider(result="Should not be called")
     entry = FakeEntry(requires_gpu=False)
     registry = FakeRegistry(entry=entry, provider=provider)
     _patch_registry(monkeypatch, registry)
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=200, stage="SCRIPT_REVIEW")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(
-        run_id=108,
-        idea_brief="Base idea",
-        instructions="Use energetic narration",
-    )
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=200, idea_brief="Should be blocked")
+
+    # Provider should never have been called
+    assert provider.calls == []
+    assert script_service.calls == []
+    # Should still mark run as FAILED
+    assert storage.calls == [(200, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_stage_guard_accepts_script_generating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task should accept SCRIPT_GENERATING stage (retry / re-entry scenario)."""
+    provider = FakeProvider(result="Retry draft")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=201, stage="SCRIPT_GENERATING")
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=201, idea_brief="Retry generation")
 
     assert result["status"] == "success"
-    used_prompt = provider.calls[0][0]
-    assert "Base idea" in used_prompt
-    assert "Additional instructions:" in used_prompt
-    assert "Use energetic narration" in used_prompt
+    assert script_service.calls == [(201, "generated_by_model", "Retry draft")]
+
+
+def test_stage_guard_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must fail when run_id does not exist."""
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()  # No runs at all
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(ValueError, match="Run 999 not found"):
+        _invoke_task(run_id=999, idea_brief="Ghost run")
+
+    assert provider.calls == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Oracle-requested: re-raise propagation
+# ──────────────────────────────────────────────────────────────────────
+
+def test_failure_propagates_to_celery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must re-raise exceptions so Celery marks the task as FAILURE."""
+    provider = FakeProvider(error=RuntimeError("LLM exploded"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=300, stage="IDEA_READY")
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(RuntimeError, match="LLM exploded"):
+        _invoke_task(run_id=300, idea_brief="Propagation test")
+
+    # The FAILED stage update must still have happened before re-raise
+    assert storage.calls == [(300, {"current_stage": "FAILED", "status": "failed"})]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Oracle-requested: release_gpu_lock failure resilience
+# ──────────────────────────────────────────────────────────────────────
+
+def test_release_gpu_lock_failure_still_propagates_original_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If release_gpu_lock raises, the original generation error still propagates."""
+    provider = FakeProvider(error=RuntimeError("generation boom"))
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    monkeypatch.setattr(generate_script_module, "acquire_gpu_lock", lambda *_: True)
+    monkeypatch.setattr(
+        generate_script_module,
+        "release_gpu_lock",
+        lambda *_: (_ for _ in ()).throw(ConnectionError("redis gone")),
+    )
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=400, stage="IDEA_READY")
+    _patch_services(monkeypatch, script_service, storage)
+
+    # The original error should propagate (not the release_gpu_lock ConnectionError)
+    with pytest.raises(RuntimeError, match="generation boom"):
+        _invoke_task(run_id=400, idea_brief="Lock release failure")
+
+
+def test_update_run_failure_in_error_path_still_re_raises_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If update_run fails in the error handler, the original exception still propagates."""
+    provider = FakeProvider(error=RuntimeError("original error"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=500, stage="IDEA_READY")
+    storage.error = ConnectionError("DB down")  # update_run will fail too
+    _patch_services(monkeypatch, script_service, storage)
+
+    # Original error must still propagate even if FAILED-stage update fails
+    with pytest.raises(RuntimeError, match="original error"):
+        _invoke_task(run_id=500, idea_brief="Double failure")

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tasks import generate_script as generate_script_module
+
+
+@dataclass
+class FakeEntry:
+    provider_type: str = "ollama"
+    endpoint: str = "http://ollama:11434"
+    requires_gpu: bool = True
+    default_params: dict[str, object] | None = None
+
+
+class FakeProvider:
+    def __init__(self, result: str = "Generated script", error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[tuple[str, dict[str, object] | None]] = []
+
+    async def generate(self, prompt: str, params: dict[str, object] | None = None) -> str:
+        self.calls.append((prompt, params))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class FakeStorage:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[int, dict[str, object]]] = []
+
+    async def update_run(self, run_id: int, updates: dict[str, object]) -> dict[str, object]:
+        self.calls.append((run_id, updates))
+        if self.error is not None:
+            raise self.error
+        return {"id": run_id, **updates}
+
+
+class FakeScriptService:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[int, str, str | None]] = []
+
+    async def save_draft(self, run_id: int, source_type: str, markdown_content: str | None) -> dict[str, object]:
+        self.calls.append((run_id, source_type, markdown_content))
+        if self.error is not None:
+            raise self.error
+        return {"run_id": run_id, "source_type": source_type, "markdown_content": markdown_content}
+
+
+class FakeRegistry:
+    def __init__(self, entry: FakeEntry, provider: FakeProvider, resolve_error: Exception | None = None) -> None:
+        self.entry = entry
+        self.provider = provider
+        self.resolve_error = resolve_error
+
+    def resolve(self, _model_key: str) -> FakeEntry:
+        if self.resolve_error is not None:
+            raise self.resolve_error
+        return self.entry
+
+    def get_provider(self, _model_key: str) -> FakeProvider:
+        return self.provider
+
+
+def _patch_registry(monkeypatch: pytest.MonkeyPatch, registry: FakeRegistry) -> None:
+    class _ProviderRegistry:
+        @staticmethod
+        def create_default() -> FakeRegistry:
+            return registry
+
+    monkeypatch.setattr(generate_script_module, "ProviderRegistry", _ProviderRegistry)
+
+
+def _patch_redis(monkeypatch: pytest.MonkeyPatch, redis_client: object) -> None:
+    redis_stub = SimpleNamespace(Redis=SimpleNamespace(from_url=lambda _: redis_client))
+    monkeypatch.setattr(generate_script_module, "redis", redis_stub)
+
+
+def _patch_services(
+    monkeypatch: pytest.MonkeyPatch,
+    script_service: FakeScriptService,
+    storage: FakeStorage,
+) -> None:
+    monkeypatch.setattr(generate_script_module, "_script_service", script_service)
+    monkeypatch.setattr(generate_script_module, "_run_service", SimpleNamespace(storage=storage))
+
+
+def _invoke_task(**kwargs: Any) -> dict[str, object]:
+    task = generate_script_module.generate_script
+    run_callable = getattr(task, "run", task)
+    return run_callable(**kwargs)
+
+
+def test_generate_script_happy_path_local_model_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="# Draft")
+    entry = FakeEntry(requires_gpu=True, default_params={"temperature": 0.2})
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    lock_calls: list[str] = []
+    release_calls: list[str] = []
+
+    monkeypatch.setattr(generate_script_module, "acquire_gpu_lock", lambda client, task_id: lock_calls.append(task_id))
+    monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda client, task_id: release_calls.append(task_id))
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=101, idea_brief="A city mystery", model_key="qwen3-4b")
+
+    assert result["status"] == "success"
+    assert result["provider_type"] == "ollama"
+    assert result["endpoint"] == "http://ollama:11434"
+    assert result["gpu_lock_acquired_at"] is not None
+    assert result["gpu_lock_released_at"] is not None
+    assert lock_calls == ["run-101"]
+    assert release_calls == ["run-101"]
+    assert script_service.calls == [(101, "generated_by_model", "# Draft")]
+    assert storage.calls == [(101, {"current_stage": "SCRIPT_REVIEW", "status": "running"})]
+    assert provider.calls[0][1] == {"temperature": 0.2}
+
+
+def test_generate_script_happy_path_external_model_without_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="Script from external")
+    entry = FakeEntry(provider_type="openai", endpoint="https://api.openai.com", requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    monkeypatch.setattr(generate_script_module, "acquire_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+    monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=102, idea_brief="Ocean documentary", model_key="gpt-4.1")
+
+    assert result["status"] == "success"
+    assert result["provider_type"] == "openai"
+    assert result["gpu_lock_acquired_at"] is None
+    assert result["gpu_lock_released_at"] is None
+    assert storage.calls == [(102, {"current_stage": "SCRIPT_REVIEW", "status": "running"})]
+
+
+def test_generate_script_provider_resolution_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = FakeRegistry(
+        entry=FakeEntry(),
+        provider=FakeProvider(),
+        resolve_error=KeyError("Model not found"),
+    )
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=103, idea_brief="Unknown model", model_key="missing")
+
+    assert result["status"] == "failed"
+    assert "Model not found" in str(result["error"])
+    assert script_service.calls == []
+    assert storage.calls == [(103, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_llm_generation_failure_sets_failed_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(error=RuntimeError("generation failed"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=104, idea_brief="Failing generation")
+
+    assert result["status"] == "failed"
+    assert result["error"] == "generation failed"
+    assert script_service.calls == []
+    assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_gpu_lock_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    monkeypatch.setattr(
+        generate_script_module,
+        "acquire_gpu_lock",
+        lambda *_: (_ for _ in ()).throw(TimeoutError("lock timeout")),
+    )
+    monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda *_: None)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=105, idea_brief="Lock timeout")
+
+    assert result["status"] == "failed"
+    assert result["error"] == "lock timeout"
+    assert result["gpu_lock_acquired_at"] is None
+    assert result["gpu_lock_released_at"] is None
+    assert script_service.calls == []
+    assert storage.calls == [(105, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_releases_gpu_lock_when_llm_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(error=RuntimeError("provider exploded"))
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    released: list[str] = []
+    monkeypatch.setattr(generate_script_module, "acquire_gpu_lock", lambda *_: True)
+    monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda _, task_id: released.append(task_id))
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=106, idea_brief="Failure with GPU")
+
+    assert result["status"] == "failed"
+    assert released == ["run-106"]
+    assert result["gpu_lock_released_at"] is not None
+    assert storage.calls == [(106, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_script_save_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="Draft text")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(error=RuntimeError("save failed"))
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=107, idea_brief="Save failure")
+
+    assert result["status"] == "failed"
+    assert result["error"] == "save failed"
+    assert storage.calls == [(107, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_appends_custom_instructions_to_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="Draft")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(
+        run_id=108,
+        idea_brief="Base idea",
+        instructions="Use energetic narration",
+    )
+
+    assert result["status"] == "success"
+    used_prompt = provider.calls[0][0]
+    assert "Base idea" in used_prompt
+    assert "Additional instructions:" in used_prompt
+    assert "Use energetic narration" in used_prompt

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -48,6 +48,23 @@ class FakeStorage:
             raise self.error
         return {"id": run_id, **updates}
 
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        if self.error is not None:
+            raise self.error
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
 
 def _make_storage(run_id: int = 101, stage: str = "IDEA_READY", **extra: Any) -> FakeStorage:
     """Create a FakeStorage pre-populated with a single run in the given stage."""
@@ -499,12 +516,13 @@ def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.Monke
 
 
 class RaceConditionStorage(FakeStorage):
-    """Storage that simulates a competing task advancing the run between calls.
+    """Storage that simulates a competing task advancing the run between operations.
 
-    After `advance_after` calls to get_run for the target run_id, the run's
-    stage is changed to `advanced_stage`. This allows testing both:
-    - Success path race: advance_after=1 (guard sees IDEA_READY, success check sees advanced)
-    - Failure path race: advance_after=1 (guard sees IDEA_READY, error handler sees advanced)
+    After `advance_after` read/CAS operations on the target run_id, the run's
+    stage is changed to `advanced_stage` before the operation reads it. This
+    allows testing both:
+    - Success path race: advance_after=1 (guard sees IDEA_READY, CAS sees advanced)
+    - Failure path race: advance_after=1 (guard sees IDEA_READY, CAS sees advanced)
     """
 
     def __init__(self, run_id: int, initial_stage: str, advanced_stage: str, advance_after: int = 1) -> None:
@@ -512,14 +530,36 @@ class RaceConditionStorage(FakeStorage):
         self._target_id = run_id
         self._advanced_stage = advanced_stage
         self._advance_after = advance_after
-        self._get_count = 0
+        self._op_count = 0
+
+    def _maybe_advance(self, run_id: int) -> None:
+        """Simulate a competing task advancing the run after N operations."""
+        if run_id == self._target_id:
+            self._op_count += 1
+            if self._op_count > self._advance_after:
+                self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
 
     async def get_run(self, run_id: int) -> dict[str, object] | None:
-        self._get_count += 1
-        if run_id == self._target_id and self._get_count > self._advance_after:
-            self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
+        self._maybe_advance(run_id)
         return self._runs.get(run_id)
 
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        """Atomic CAS — advance happens before the check, simulating a race."""
+        self._maybe_advance(run_id)
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
 
 def test_conditional_fail_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
     """If a competing task advances the run to SCRIPT_REVIEW before the error handler

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -499,18 +499,24 @@ def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.Monke
 
 
 class RaceConditionStorage(FakeStorage):
-    """Storage that simulates a competing task advancing the run between guard and error handler."""
+    """Storage that simulates a competing task advancing the run between calls.
 
-    def __init__(self, run_id: int, initial_stage: str, advanced_stage: str) -> None:
+    After `advance_after` calls to get_run for the target run_id, the run's
+    stage is changed to `advanced_stage`. This allows testing both:
+    - Success path race: advance_after=1 (guard sees IDEA_READY, success check sees advanced)
+    - Failure path race: advance_after=1 (guard sees IDEA_READY, error handler sees advanced)
+    """
+
+    def __init__(self, run_id: int, initial_stage: str, advanced_stage: str, advance_after: int = 1) -> None:
         super().__init__(runs={run_id: {"id": run_id, "current_stage": initial_stage}})
         self._target_id = run_id
         self._advanced_stage = advanced_stage
+        self._advance_after = advance_after
         self._get_count = 0
 
     async def get_run(self, run_id: int) -> dict[str, object] | None:
         self._get_count += 1
-        if run_id == self._target_id and self._get_count > 1:
-            # Second get_run call (from _conditional_fail) sees the advanced stage
+        if run_id == self._target_id and self._get_count > self._advance_after:
             self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
         return self._runs.get(run_id)
 
@@ -561,3 +567,38 @@ def test_conditional_fail_marks_failed_when_still_in_generating_stage(monkeypatc
 
     # Run was still in IDEA_READY -> FAILED write should happen
     assert storage.calls == [(901, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_success_transition_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a competing task advances the run past generation before this task's
+    success transition, the SCRIPT_REVIEW write must be skipped.
+
+    Scenario: two duplicate tasks both pass the stage guard (both see IDEA_READY).
+    Task A completes and moves the run to VISUAL_PLAN_GENERATING. Task B then
+    completes generation -- its success transition re-checks and sees the run is
+    no longer in a generating stage, so it skips the SCRIPT_REVIEW write.
+    """
+    provider = FakeProvider(result="Duplicate draft")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    # First get_run (stage guard) returns IDEA_READY -> passes guard.
+    # Second get_run (success transition check) returns VISUAL_PLAN_GENERATING
+    # -> competing task already advanced the run further.
+    storage = RaceConditionStorage(
+        run_id=950, initial_stage="IDEA_READY", advanced_stage="VISUAL_PLAN_GENERATING"
+    )
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=950, idea_brief="Duplicate success scenario")
+
+    # Task still reports success (it generated and saved the draft)
+    assert result["status"] == "success"
+    # But the SCRIPT_REVIEW update_run must NOT have happened
+    assert storage.calls == []
+    # Draft was still saved (that is fine -- it will not be the active one)
+    assert script_service.calls == [(950, "generated_by_model", "Duplicate draft")]
+    # Run stays at the advanced stage, not overwritten to SCRIPT_REVIEW
+    assert storage._runs[950]["current_stage"] == "VISUAL_PLAN_GENERATING"

--- a/packages/creator-domain/models/__init__.py
+++ b/packages/creator-domain/models/__init__.py
@@ -3,6 +3,15 @@ from .model_selection import ModelSelection
 from .pipeline_run import PipelineRun
 from .project import Project
 from .script_draft import ScriptDraft, ScriptSection, VisualOverride
+from .stage import (
+    GENERATING_STAGES,
+    REVIEW_STAGES,
+    TRANSITIONS,
+    RunStage,
+    advance,
+    can_transition,
+    next_stages,
+)
 from .subtitle_artifact import SubtitleArtifact
 from .video_artifact import VideoArtifact
 from .visual_asset import VisualAsset
@@ -15,6 +24,13 @@ __all__ = [
     "ScriptDraft",
     "ScriptSection",
     "VisualOverride",
+    "RunStage",
+    "TRANSITIONS",
+    "REVIEW_STAGES",
+    "GENERATING_STAGES",
+    "can_transition",
+    "next_stages",
+    "advance",
     "VisualPlan",
     "VisualScene",
     "VisualAsset",

--- a/packages/creator-domain/models/__init__.py
+++ b/packages/creator-domain/models/__init__.py
@@ -1,1 +1,24 @@
-"""Placeholder for creator_domain.models."""
+from .audio_artifact import AudioArtifact
+from .model_selection import ModelSelection
+from .pipeline_run import PipelineRun
+from .project import Project
+from .script_draft import ScriptDraft, ScriptSection, VisualOverride
+from .subtitle_artifact import SubtitleArtifact
+from .video_artifact import VideoArtifact
+from .visual_asset import VisualAsset
+from .visual_plan import VisualPlan, VisualScene
+
+__all__ = [
+    "Project",
+    "PipelineRun",
+    "ModelSelection",
+    "ScriptDraft",
+    "ScriptSection",
+    "VisualOverride",
+    "VisualPlan",
+    "VisualScene",
+    "VisualAsset",
+    "AudioArtifact",
+    "SubtitleArtifact",
+    "VideoArtifact",
+]

--- a/packages/creator-domain/models/audio_artifact.py
+++ b/packages/creator-domain/models/audio_artifact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -20,25 +21,25 @@ class AudioArtifact(BaseModel):
 
     @classmethod
     def from_row(cls, row: dict) -> AudioArtifact:
-        """Construct from a DB row dict, mapping column names to domain fields.
+        """Construct from a creator_artifacts DB row.
 
-        Handles:
-        - file_path (TEXT) -> path (str)
-        - metadata_json (TEXT) -> ignored (not on this model)
-        - provider (VARCHAR, if present) -> provider_type (str)
+        The creator_artifacts table stores artifact-specific fields in
+        metadata_json.  This method extracts model_used, provider_type,
+        and voice from that JSON column and maps file_path -> path.
         """
         mapped = dict(row)
         if "file_path" in mapped and "path" not in mapped:
             mapped["path"] = mapped.pop("file_path")
-        if "provider" in mapped and "provider_type" not in mapped:
-            mapped["provider_type"] = mapped.pop("provider")
+        # Extract domain fields from metadata_json
+        raw_meta = mapped.pop("metadata_json", None)
+        if raw_meta is not None:
+            meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+            mapped.setdefault("model_used", meta.get("model_used"))
+            mapped.setdefault("provider_type", meta.get("provider_type"))
+            mapped.setdefault("voice", meta.get("voice"))
         # Discard DB-only columns not in this domain model
-        mapped.pop("metadata_json", None)
-        mapped.pop("artifact_type", None)
-        mapped.pop("scene_id", None)
-        mapped.pop("file_size_bytes", None)
-        mapped.pop("mime_type", None)
-        mapped.pop("updated_at", None)
+        for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
+            mapped.pop(key, None)
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/models/audio_artifact.py
+++ b/packages/creator-domain/models/audio_artifact.py
@@ -3,20 +3,17 @@ from datetime import datetime
 from pydantic import BaseModel
 
 
-class VisualAsset(BaseModel):
+class AudioArtifact(BaseModel):
     id: int
     run_id: int
-    scene_id: str
-    version: int = 1
-    asset_path: str
-    prompt_snapshot: str | None = None
+    path: str
     model_used: str | None = None
     provider_type: str | None = None
-    is_active: bool = True
+    voice: str | None = None
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "VisualAsset":
+    def from_dict(cls, data: dict) -> "AudioArtifact":
         return cls.model_validate(data)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/models/audio_artifact.py
+++ b/packages/creator-domain/models/audio_artifact.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -13,8 +15,31 @@ class AudioArtifact(BaseModel):
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "AudioArtifact":
+    def from_dict(cls, data: dict) -> AudioArtifact:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> AudioArtifact:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - file_path (TEXT) -> path (str)
+        - metadata_json (TEXT) -> ignored (not on this model)
+        - provider (VARCHAR, if present) -> provider_type (str)
+        """
+        mapped = dict(row)
+        if "file_path" in mapped and "path" not in mapped:
+            mapped["path"] = mapped.pop("file_path")
+        if "provider" in mapped and "provider_type" not in mapped:
+            mapped["provider_type"] = mapped.pop("provider")
+        # Discard DB-only columns not in this domain model
+        mapped.pop("metadata_json", None)
+        mapped.pop("artifact_type", None)
+        mapped.pop("scene_id", None)
+        mapped.pop("file_size_bytes", None)
+        mapped.pop("mime_type", None)
+        mapped.pop("updated_at", None)
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/model_selection.py
+++ b/packages/creator-domain/models/model_selection.py
@@ -1,1 +1,16 @@
-"""Placeholder for model_selection."""
+from pydantic import BaseModel
+
+
+class ModelSelection(BaseModel):
+    script_model: str | None = None
+    image_model: str | None = None
+    tts_model: str | None = None
+    subtitle_model: str | None = None
+    render_profile: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ModelSelection":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/pipeline_run.py
+++ b/packages/creator-domain/models/pipeline_run.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import json
 from datetime import datetime
 from typing import Literal
 
@@ -22,8 +25,25 @@ class PipelineRun(BaseModel):
     updated_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "PipelineRun":
+    def from_dict(cls, data: dict) -> PipelineRun:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> PipelineRun:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - model_defaults_json (TEXT) -> model_defaults (ModelSelection | None)
+        - metadata_json (TEXT) -> metadata (dict | None)
+        """
+        mapped = dict(row)
+        raw_defaults = mapped.pop("model_defaults_json", None)
+        if raw_defaults is not None:
+            mapped["model_defaults"] = json.loads(raw_defaults)
+        raw_meta = mapped.pop("metadata_json", None)
+        if raw_meta is not None:
+            mapped["metadata"] = json.loads(raw_meta)
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/pipeline_run.py
+++ b/packages/creator-domain/models/pipeline_run.py
@@ -1,1 +1,29 @@
-"""Placeholder for pipeline_run."""
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+from .model_selection import ModelSelection
+
+
+class PipelineRun(BaseModel):
+    id: int
+    project_id: int
+    current_stage: str | None = None
+    status: Literal["pending", "running", "paused", "completed", "failed", "cancelled"] = "pending"
+    review_stage: str | None = None
+    restart_from: str | None = None
+    model_defaults: ModelSelection | None = None
+    metadata: dict | None = None
+    style_preset: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PipelineRun":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/project.py
+++ b/packages/creator-domain/models/project.py
@@ -1,1 +1,23 @@
-"""Placeholder for project."""
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class Project(BaseModel):
+    id: int
+    title: str | None = None
+    source_type: Literal["idea", "markdown", "url"] = "idea"
+    idea_brief: str | None = None
+    markdown_source: str | None = None
+    url_source: str | None = None
+    status: Literal["draft", "active", "completed", "archived"] = "draft"
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Project":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/script_draft.py
+++ b/packages/creator-domain/models/script_draft.py
@@ -10,7 +10,7 @@ class VisualOverride(BaseModel):
 
 
 class ScriptSection(BaseModel):
-    id: str
+    section_id: str
     type: str
     text: str
     display_text: str | None = None

--- a/packages/creator-domain/models/script_draft.py
+++ b/packages/creator-domain/models/script_draft.py
@@ -1,1 +1,42 @@
-"""Placeholder for script_draft."""
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class VisualOverride(BaseModel):
+    type: Literal["prompt", "image_url", "none"]
+    value: str | None = None
+
+
+class ScriptSection(BaseModel):
+    id: str
+    type: str
+    text: str
+    display_text: str | None = None
+    speaker: str | None = "host"
+    duration: float | None = None
+    turn_kind: str | None = None
+    visual_override: VisualOverride | None = None
+
+
+class ScriptDraft(BaseModel):
+    id: int
+    run_id: int
+    source_type: Literal[
+        "generated_by_model",
+        "pasted_markdown",
+        "uploaded_markdown",
+        "edited_manually",
+    ]
+    markdown_content: str | None = None
+    structured_script: list[ScriptSection] | None = None
+    version: int = 1
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ScriptDraft":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/stage.py
+++ b/packages/creator-domain/models/stage.py
@@ -1,15 +1,11 @@
-from enum import Enum
-from typing import TYPE_CHECKING
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
 
-if TYPE_CHECKING:
-    class StrEnum(Enum):
-        ...
-else:
-    try:
-        from enum import StrEnum
-    except ImportError:
-        StrEnum = Enum("StrEnum", {}, type=str)
-
+    class StrEnum(str, Enum):  # noqa: UP042
+        def __str__(self) -> str:
+            return self.value
 
 class RunStage(StrEnum):
     IDEA_READY = "IDEA_READY"

--- a/packages/creator-domain/models/stage.py
+++ b/packages/creator-domain/models/stage.py
@@ -1,0 +1,80 @@
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    class StrEnum(Enum):
+        ...
+else:
+    try:
+        from enum import StrEnum
+    except ImportError:
+        StrEnum = Enum("StrEnum", {}, type=str)
+
+
+class RunStage(StrEnum):
+    IDEA_READY = "IDEA_READY"
+    SCRIPT_GENERATING = "SCRIPT_GENERATING"
+    SCRIPT_REVIEW = "SCRIPT_REVIEW"
+    VISUAL_PLAN_GENERATING = "VISUAL_PLAN_GENERATING"
+    VISUAL_PLAN_REVIEW = "VISUAL_PLAN_REVIEW"
+    VISUAL_ASSET_GENERATING = "VISUAL_ASSET_GENERATING"
+    VISUAL_ASSET_REVIEW = "VISUAL_ASSET_REVIEW"
+    AUDIO_GENERATING = "AUDIO_GENERATING"
+    SUBTITLE_GENERATING = "SUBTITLE_GENERATING"
+    RENDER_GENERATING = "RENDER_GENERATING"
+    FINAL_REVIEW = "FINAL_REVIEW"
+    PUBLISHED = "PUBLISHED"
+    FAILED = "FAILED"
+
+
+TRANSITIONS: dict[RunStage, tuple[RunStage, ...]] = {
+    RunStage.IDEA_READY: (RunStage.SCRIPT_GENERATING,),
+    RunStage.SCRIPT_GENERATING: (RunStage.SCRIPT_REVIEW, RunStage.FAILED),
+    RunStage.SCRIPT_REVIEW: (RunStage.VISUAL_PLAN_GENERATING, RunStage.SCRIPT_GENERATING),
+    RunStage.VISUAL_PLAN_GENERATING: (RunStage.VISUAL_PLAN_REVIEW, RunStage.FAILED),
+    RunStage.VISUAL_PLAN_REVIEW: (RunStage.VISUAL_ASSET_GENERATING, RunStage.VISUAL_PLAN_GENERATING),
+    RunStage.VISUAL_ASSET_GENERATING: (RunStage.VISUAL_ASSET_REVIEW, RunStage.FAILED),
+    RunStage.VISUAL_ASSET_REVIEW: (RunStage.AUDIO_GENERATING, RunStage.VISUAL_ASSET_GENERATING),
+    RunStage.AUDIO_GENERATING: (RunStage.SUBTITLE_GENERATING, RunStage.FAILED),
+    RunStage.SUBTITLE_GENERATING: (RunStage.RENDER_GENERATING, RunStage.FAILED),
+    RunStage.RENDER_GENERATING: (RunStage.FINAL_REVIEW, RunStage.FAILED),
+    RunStage.FINAL_REVIEW: (RunStage.PUBLISHED, RunStage.RENDER_GENERATING),
+    RunStage.PUBLISHED: (),
+    RunStage.FAILED: (),
+}
+
+
+REVIEW_STAGES: frozenset[RunStage] = frozenset(
+    {
+        RunStage.SCRIPT_REVIEW,
+        RunStage.VISUAL_PLAN_REVIEW,
+        RunStage.VISUAL_ASSET_REVIEW,
+        RunStage.FINAL_REVIEW,
+    }
+)
+
+GENERATING_STAGES: frozenset[RunStage] = frozenset(
+    {
+        RunStage.SCRIPT_GENERATING,
+        RunStage.VISUAL_PLAN_GENERATING,
+        RunStage.VISUAL_ASSET_GENERATING,
+        RunStage.AUDIO_GENERATING,
+        RunStage.SUBTITLE_GENERATING,
+        RunStage.RENDER_GENERATING,
+    }
+)
+
+
+def can_transition(current: RunStage, target: RunStage) -> bool:
+    return target in TRANSITIONS[current]
+
+
+def next_stages(current: RunStage) -> list[RunStage]:
+    return list(TRANSITIONS[current])
+
+
+def advance(current: RunStage) -> RunStage:
+    candidates = [stage for stage in TRANSITIONS[current] if stage is not RunStage.FAILED]
+    if len(candidates) != 1:
+        raise ValueError(f"Stage {current} does not have exactly one non-failed transition")
+    return candidates[0]

--- a/packages/creator-domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/models/subtitle_artifact.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Literal
 
@@ -12,8 +14,27 @@ class SubtitleArtifact(BaseModel):
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "SubtitleArtifact":
+    def from_dict(cls, data: dict) -> SubtitleArtifact:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> SubtitleArtifact:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - file_path (TEXT) -> path (str)
+        """
+        mapped = dict(row)
+        if "file_path" in mapped and "path" not in mapped:
+            mapped["path"] = mapped.pop("file_path")
+        # Discard DB-only columns not in this domain model
+        mapped.pop("metadata_json", None)
+        mapped.pop("artifact_type", None)
+        mapped.pop("scene_id", None)
+        mapped.pop("file_size_bytes", None)
+        mapped.pop("mime_type", None)
+        mapped.pop("updated_at", None)
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/models/subtitle_artifact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Literal
 
@@ -19,21 +20,23 @@ class SubtitleArtifact(BaseModel):
 
     @classmethod
     def from_row(cls, row: dict) -> SubtitleArtifact:
-        """Construct from a DB row dict, mapping column names to domain fields.
+        """Construct from a creator_artifacts DB row.
 
-        Handles:
-        - file_path (TEXT) -> path (str)
+        The creator_artifacts table stores artifact-specific fields in
+        metadata_json.  This method extracts format from that JSON column
+        and maps file_path -> path.
         """
         mapped = dict(row)
         if "file_path" in mapped and "path" not in mapped:
             mapped["path"] = mapped.pop("file_path")
+        # Extract domain fields from metadata_json
+        raw_meta = mapped.pop("metadata_json", None)
+        if raw_meta is not None:
+            meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+            mapped.setdefault("format", meta.get("format"))
         # Discard DB-only columns not in this domain model
-        mapped.pop("metadata_json", None)
-        mapped.pop("artifact_type", None)
-        mapped.pop("scene_id", None)
-        mapped.pop("file_size_bytes", None)
-        mapped.pop("mime_type", None)
-        mapped.pop("updated_at", None)
+        for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
+            mapped.pop(key, None)
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/models/subtitle_artifact.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class SubtitleArtifact(BaseModel):
+    id: int
+    run_id: int
+    path: str
+    format: Literal["srt", "vtt"] = "srt"
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SubtitleArtifact":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/video_artifact.py
+++ b/packages/creator-domain/models/video_artifact.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -11,8 +13,27 @@ class VideoArtifact(BaseModel):
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "VideoArtifact":
+    def from_dict(cls, data: dict) -> VideoArtifact:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> VideoArtifact:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - file_path (TEXT) -> path (str)
+        """
+        mapped = dict(row)
+        if "file_path" in mapped and "path" not in mapped:
+            mapped["path"] = mapped.pop("file_path")
+        # Discard DB-only columns not in this domain model
+        mapped.pop("metadata_json", None)
+        mapped.pop("artifact_type", None)
+        mapped.pop("scene_id", None)
+        mapped.pop("file_size_bytes", None)
+        mapped.pop("mime_type", None)
+        mapped.pop("updated_at", None)
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/video_artifact.py
+++ b/packages/creator-domain/models/video_artifact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -18,21 +19,23 @@ class VideoArtifact(BaseModel):
 
     @classmethod
     def from_row(cls, row: dict) -> VideoArtifact:
-        """Construct from a DB row dict, mapping column names to domain fields.
+        """Construct from a creator_artifacts DB row.
 
-        Handles:
-        - file_path (TEXT) -> path (str)
+        The creator_artifacts table stores artifact-specific fields in
+        metadata_json.  This method extracts render_profile from that JSON
+        column and maps file_path -> path.
         """
         mapped = dict(row)
         if "file_path" in mapped and "path" not in mapped:
             mapped["path"] = mapped.pop("file_path")
+        # Extract domain fields from metadata_json
+        raw_meta = mapped.pop("metadata_json", None)
+        if raw_meta is not None:
+            meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+            mapped.setdefault("render_profile", meta.get("render_profile"))
         # Discard DB-only columns not in this domain model
-        mapped.pop("metadata_json", None)
-        mapped.pop("artifact_type", None)
-        mapped.pop("scene_id", None)
-        mapped.pop("file_size_bytes", None)
-        mapped.pop("mime_type", None)
-        mapped.pop("updated_at", None)
+        for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
+            mapped.pop(key, None)
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/models/video_artifact.py
+++ b/packages/creator-domain/models/video_artifact.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class VideoArtifact(BaseModel):
+    id: int
+    run_id: int
+    path: str
+    render_profile: str | None = None
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "VideoArtifact":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/visual_asset.py
+++ b/packages/creator-domain/models/visual_asset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -16,8 +18,20 @@ class VisualAsset(BaseModel):
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "VisualAsset":
+    def from_dict(cls, data: dict) -> VisualAsset:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> VisualAsset:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - provider (VARCHAR) -> provider_type (str)
+        """
+        mapped = dict(row)
+        if "provider" in mapped and "provider_type" not in mapped:
+            mapped["provider_type"] = mapped.pop("provider")
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/visual_plan.py
+++ b/packages/creator-domain/models/visual_plan.py
@@ -1,1 +1,35 @@
-"""Placeholder for visual_plan."""
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class VisualScene(BaseModel):
+    scene_id: str
+    section_id: str
+    scene_index: int
+    section_type: str
+    original_text: str
+    prompt: str
+    prompt_edited: bool = False
+    prompt_source: Literal["auto_generated", "user_edited", "model_suggested"] = "auto_generated"
+    style_tags: list[str] = Field(default_factory=list)
+    mood: str | None = None
+    composition: str | None = None
+    generation_status: Literal["pending", "generating", "completed", "failed"] = "pending"
+    latest_asset_id: int | None = None
+
+
+class VisualPlan(BaseModel):
+    id: int
+    run_id: int
+    version: int = 1
+    scenes: list[VisualScene]
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "VisualPlan":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/tests/test_stage.py
+++ b/packages/creator-domain/tests/test_stage.py
@@ -87,3 +87,9 @@ def test_stage_group_sets() -> None:
         RunStage.SUBTITLE_GENERATING,
         RunStage.RENDER_GENERATING,
     } == GENERATING_STAGES
+
+
+def test_run_stage_str_returns_value() -> None:
+    """Regression: str(RunStage.X) must return the raw value, not 'RunStage.X'."""
+    for stage in RunStage:
+        assert str(stage) == stage.value

--- a/packages/creator-domain/tests/test_stage.py
+++ b/packages/creator-domain/tests/test_stage.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models import (  # noqa: E402
+    GENERATING_STAGES,
+    REVIEW_STAGES,
+    TRANSITIONS,
+    RunStage,
+    advance,
+    can_transition,
+    next_stages,
+)
+
+
+def test_all_valid_transitions_are_allowed() -> None:
+    for current, targets in TRANSITIONS.items():
+        for target in targets:
+            assert can_transition(current, target)
+
+
+def test_invalid_transition_returns_false() -> None:
+    assert not can_transition(RunStage.IDEA_READY, RunStage.PUBLISHED)
+    assert not can_transition(RunStage.PUBLISHED, RunStage.FAILED)
+    assert not can_transition(RunStage.FAILED, RunStage.IDEA_READY)
+
+
+def test_advance_raises_for_stages_without_single_non_failed_path() -> None:
+    with pytest.raises(ValueError):
+        advance(RunStage.SCRIPT_REVIEW)
+
+    with pytest.raises(ValueError):
+        advance(RunStage.FINAL_REVIEW)
+
+    with pytest.raises(ValueError):
+        advance(RunStage.PUBLISHED)
+
+    with pytest.raises(ValueError):
+        advance(RunStage.FAILED)
+
+
+def test_happy_path_sequence_idea_ready_to_published() -> None:
+    happy_path = [
+        RunStage.IDEA_READY,
+        RunStage.SCRIPT_GENERATING,
+        RunStage.SCRIPT_REVIEW,
+        RunStage.VISUAL_PLAN_GENERATING,
+        RunStage.VISUAL_PLAN_REVIEW,
+        RunStage.VISUAL_ASSET_GENERATING,
+        RunStage.VISUAL_ASSET_REVIEW,
+        RunStage.AUDIO_GENERATING,
+        RunStage.SUBTITLE_GENERATING,
+        RunStage.RENDER_GENERATING,
+        RunStage.FINAL_REVIEW,
+        RunStage.PUBLISHED,
+    ]
+
+    for current, nxt in zip(happy_path, happy_path[1:], strict=False):
+        assert can_transition(current, nxt)
+
+
+def test_failed_is_reachable_from_all_generating_stages() -> None:
+    for stage in GENERATING_STAGES:
+        assert RunStage.FAILED in next_stages(stage)
+
+
+def test_next_stages_match_transition_map() -> None:
+    for stage in RunStage:
+        assert next_stages(stage) == list(TRANSITIONS[stage])
+
+
+def test_stage_group_sets() -> None:
+    assert {
+        RunStage.SCRIPT_REVIEW,
+        RunStage.VISUAL_PLAN_REVIEW,
+        RunStage.VISUAL_ASSET_REVIEW,
+        RunStage.FINAL_REVIEW,
+    } == REVIEW_STAGES
+    assert {
+        RunStage.SCRIPT_GENERATING,
+        RunStage.VISUAL_PLAN_GENERATING,
+        RunStage.VISUAL_ASSET_GENERATING,
+        RunStage.AUDIO_GENERATING,
+        RunStage.SUBTITLE_GENERATING,
+        RunStage.RENDER_GENERATING,
+    } == GENERATING_STAGES

--- a/packages/creator-provider/__init__.py
+++ b/packages/creator-provider/__init__.py
@@ -1,4 +1,5 @@
 from .base import AudioResult, ImageProvider, ImageResult, LLMProvider, STTProvider, SubtitleResult, TTSProvider
+from .gpu_lock import acquire_gpu_lock, gpu_lock_context, release_gpu_lock
 from .registry import ModelCatalogEntry, ProviderCategory, ProviderRegistry
 
 __all__ = [
@@ -9,6 +10,9 @@ __all__ = [
     "ImageResult",
     "AudioResult",
     "SubtitleResult",
+    "acquire_gpu_lock",
+    "release_gpu_lock",
+    "gpu_lock_context",
     "ProviderRegistry",
     "ProviderCategory",
     "ModelCatalogEntry",

--- a/packages/creator-provider/gpu_lock.py
+++ b/packages/creator-provider/gpu_lock.py
@@ -1,0 +1,70 @@
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+
+GPU_LOCK_KEY = os.getenv("GPU_LOCK_KEY", "gpu:lock")
+
+try:
+    GPU_LOCK_TIMEOUT_SECONDS = int(os.getenv("GPU_LOCK_TIMEOUT_SECONDS", "600"))
+except ValueError:
+    GPU_LOCK_TIMEOUT_SECONDS = 600
+
+
+RELEASE_LOCK_SCRIPT = """
+local current = redis.call('GET', KEYS[1])
+if not current then
+    return 0
+end
+
+if string.sub(current, 1, string.len(ARGV[1])) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+
+return 0
+"""
+
+
+def acquire_gpu_lock(
+    redis_client: Any,
+    task_id: str,
+    timeout: int = GPU_LOCK_TIMEOUT_SECONDS,
+    retry_interval: float = 2.0,
+    max_wait: float = 300.0,
+) -> bool:
+    start_time = time.monotonic()
+    backoff = retry_interval
+
+    while True:
+        lock_value = f"{task_id}:{int(time.time())}"
+        acquired = redis_client.set(GPU_LOCK_KEY, lock_value, nx=True, ex=timeout)
+        if acquired:
+            return True
+
+        elapsed = time.monotonic() - start_time
+        if elapsed >= max_wait:
+            raise TimeoutError(f"Timed out acquiring GPU lock for task '{task_id}'")
+
+        sleep_for = min(backoff, max_wait - elapsed)
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+        backoff = min(backoff * 2, 30.0)
+
+
+def release_gpu_lock(redis_client: Any, task_id: str) -> bool:
+    released = redis_client.eval(RELEASE_LOCK_SCRIPT, 1, GPU_LOCK_KEY, f"{task_id}:")
+    return bool(released)
+
+
+@asynccontextmanager
+async def gpu_lock_context(
+    redis_client: Any,
+    task_id: str,
+    timeout: int = GPU_LOCK_TIMEOUT_SECONDS,
+) -> AsyncIterator[None]:
+    acquire_gpu_lock(redis_client, task_id, timeout=timeout)
+    try:
+        yield
+    finally:
+        release_gpu_lock(redis_client, task_id)

--- a/packages/creator-provider/tests/test_gpu_lock.py
+++ b/packages/creator-provider/tests/test_gpu_lock.py
@@ -1,0 +1,88 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from gpu_lock import GPU_LOCK_KEY, RELEASE_LOCK_SCRIPT, acquire_gpu_lock, gpu_lock_context, release_gpu_lock
+
+
+class GpuLockTests(unittest.TestCase):
+    def test_acquire_succeeds_on_first_try(self) -> None:
+        redis_client = Mock()
+        redis_client.set.return_value = True
+
+        acquired = acquire_gpu_lock(redis_client, "task-1", timeout=42)
+
+        self.assertTrue(acquired)
+        redis_client.set.assert_called_once()
+        call_args = redis_client.set.call_args
+        self.assertEqual(call_args.kwargs["nx"], True)
+        self.assertEqual(call_args.kwargs["ex"], 42)
+        self.assertEqual(call_args.args[0], GPU_LOCK_KEY)
+        self.assertTrue(call_args.args[1].startswith("task-1:"))
+
+    def test_acquire_retries_when_lock_is_held(self) -> None:
+        redis_client = Mock()
+        redis_client.set.side_effect = [False, False, True]
+
+        with patch("gpu_lock.time.sleep") as sleep_mock:
+            acquired = acquire_gpu_lock(redis_client, "task-2", retry_interval=0.01, max_wait=1.0)
+
+        self.assertTrue(acquired)
+        self.assertEqual(redis_client.set.call_count, 3)
+        self.assertEqual(sleep_mock.call_count, 2)
+
+    def test_release_succeeds_for_holder(self) -> None:
+        redis_client = Mock()
+        redis_client.eval.return_value = 1
+
+        released = release_gpu_lock(redis_client, "task-3")
+
+        self.assertTrue(released)
+        redis_client.eval.assert_called_once_with(RELEASE_LOCK_SCRIPT, 1, GPU_LOCK_KEY, "task-3:")
+
+    def test_release_returns_false_when_not_holder(self) -> None:
+        redis_client = Mock()
+        redis_client.eval.return_value = 0
+
+        released = release_gpu_lock(redis_client, "task-4")
+
+        self.assertFalse(released)
+
+    def test_acquire_raises_timeout_after_max_wait(self) -> None:
+        redis_client = Mock()
+        redis_client.set.return_value = False
+
+        with patch("gpu_lock.time.monotonic", side_effect=[0.0, 0.5, 1.1]), patch("gpu_lock.time.sleep"):
+            with self.assertRaises(TimeoutError):
+                acquire_gpu_lock(redis_client, "task-timeout", retry_interval=0.01, max_wait=1.0)
+
+    def test_double_release_safety(self) -> None:
+        redis_client = Mock()
+        redis_client.eval.side_effect = [1, 0]
+
+        first_release = release_gpu_lock(redis_client, "task-5")
+        second_release = release_gpu_lock(redis_client, "task-5")
+
+        self.assertTrue(first_release)
+        self.assertFalse(second_release)
+
+    def test_context_manager_enters_and_exits_cleanly(self) -> None:
+        redis_client = Mock()
+        redis_client.set.return_value = True
+        redis_client.eval.return_value = 1
+
+        async def _run() -> None:
+            async with gpu_lock_context(redis_client, "task-ctx", timeout=30):
+                return
+
+        asyncio.run(_run())
+
+        redis_client.set.assert_called_once()
+        redis_client.eval.assert_called_once_with(RELEASE_LOCK_SCRIPT, 1, GPU_LOCK_KEY, "task-ctx:")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/creator-service/ffmpeg_service.py
+++ b/packages/creator-service/ffmpeg_service.py
@@ -1,0 +1,76 @@
+import subprocess
+from pathlib import Path
+from dataclasses import dataclass
+
+from .render_profile import RenderProfile
+
+
+@dataclass
+class RenderInput:
+    image_paths: list[Path]       # ordered scene images
+    audio_path: Path | None       # narration audio
+    subtitle_path: Path | None    # SRT subtitle file
+    scene_durations: list[float]  # duration per scene in seconds
+
+
+class FFmpegService:
+    def __init__(self, profile: RenderProfile | None = None):
+        self.profile = profile or RenderProfile.default()
+
+    def build_command(self, input_data: RenderInput, output_path: Path) -> list[str]:
+        """Build FFmpeg command for rendering video from scenes."""
+        # This builds the actual FFmpeg command
+        # Ken Burns effect: use zoompan filter
+        # Subtitle burn-in: use subtitles filter
+        cmd = ["ffmpeg", "-y"]  # overwrite output
+        
+        # Build filter complex for image sequence with ken burns
+        filter_parts = []
+        for i, (img, dur) in enumerate(zip(input_data.image_paths, input_data.scene_durations)):
+            cmd.extend(["-loop", "1", "-t", str(dur), "-i", str(img)])
+            # Scale + Ken Burns zoom
+            filter_parts.append(
+                f"[{i}:v]scale={self.profile.width}:{self.profile.height}:force_original_aspect_ratio=decrease,"
+                f"pad={self.profile.width}:{self.profile.height}:(ow-iw)/2:(oh-ih)/2,"
+                f"setsar=1[v{i}]"
+            )
+        
+        # Concat all scenes
+        concat_inputs = "".join(f"[v{i}]" for i in range(len(input_data.image_paths)))
+        filter_parts.append(f"{concat_inputs}concat=n={len(input_data.image_paths)}:v=1:a=0[vout]")
+        
+        cmd.extend(["-filter_complex", ";".join(filter_parts)])
+        
+        # Add audio if present
+        if input_data.audio_path:
+            cmd.extend(["-i", str(input_data.audio_path)])
+            cmd.extend(["-map", "[vout]", "-map", f"{len(input_data.image_paths)}:a"])
+        else:
+            cmd.extend(["-map", "[vout]"])
+        
+        # Codec settings
+        cmd.extend([
+            "-c:v", self.profile.video_codec.value,
+            "-crf", str(self.profile.crf),
+            "-preset", self.profile.preset,
+            "-r", str(self.profile.fps),
+        ])
+        
+        if input_data.audio_path:
+            cmd.extend(["-c:a", self.profile.audio_codec.value])
+        
+        # Subtitle burn-in
+        if self.profile.burn_subtitles and input_data.subtitle_path:
+            cmd.extend(["-vf", f"subtitles={input_data.subtitle_path}:force_style='FontSize={self.profile.subtitle_font_size}'"])
+        
+        cmd.append(str(output_path))
+        return cmd
+
+    def render(self, input_data: RenderInput, output_path: Path) -> Path:
+        """Execute FFmpeg render. Returns output path on success."""
+        cmd = self.build_command(input_data, output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        if result.returncode != 0:
+            raise RuntimeError(f"FFmpeg render failed: {result.stderr}")
+        return output_path

--- a/packages/creator-service/logging_config.py
+++ b/packages/creator-service/logging_config.py
@@ -1,0 +1,95 @@
+"""Shared structured JSON logging configuration."""
+
+import json
+import logging
+from typing import Any
+
+
+class JsonFormatter(logging.Formatter):
+    """JSON formatter for structured logging."""
+
+    def __init__(self, service_name: str) -> None:
+        """Initialize JSON formatter.
+        
+        Args:
+            service_name: Name of the service using this logger
+        """
+        super().__init__()
+        self.service_name = service_name
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format log record as JSON.
+        
+        Args:
+            record: Log record to format
+            
+        Returns:
+            JSON-formatted log string
+        """
+        log_obj: dict[str, Any] = {
+            "timestamp": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "service": self.service_name,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Add exception info if present
+        if record.exc_info:
+            log_obj["exc_info"] = self.formatException(record.exc_info)
+
+        # Add extra fields
+        if hasattr(record, "__dict__"):
+            for key, value in record.__dict__.items():
+                if key not in [
+                    "name",
+                    "msg",
+                    "args",
+                    "created",
+                    "filename",
+                    "funcName",
+                    "levelname",
+                    "levelno",
+                    "lineno",
+                    "module",
+                    "msecs",
+                    "message",
+                    "pathname",
+                    "process",
+                    "processName",
+                    "relativeCreated",
+                    "thread",
+                    "threadName",
+                    "exc_info",
+                    "exc_text",
+                    "stack_info",
+                ]:
+                    log_obj[key] = value
+
+        return json.dumps(log_obj, default=str)
+
+
+def setup_json_logging(service_name: str, level: str = "INFO") -> None:
+    """Configure root logger with JSON formatting.
+    
+    Args:
+        service_name: Name of the service
+        level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    """
+    # Remove existing handlers
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+
+    # Create console handler with JSON formatter
+    handler = logging.StreamHandler()
+    formatter = JsonFormatter(service_name=service_name)
+    handler.setFormatter(formatter)
+
+    # Configure root logger
+    root_logger.addHandler(handler)
+    root_logger.setLevel(getattr(logging, level))
+
+    # Suppress noisy loggers
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("asyncio").setLevel(logging.WARNING)

--- a/packages/creator-service/markdown_parser.py
+++ b/packages/creator-service/markdown_parser.py
@@ -1,0 +1,88 @@
+import re
+
+try:
+    from creator_domain.models import ScriptSection  # pyright: ignore[reportMissingImports]
+except ImportError:
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
+    from models import ScriptSection  # pyright: ignore[reportMissingImports]
+
+
+_LEVEL_TWO_HEADING_RE = re.compile(r"^\s{0,3}##(?!#)\s*(.*?)\s*$")
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _normalize_section_type(raw_heading: str) -> str:
+    normalized = _NON_ALNUM_RE.sub("-", raw_heading.strip().lower()).strip("-")
+    return normalized or "body"
+
+
+def _join_and_trim(lines: list[str]) -> str:
+    return "\n".join(lines).strip()
+
+
+def _extract_sections(markdown: str) -> list[tuple[str, str]]:
+    lines = markdown.splitlines()
+    extracted: list[tuple[str, str]] = []
+    pending_lines: list[str] = []
+    current_type: str | None = None
+
+    for line in lines:
+        heading_match = _LEVEL_TWO_HEADING_RE.match(line)
+        if heading_match:
+            if current_type is None:
+                prelude = _join_and_trim(pending_lines)
+                if prelude:
+                    extracted.append(("body", prelude))
+            else:
+                extracted.append((current_type, _join_and_trim(pending_lines)))
+
+            current_type = _normalize_section_type(heading_match.group(1))
+            pending_lines = []
+            continue
+
+        pending_lines.append(line)
+
+    if current_type is None:
+        body_text = _join_and_trim(pending_lines)
+        return [("body", body_text)] if body_text else []
+
+    extracted.append((current_type, _join_and_trim(pending_lines)))
+    return extracted
+
+
+def parse_markdown(
+    markdown: str, existing_sections: list[ScriptSection] | None = None
+) -> list[ScriptSection]:
+    if not markdown or not markdown.strip():
+        return []
+
+    extracted_sections = _extract_sections(markdown)
+    existing_id_by_key: dict[tuple[str, int], str] = {}
+
+    if existing_sections:
+        for position, section in enumerate(existing_sections, start=1):
+            key = (section.type, position)
+            if key not in existing_id_by_key:
+                existing_id_by_key[key] = section.section_id
+
+    parsed_sections: list[ScriptSection] = []
+    for position, (section_type, text) in enumerate(extracted_sections, start=1):
+        key = (section_type, position)
+        section_id = existing_id_by_key.get(key, f"{section_type}-{position}")
+        parsed_sections.append(
+            ScriptSection(
+                section_id=section_id,
+                type=section_type,
+                text=text,
+                display_text=text,
+                speaker="host",
+                duration=None,
+                turn_kind=None,
+                visual_override=None,
+            )
+        )
+
+    return parsed_sections

--- a/packages/creator-service/model_catalog_service.py
+++ b/packages/creator-service/model_catalog_service.py
@@ -34,6 +34,19 @@ class ModelCatalogService:
         ModelStatus.UNKNOWN: "unknown",
     }
 
+    # Explicit labels for known model keys.  New models that lack an entry
+    # fall through to the generic _format_label_fallback() formatter.
+    _KNOWN_LABELS: dict[str, str] = {
+        "qwen3-4b": "Qwen3 4B",
+        "qwen3-8b": "Qwen3 8B",
+        "sd15": "Stable Diffusion 1.5",
+        "sd-2.1": "Stable Diffusion 2.1",
+        "qwen-tts": "Qwen TTS",
+        "whisper-medium": "Whisper Medium",
+        "gpt-4o-mini": "GPT-4o Mini",
+        "llama-3.1-8b": "Llama 3.1 8B",
+    }
+
     def __init__(self, registry: Any, health_service: ModelHealthService):
         self.registry = registry
         self.health_service = health_service
@@ -79,7 +92,7 @@ class ModelCatalogService:
             health_result = await self.health_service.check_model(health_key)
             providers.append(
                 {
-                    "name": entry.provider_type,
+                    "name": self._health_key(entry),
                     "endpoint": entry.endpoint,
                     "healthy": health_result.status == ModelStatus.HEALTHY,
                     "loaded_model": None,
@@ -107,22 +120,25 @@ class ModelCatalogService:
             "status": self._HEALTH_TO_CATALOG_STATUS[health_result.status],
         }
 
-    @staticmethod
-    def _format_label(model_key: str, is_local: bool) -> str:
-        words = []
-        for token in model_key.replace("_", "-").split("-"):
-            if not token:
-                continue
-            if token[:-1].isdigit() and token[-1:].isalpha():
-                words.append(f"{token[:-1]}{token[-1:].upper()}")
-            else:
-                words.append(token[:1].upper() + token[1:])
-
+    def _format_label(self, model_key: str, is_local: bool) -> str:
+        known = self._KNOWN_LABELS.get(model_key)
+        base = known if known is not None else self._format_label_fallback(model_key)
         location = "Local" if is_local else "Remote"
-        return f"{' '.join(words)} ({location})"
+        return f"{base} ({location})"
+
+    @staticmethod
+    def _format_label_fallback(model_key: str) -> str:
+        """Best-effort title-case for unknown model keys."""
+        return model_key.replace("-", " ").replace("_", " ").title()
 
     @staticmethod
     def _health_key(entry: Any) -> str:
+        """Derive the ModelHealthService lookup key from a registry entry.
+
+        ModelHealthService is keyed by Docker service hostname (e.g.
+        "ollama", "stable-diffusion"), which matches the hostname portion
+        of the endpoint URL in the registry.
+        """
         parsed = urlparse(entry.endpoint)
         if parsed.hostname:
             return parsed.hostname

--- a/packages/creator-service/model_catalog_service.py
+++ b/packages/creator-service/model_catalog_service.py
@@ -1,1 +1,129 @@
-"""Placeholder for model_catalog_service."""
+"""Model catalog service backed by provider registry and health checks."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+try:
+    from .model_health_service import ModelHealthService, ModelStatus
+except ImportError:
+    from model_health_service import ModelHealthService, ModelStatus
+
+
+class ModelCatalogService:
+    """Expose registry-backed model catalog and provider status."""
+
+    _CATEGORY_TO_REGISTRY_VALUE = {
+        "script": "llm",
+        "image": "image",
+        "tts": "tts",
+        "stt": "stt",
+    }
+
+    _CATEGORY_TO_RESPONSE_KEY = {
+        "llm": "script_models",
+        "image": "image_models",
+        "tts": "tts_models",
+        "stt": "stt_models",
+    }
+
+    _HEALTH_TO_CATALOG_STATUS = {
+        ModelStatus.HEALTHY: "available",
+        ModelStatus.UNHEALTHY: "unavailable",
+        ModelStatus.UNKNOWN: "unknown",
+    }
+
+    def __init__(self, registry: Any, health_service: ModelHealthService):
+        self.registry = registry
+        self.health_service = health_service
+
+    async def list_models(self, category: str | None = None) -> dict[str, list[dict[str, object]]]:
+        """List catalog models grouped by API response category keys."""
+        response: dict[str, list[dict[str, object]]] = {
+            "script_models": [],
+            "image_models": [],
+            "tts_models": [],
+            "stt_models": [],
+        }
+
+        category_value = None
+        if category is not None:
+            category_value = self._CATEGORY_TO_REGISTRY_VALUE.get(category)
+            if category_value is None:
+                raise ValueError(f"Unsupported category '{category}'")
+
+        entries = self.registry.list_models()
+        for entry in entries:
+            entry_category = entry.category.value
+            if category_value is not None and entry_category != category_value:
+                continue
+
+            response_key = self._CATEGORY_TO_RESPONSE_KEY[entry_category]
+            response[response_key].append(await self._catalog_entry(entry))
+
+        return response
+
+    async def get_status(self) -> dict[str, object]:
+        """Return provider-level health and current GPU lock defaults."""
+        providers: list[dict[str, object]] = []
+        seen: set[tuple[str, str]] = set()
+
+        for entry in self.registry.list_models():
+            provider_id = (entry.provider_type, entry.endpoint)
+            if provider_id in seen:
+                continue
+            seen.add(provider_id)
+
+            health_key = self._health_key(entry)
+            health_result = await self.health_service.check_model(health_key)
+            providers.append(
+                {
+                    "name": entry.provider_type,
+                    "endpoint": entry.endpoint,
+                    "healthy": health_result.status == ModelStatus.HEALTHY,
+                    "loaded_model": None,
+                    "gpu_locked": False,
+                }
+            )
+
+        return {
+            "providers": providers,
+            "gpu_lock": {
+                "active": False,
+                "holder": None,
+                "ttl_remaining": None,
+            },
+        }
+
+    async def _catalog_entry(self, entry: Any) -> dict[str, object]:
+        health_result = await self.health_service.check_model(self._health_key(entry))
+        return {
+            "key": entry.model_key,
+            "label": self._format_label(entry.model_key, entry.is_local),
+            "provider_type": entry.provider_type,
+            "is_local": entry.is_local,
+            "requires_gpu": entry.requires_gpu,
+            "status": self._HEALTH_TO_CATALOG_STATUS[health_result.status],
+        }
+
+    @staticmethod
+    def _format_label(model_key: str, is_local: bool) -> str:
+        words = []
+        for token in model_key.replace("_", "-").split("-"):
+            if not token:
+                continue
+            if token[:-1].isdigit() and token[-1:].isalpha():
+                words.append(f"{token[:-1]}{token[-1:].upper()}")
+            else:
+                words.append(token[:1].upper() + token[1:])
+
+        location = "Local" if is_local else "Remote"
+        return f"{' '.join(words)} ({location})"
+
+    @staticmethod
+    def _health_key(entry: Any) -> str:
+        parsed = urlparse(entry.endpoint)
+        if parsed.hostname:
+            return parsed.hostname
+        return entry.provider_type

--- a/packages/creator-service/model_health_service.py
+++ b/packages/creator-service/model_health_service.py
@@ -1,0 +1,84 @@
+"""Model health check service for monitoring model serving containers."""
+
+from dataclasses import dataclass
+from enum import Enum
+import os
+
+
+class ModelStatus(Enum):
+    """Status of a model container."""
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ModelHealthResult:
+    """Result of a model health check."""
+    model_name: str
+    endpoint: str
+    status: ModelStatus
+    response_time_ms: float | None = None
+    error: str | None = None
+
+
+class ModelHealthService:
+    """Check health of model serving containers."""
+    
+    def __init__(self):
+        """Initialize health service with model endpoints from environment variables."""
+        self.endpoints = {
+            "ollama": os.getenv("OLLAMA_BASE_URL", "http://ollama:11434"),
+            "stable-diffusion": os.getenv("STABLE_DIFFUSION_BASE_URL", "http://stable-diffusion:7860"),
+            "tts-qwen3": os.getenv("TTS_QWEN_BASE_URL", "http://tts-qwen3:9880"),
+            "stt-whisper": os.getenv("STT_WHISPER_BASE_URL", "http://stt-whisper:9000"),
+        }
+        self.health_paths = {
+            "ollama": "/api/tags",
+            "stable-diffusion": "/sdapi/v1/options",
+            "tts-qwen3": "/",  # placeholder — update when TTS health endpoint is known
+            "stt-whisper": "/",  # placeholder — update when STT health endpoint is known
+        }
+
+    async def check_model(self, model_name: str) -> ModelHealthResult:
+        """Check health of a single model container.
+        
+        Args:
+            model_name: Name of the model to check
+            
+        Returns:
+            ModelHealthResult with health status and metadata
+        """
+        endpoint = self.endpoints.get(model_name)
+        if not endpoint:
+            return ModelHealthResult(
+                model_name=model_name,
+                endpoint="unknown",
+                status=ModelStatus.UNKNOWN,
+                error="Unknown model"
+            )
+        
+        health_path = self.health_paths.get(model_name, "/")
+        url = f"{endpoint}{health_path}"
+        
+        # TODO: Implement actual HTTP call using httpx
+        # In production: async with httpx.AsyncClient() as client: ...
+        # For now, return placeholder result
+        return ModelHealthResult(
+            model_name=model_name,
+            endpoint=endpoint,
+            status=ModelStatus.UNKNOWN,
+            error="Health check not yet implemented"
+        )
+
+    async def check_all(self) -> list[ModelHealthResult]:
+        """Check health of all model containers.
+        
+        Returns:
+            List of ModelHealthResult for each model container
+        """
+        results = []
+        for name in self.endpoints:
+            result = await self.check_model(name)
+            results.append(result)
+        return results

--- a/packages/creator-service/project_service.py
+++ b/packages/creator-service/project_service.py
@@ -7,41 +7,19 @@ the same async service-facing interface.
 
 from __future__ import annotations
 
-import importlib
-import sys
+try:
+    from creator_domain.models import Project
+except ImportError:
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
+    from models import Project
+
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import Any, Literal, Protocol
 
-
-def _load_project_model() -> Any:
-    try:
-        return importlib.import_module("models").Project
-    except ModuleNotFoundError:
-        domain_root = Path(__file__).resolve().parents[1] / "creator-domain"
-        if str(domain_root) not in sys.path:
-            sys.path.insert(0, str(domain_root))
-        return importlib.import_module("models").Project
-
-
-if TYPE_CHECKING:
-    from pydantic import BaseModel
-
-    class Project(BaseModel):
-        id: int
-        title: str | None
-        source_type: Literal["idea", "markdown", "url"]
-        idea_brief: str | None
-        markdown_source: str | None
-        url_source: str | None
-        status: Literal["draft", "active", "completed", "archived"]
-        created_at: datetime
-        updated_at: datetime
-else:
-    Project = _load_project_model()
-
-
-LatestRunSummary = dict[str, int | str]
+LatestRunSummary = dict[str, int | str | None]
 
 
 class ProjectStorageBackend(Protocol):
@@ -152,6 +130,14 @@ class ProjectService:
     ) -> Project:
         if source_type not in self._ALLOWED_SOURCE_TYPES:
             raise ValueError(f"Unsupported source_type '{source_type}'")
+
+        # Validate payload matches source_type
+        if source_type == "markdown" and markdown_source is None:
+            raise ValueError("source_type='markdown' requires markdown_source to be provided")
+        if source_type == "url" and url_source is None:
+            raise ValueError("source_type='url' requires url_source to be provided")
+        if source_type == "idea" and idea_brief is None:
+            raise ValueError("source_type='idea' requires idea_brief to be provided")
 
         row = await self.db.insert_project(
             {

--- a/packages/creator-service/project_service.py
+++ b/packages/creator-service/project_service.py
@@ -7,16 +7,16 @@ the same async service-facing interface.
 
 from __future__ import annotations
 
-try:
-    from creator_domain.models import Project
-except ImportError:
-    import sys
-    from pathlib import Path
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
-    from models import Project
+import sys
+from pathlib import Path
+
+_DOMAIN_DIR = str(Path(__file__).resolve().parent.parent / "creator-domain")
+if _DOMAIN_DIR not in sys.path:
+    sys.path.insert(0, _DOMAIN_DIR)
+
+from models.project import Project
 
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Literal, Protocol
 
 LatestRunSummary = dict[str, int | str | None]
@@ -138,6 +138,14 @@ class ProjectService:
             raise ValueError("source_type='url' requires url_source to be provided")
         if source_type == "idea" and idea_brief is None:
             raise ValueError("source_type='idea' requires idea_brief to be provided")
+
+        # Enforce field exclusivity: each source_type should only have its corresponding field
+        if source_type == "idea" and (markdown_source is not None or url_source is not None):
+            raise ValueError("source_type='idea' cannot have markdown_source or url_source set")
+        if source_type == "markdown" and (idea_brief is not None or url_source is not None):
+            raise ValueError("source_type='markdown' cannot have idea_brief or url_source set")
+        if source_type == "url" and (idea_brief is not None or markdown_source is not None):
+            raise ValueError("source_type='url' cannot have idea_brief or markdown_source set")
 
         row = await self.db.insert_project(
             {

--- a/packages/creator-service/project_service.py
+++ b/packages/creator-service/project_service.py
@@ -1,1 +1,190 @@
-"""Placeholder for project_service."""
+"""Project service with a pluggable async storage backend.
+
+The long-term target is an async DB connection/pool (for example, asyncpg).
+Until DB wiring is in place, this module uses an in-memory backend that exposes
+the same async service-facing interface.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+
+def _load_project_model() -> Any:
+    try:
+        return importlib.import_module("models").Project
+    except ModuleNotFoundError:
+        domain_root = Path(__file__).resolve().parents[1] / "creator-domain"
+        if str(domain_root) not in sys.path:
+            sys.path.insert(0, str(domain_root))
+        return importlib.import_module("models").Project
+
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+    class Project(BaseModel):
+        id: int
+        title: str | None
+        source_type: Literal["idea", "markdown", "url"]
+        idea_brief: str | None
+        markdown_source: str | None
+        url_source: str | None
+        status: Literal["draft", "active", "completed", "archived"]
+        created_at: datetime
+        updated_at: datetime
+else:
+    Project = _load_project_model()
+
+
+LatestRunSummary = dict[str, int | str]
+
+
+class ProjectStorageBackend(Protocol):
+    """Abstract async storage interface used by ProjectService."""
+
+    async def insert_project(self, payload: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+    async def fetch_project(self, project_id: int) -> dict[str, Any] | None:
+        ...
+
+    async def list_projects(self, limit: int, offset: int) -> list[dict[str, Any]]:
+        ...
+
+    async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
+        ...
+
+
+class InMemoryProjectStorage:
+    """Temporary async storage backend used before DB integration."""
+
+    def __init__(self) -> None:
+        self._projects: dict[int, dict[str, Any]] = {}
+        self._runs_by_project: dict[int, list[dict[str, Any]]] = {}
+        self._next_project_id = 1
+        self._next_run_id = 1
+
+    async def insert_project(self, payload: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        project_id = self._next_project_id
+        self._next_project_id += 1
+
+        row = {
+            "id": project_id,
+            "title": payload.get("title"),
+            "source_type": payload.get("source_type", "idea"),
+            "idea_brief": payload.get("idea_brief"),
+            "markdown_source": payload.get("markdown_source"),
+            "url_source": payload.get("url_source"),
+            "status": payload.get("status", "draft"),
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._projects[project_id] = row
+        return dict(row)
+
+    async def fetch_project(self, project_id: int) -> dict[str, Any] | None:
+        row = self._projects.get(project_id)
+        if row is None:
+            return None
+        return dict(row)
+
+    async def list_projects(self, limit: int, offset: int) -> list[dict[str, Any]]:
+        ordered = sorted(
+            self._projects.values(),
+            key=lambda row: (row["created_at"], row["id"]),
+            reverse=True,
+        )
+        return [dict(row) for row in ordered[offset : offset + limit]]
+
+    async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
+        runs = self._runs_by_project.get(project_id, [])
+        if not runs:
+            return None
+        latest = max(runs, key=lambda run: run["id"])
+        return {
+            "run_id": latest["id"],
+            "current_stage": latest["current_stage"],
+            "status": latest["status"],
+        }
+
+    async def insert_run(
+        self,
+        project_id: int,
+        current_stage: str | None,
+        status: str,
+    ) -> dict[str, Any]:
+        run_id = self._next_run_id
+        self._next_run_id += 1
+        row = {
+            "id": run_id,
+            "project_id": project_id,
+            "current_stage": current_stage,
+            "status": status,
+            "created_at": datetime.now(timezone.utc),
+        }
+        self._runs_by_project.setdefault(project_id, []).append(row)
+        return dict(row)
+
+
+class ProjectWithLatestRun(Project):
+    latest_run: LatestRunSummary | None = None
+
+
+class ProjectService:
+    _ALLOWED_SOURCE_TYPES = {"idea", "markdown", "url"}
+
+    def __init__(self, db: ProjectStorageBackend | None = None) -> None:
+        self.db = db if db is not None else InMemoryProjectStorage()
+
+    async def create_project(
+        self,
+        title: str,
+        source_type: Literal["idea", "markdown", "url"],
+        idea_brief: str | None = None,
+        markdown_source: str | None = None,
+        url_source: str | None = None,
+    ) -> Project:
+        if source_type not in self._ALLOWED_SOURCE_TYPES:
+            raise ValueError(f"Unsupported source_type '{source_type}'")
+
+        row = await self.db.insert_project(
+            {
+                "title": title,
+                "source_type": source_type,
+                "idea_brief": idea_brief,
+                "markdown_source": markdown_source,
+                "url_source": url_source,
+                "status": "draft",
+            }
+        )
+        return Project.model_validate(row)
+
+    async def get_project(self, project_id: int) -> Project | None:
+        row = await self.db.fetch_project(project_id)
+        if row is None:
+            return None
+
+        latest_run = await self.db.fetch_latest_run_summary(project_id)
+        return ProjectWithLatestRun.model_validate({**row, "latest_run": latest_run})
+
+    async def list_projects(self, limit: int = 20, offset: int = 0) -> list[Project]:
+        if limit < 0:
+            raise ValueError("limit must be >= 0")
+        if offset < 0:
+            raise ValueError("offset must be >= 0")
+
+        rows = await self.db.list_projects(limit=limit, offset=offset)
+        projects: list[Project] = []
+        for row in rows:
+            latest_run = await self.db.fetch_latest_run_summary(row["id"])
+            projects.append(ProjectWithLatestRun.model_validate({**row, "latest_run": latest_run}))
+        return projects
+
+
+project_service = ProjectService()

--- a/packages/creator-service/project_service.py
+++ b/packages/creator-service/project_service.py
@@ -37,6 +37,9 @@ class ProjectStorageBackend(Protocol):
     async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
         ...
 
+    async def count_projects(self) -> int:
+        ...
+
 
 class InMemoryProjectStorage:
     """Temporary async storage backend used before DB integration."""
@@ -79,6 +82,9 @@ class InMemoryProjectStorage:
             reverse=True,
         )
         return [dict(row) for row in ordered[offset : offset + limit]]
+
+    async def count_projects(self) -> int:
+        return len(self._projects)
 
     async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
         runs = self._runs_by_project.get(project_id, [])
@@ -179,6 +185,9 @@ class ProjectService:
             latest_run = await self.db.fetch_latest_run_summary(row["id"])
             projects.append(ProjectWithLatestRun.model_validate({**row, "latest_run": latest_run}))
         return projects
+
+    async def count_projects(self) -> int:
+        return await self.db.count_projects()
 
 
 project_service = ProjectService()

--- a/packages/creator-service/render_profile.py
+++ b/packages/creator-service/render_profile.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Codec(Enum):
+    H264 = "libx264"
+    H265 = "libx265"
+
+
+class AudioCodec(Enum):
+    AAC = "aac"
+    MP3 = "libmp3lame"
+
+
+class TransitionStyle(Enum):
+    CUT = "cut"
+    FADE = "fade"
+    KEN_BURNS = "ken_burns"
+
+
+@dataclass
+class RenderProfile:
+    name: str = "shorts_default"
+    width: int = 1080
+    height: int = 1920  # 9:16 vertical
+    fps: int = 30
+    video_codec: Codec = Codec.H264
+    audio_codec: AudioCodec = AudioCodec.AAC
+    transition_style: TransitionStyle = TransitionStyle.KEN_BURNS
+    min_duration_seconds: int = 15
+    max_duration_seconds: int = 60
+    crf: int = 23  # quality (lower = better, 18-28 typical)
+    preset: str = "medium"  # encoding speed
+    burn_subtitles: bool = True
+    subtitle_font_size: int = 24
+
+    @classmethod
+    def default(cls) -> "RenderProfile":
+        return cls()
+
+    @classmethod
+    def high_quality(cls) -> "RenderProfile":
+        return cls(name="high_quality", crf=18, preset="slow")
+
+    @classmethod
+    def fast_preview(cls) -> "RenderProfile":
+        return cls(name="fast_preview", width=540, height=960, fps=15, crf=28, preset="ultrafast")

--- a/packages/creator-service/run_service.py
+++ b/packages/creator-service/run_service.py
@@ -1,1 +1,143 @@
-"""Placeholder for run_service."""
+"""Run service with in-memory storage backend."""
+
+from __future__ import annotations
+
+import json
+import importlib
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
+domain_models = importlib.import_module("models")
+ModelSelection = domain_models.ModelSelection
+PipelineRun = domain_models.PipelineRun
+RunStage = domain_models.RunStage
+REVIEW_STAGES = domain_models.REVIEW_STAGES
+can_transition = domain_models.can_transition
+
+
+class RunStorageBackend(Protocol):
+    async def create_run(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist a run row and return stored row."""
+        ...
+
+    async def get_run(self, run_id: int) -> dict[str, Any] | None:
+        """Fetch run row by id."""
+        ...
+
+    async def update_run(self, run_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update and return run row by id."""
+        ...
+
+
+class InMemoryRunStorage:
+    def __init__(self) -> None:
+        self._rows: dict[int, dict[str, Any]] = {}
+        self._next_id = 1
+
+    async def create_run(self, row: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        saved = {
+            "id": self._next_id,
+            "created_at": now,
+            "updated_at": now,
+            **row,
+        }
+        self._rows[self._next_id] = saved
+        self._next_id += 1
+        return dict(saved)
+
+    async def get_run(self, run_id: int) -> dict[str, Any] | None:
+        row = self._rows.get(run_id)
+        return dict(row) if row is not None else None
+
+    async def update_run(self, run_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        row = self._rows.get(run_id)
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        row.update(updates)
+        row["updated_at"] = datetime.now(timezone.utc)
+        self._rows[run_id] = row
+        return dict(row)
+
+
+class RunService:
+    def __init__(self, storage: RunStorageBackend):
+        self.storage = storage
+
+    async def create_run(
+        self,
+        project_id: int,
+        model_defaults: dict[str, Any] | Any | None,
+        style_preset: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> PipelineRun:
+        model_defaults_payload: str | None = None
+        if model_defaults is not None:
+            model_dump = getattr(model_defaults, "model_dump", None)
+            if callable(model_dump):
+                model_defaults_payload = json.dumps(model_dump())
+            else:
+                model_defaults_payload = json.dumps(model_defaults)
+
+        metadata_payload: str | None = None
+        if metadata is not None:
+            metadata_payload = json.dumps(metadata)
+
+        row = await self.storage.create_run(
+            {
+                "project_id": project_id,
+                "current_stage": RunStage.IDEA_READY.value,
+                "status": "pending",
+                "review_stage": None,
+                "restart_from": None,
+                "model_defaults_json": model_defaults_payload,
+                "metadata_json": metadata_payload,
+                "style_preset": style_preset,
+                "started_at": None,
+                "finished_at": None,
+            }
+        )
+        return PipelineRun.from_row(row)
+
+    async def get_run(self, run_id: int) -> PipelineRun | None:
+        row = await self.storage.get_run(run_id)
+        if row is None:
+            return None
+        return PipelineRun.from_row(row)
+
+    async def restart_run(self, run_id: int, from_stage: str) -> PipelineRun:
+        run = await self.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        try:
+            target_stage = RunStage(from_stage)
+        except ValueError as exc:
+            raise ValueError(f"Invalid stage '{from_stage}'") from exc
+
+        if run.current_stage is None:
+            raise ValueError(f"Run {run_id} has no current stage")
+
+        try:
+            current_stage = RunStage(run.current_stage)
+        except ValueError as exc:
+            raise ValueError(f"Invalid current stage '{run.current_stage}' for run {run_id}") from exc
+
+        if not can_transition(current_stage, target_stage) and target_stage not in REVIEW_STAGES:
+            raise ValueError(f"Cannot restart run {run_id} from {current_stage.value} to {target_stage.value}")
+
+        row = await self.storage.update_run(
+            run_id,
+            {
+                "restart_from": target_stage.value,
+                "current_stage": target_stage.value,
+            },
+        )
+        return PipelineRun.from_row(row)
+
+
+run_service = RunService(InMemoryRunStorage())

--- a/packages/creator-service/run_service.py
+++ b/packages/creator-service/run_service.py
@@ -31,6 +31,18 @@ class RunStorageBackend(Protocol):
         """Update and return run row by id."""
         ...
 
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, Any],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Atomically update run only if current_stage is in expected_stages.
+
+        Returns (True, updated_row) on success, (False, current_row) if stage
+        doesn't match, or (False, None) if run not found.
+        """
+        ...
 
 class InMemoryRunStorage:
     def __init__(self) -> None:
@@ -63,6 +75,21 @@ class InMemoryRunStorage:
         self._rows[run_id] = row
         return dict(row)
 
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, Any],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        row = self._rows.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        row.update(updates)
+        row["updated_at"] = datetime.now(timezone.utc)
+        self._rows[run_id] = row
+        return True, dict(row)
 
 class RunService:
     def __init__(self, storage: RunStorageBackend):

--- a/packages/creator-service/run_service.py
+++ b/packages/creator-service/run_service.py
@@ -127,8 +127,8 @@ class RunService:
         except ValueError as exc:
             raise ValueError(f"Invalid current stage '{run.current_stage}' for run {run_id}") from exc
 
-        if not can_transition(current_stage, target_stage) and target_stage not in REVIEW_STAGES:
-            raise ValueError(f"Cannot restart run {run_id} from {current_stage.value} to {target_stage.value}")
+        if not can_transition(current_stage, target_stage):
+            raise ValueError(f"Cannot transition from {current_stage.value} to {target_stage.value}")
 
         row = await self.storage.update_run(
             run_id,

--- a/packages/creator-service/script_service.py
+++ b/packages/creator-service/script_service.py
@@ -18,7 +18,13 @@ from markdown_parser import parse_markdown
 
 class ScriptStorageBackend(Protocol):
     async def save_draft(self, row: dict[str, Any]) -> dict[str, Any]:
-        """Persist a script draft row and return stored row."""
+        """Persist a script draft row and return stored row with version assigned.
+
+        The storage backend is responsible for atomically allocating the
+        next version number for the given ``run_id``.  Callers MUST NOT
+        include a ``version`` key in *row*; the returned dict MUST
+        contain the allocated ``version``.
+        """
         ...
 
     async def get_active_draft(self, run_id: int) -> dict[str, Any] | None:
@@ -31,16 +37,28 @@ class ScriptStorageBackend(Protocol):
 
 
 class InMemoryScriptStorage:
+    """In-memory storage with atomic per-run_id version allocation."""
+
     def __init__(self) -> None:
         self._drafts: dict[int, list[dict[str, Any]]] = {}
         self._next_id = 1
+        self._run_locks: dict[int, asyncio.Lock] = {}
 
     async def save_draft(self, row: dict[str, Any]) -> dict[str, Any]:
-        now = datetime.now(timezone.utc)
-        saved = {"id": self._next_id, "created_at": now, **row}
-        self._next_id += 1
         run_id = row["run_id"]
-        self._drafts.setdefault(run_id, []).append(saved)
+        lock = self._run_locks.setdefault(run_id, asyncio.Lock())
+        async with lock:
+            drafts = self._drafts.setdefault(run_id, [])
+            next_version = max((d["version"] for d in drafts), default=0) + 1
+            now = datetime.now(timezone.utc)
+            saved = {
+                "id": self._next_id,
+                "created_at": now,
+                "version": next_version,
+                **row,
+            }
+            self._next_id += 1
+            drafts.append(saved)
         return dict(saved)
 
     async def get_active_draft(self, run_id: int) -> dict[str, Any] | None:
@@ -57,7 +75,6 @@ class InMemoryScriptStorage:
 class ScriptService:
     def __init__(self, storage: ScriptStorageBackend | None = None) -> None:
         self.storage = storage if storage is not None else InMemoryScriptStorage()
-        self._run_locks: dict[int, asyncio.Lock] = {}
 
     async def save_draft(
         self,
@@ -71,43 +88,38 @@ class ScriptService:
         If markdown_content is provided and structured_script is not,
         parse the markdown to generate the structured script.
         If this run already has drafts, use existing sections for stable IDs.
-        Every save increments the version number.
 
-        Version allocation is serialised per run_id via an asyncio.Lock
-        to prevent duplicate versions under concurrent saves.
+        Version allocation is delegated to the storage backend to
+        guarantee atomicity regardless of how many ScriptService
+        instances share the same backend.
         """
-        lock = self._run_locks.setdefault(run_id, asyncio.Lock())
-        async with lock:
-            current = await self.storage.get_active_draft(run_id)
-            next_version = 1
-            existing_sections: list[ScriptSection] | None = None
+        current = await self.storage.get_active_draft(run_id)
+        existing_sections: list[ScriptSection] | None = None
 
-            if current is not None:
-                next_version = current.get("version", 0) + 1
-                existing_json = current.get("structured_script_json")
-                if existing_json:
-                    try:
-                        existing_data = json.loads(existing_json)
-                        existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
-                    except (json.JSONDecodeError, Exception):
-                        existing_sections = None
+        if current is not None:
+            existing_json = current.get("structured_script_json")
+            if existing_json:
+                try:
+                    existing_data = json.loads(existing_json)
+                    existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
+                except (json.JSONDecodeError, Exception):
+                    existing_sections = None
 
-            if markdown_content is not None and structured_script is None:
-                structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
+        if markdown_content is not None and structured_script is None:
+            structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
 
-            structured_script_json: str | None = None
-            if structured_script is not None:
-                structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
+        structured_script_json: str | None = None
+        if structured_script is not None:
+            structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
 
-            row = await self.storage.save_draft(
-                {
-                    "run_id": run_id,
-                    "source_type": source_type,
-                    "markdown_content": markdown_content,
-                    "structured_script_json": structured_script_json,
-                    "version": next_version,
-                }
-            )
+        row = await self.storage.save_draft(
+            {
+                "run_id": run_id,
+                "source_type": source_type,
+                "markdown_content": markdown_content,
+                "structured_script_json": structured_script_json,
+            }
+        )
 
         return self._row_to_draft(row)
 

--- a/packages/creator-service/script_service.py
+++ b/packages/creator-service/script_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from pathlib import Path
@@ -56,6 +57,7 @@ class InMemoryScriptStorage:
 class ScriptService:
     def __init__(self, storage: ScriptStorageBackend | None = None) -> None:
         self.storage = storage if storage is not None else InMemoryScriptStorage()
+        self._run_locks: dict[int, asyncio.Lock] = {}
 
     async def save_draft(
         self,
@@ -70,37 +72,42 @@ class ScriptService:
         parse the markdown to generate the structured script.
         If this run already has drafts, use existing sections for stable IDs.
         Every save increments the version number.
+
+        Version allocation is serialised per run_id via an asyncio.Lock
+        to prevent duplicate versions under concurrent saves.
         """
-        current = await self.storage.get_active_draft(run_id)
-        next_version = 1
-        existing_sections: list[ScriptSection] | None = None
+        lock = self._run_locks.setdefault(run_id, asyncio.Lock())
+        async with lock:
+            current = await self.storage.get_active_draft(run_id)
+            next_version = 1
+            existing_sections: list[ScriptSection] | None = None
 
-        if current is not None:
-            next_version = current.get("version", 0) + 1
-            existing_json = current.get("structured_script_json")
-            if existing_json:
-                try:
-                    existing_data = json.loads(existing_json)
-                    existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
-                except (json.JSONDecodeError, Exception):
-                    existing_sections = None
+            if current is not None:
+                next_version = current.get("version", 0) + 1
+                existing_json = current.get("structured_script_json")
+                if existing_json:
+                    try:
+                        existing_data = json.loads(existing_json)
+                        existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
+                    except (json.JSONDecodeError, Exception):
+                        existing_sections = None
 
-        if markdown_content is not None and structured_script is None:
-            structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
+            if markdown_content is not None and structured_script is None:
+                structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
 
-        structured_script_json: str | None = None
-        if structured_script is not None:
-            structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
+            structured_script_json: str | None = None
+            if structured_script is not None:
+                structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
 
-        row = await self.storage.save_draft(
-            {
-                "run_id": run_id,
-                "source_type": source_type,
-                "markdown_content": markdown_content,
-                "structured_script_json": structured_script_json,
-                "version": next_version,
-            }
-        )
+            row = await self.storage.save_draft(
+                {
+                    "run_id": run_id,
+                    "source_type": source_type,
+                    "markdown_content": markdown_content,
+                    "structured_script_json": structured_script_json,
+                    "version": next_version,
+                }
+            )
 
         return self._row_to_draft(row)
 

--- a/packages/creator-service/script_service.py
+++ b/packages/creator-service/script_service.py
@@ -1,1 +1,142 @@
-"""Placeholder for script_service."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+_DOMAIN_DIR = str(Path(__file__).resolve().parent.parent / "creator-domain")
+if _DOMAIN_DIR not in sys.path:
+    sys.path.insert(0, _DOMAIN_DIR)
+
+from models.script_draft import ScriptDraft, ScriptSection  # type: ignore[reportMissingImports]
+
+from markdown_parser import parse_markdown
+
+
+class ScriptStorageBackend(Protocol):
+    async def save_draft(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist a script draft row and return stored row."""
+        ...
+
+    async def get_active_draft(self, run_id: int) -> dict[str, Any] | None:
+        """Fetch the active (latest version) draft for a run."""
+        ...
+
+    async def list_draft_versions(self, run_id: int) -> list[dict[str, Any]]:
+        """List all draft versions for a run, newest first."""
+        ...
+
+
+class InMemoryScriptStorage:
+    def __init__(self) -> None:
+        self._drafts: dict[int, list[dict[str, Any]]] = {}
+        self._next_id = 1
+
+    async def save_draft(self, row: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        saved = {"id": self._next_id, "created_at": now, **row}
+        self._next_id += 1
+        run_id = row["run_id"]
+        self._drafts.setdefault(run_id, []).append(saved)
+        return dict(saved)
+
+    async def get_active_draft(self, run_id: int) -> dict[str, Any] | None:
+        drafts = self._drafts.get(run_id, [])
+        if not drafts:
+            return None
+        return dict(max(drafts, key=lambda d: d["version"]))
+
+    async def list_draft_versions(self, run_id: int) -> list[dict[str, Any]]:
+        drafts = self._drafts.get(run_id, [])
+        return [dict(d) for d in sorted(drafts, key=lambda d: d["version"], reverse=True)]
+
+
+class ScriptService:
+    def __init__(self, storage: ScriptStorageBackend | None = None) -> None:
+        self.storage = storage if storage is not None else InMemoryScriptStorage()
+
+    async def save_draft(
+        self,
+        run_id: int,
+        source_type: str,
+        markdown_content: str | None = None,
+        structured_script: list[ScriptSection] | None = None,
+    ) -> ScriptDraft:
+        """Save a new script draft version.
+
+        If markdown_content is provided and structured_script is not,
+        parse the markdown to generate the structured script.
+        If this run already has drafts, use existing sections for stable IDs.
+        Every save increments the version number.
+        """
+        current = await self.storage.get_active_draft(run_id)
+        next_version = 1
+        existing_sections: list[ScriptSection] | None = None
+
+        if current is not None:
+            next_version = current.get("version", 0) + 1
+            existing_json = current.get("structured_script_json")
+            if existing_json:
+                try:
+                    existing_data = json.loads(existing_json)
+                    existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
+                except (json.JSONDecodeError, Exception):
+                    existing_sections = None
+
+        if markdown_content is not None and structured_script is None:
+            structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
+
+        structured_script_json: str | None = None
+        if structured_script is not None:
+            structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
+
+        row = await self.storage.save_draft(
+            {
+                "run_id": run_id,
+                "source_type": source_type,
+                "markdown_content": markdown_content,
+                "structured_script_json": structured_script_json,
+                "version": next_version,
+            }
+        )
+
+        return self._row_to_draft(row)
+
+    async def get_active_draft(self, run_id: int) -> ScriptDraft | None:
+        """Get the active (latest version) draft for a run."""
+        row = await self.storage.get_active_draft(run_id)
+        if row is None:
+            return None
+        return self._row_to_draft(row)
+
+    async def list_draft_versions(self, run_id: int) -> list[ScriptDraft]:
+        """List all draft versions for a run, newest first."""
+        rows = await self.storage.list_draft_versions(run_id)
+        return [self._row_to_draft(row) for row in rows]
+
+    @staticmethod
+    def _row_to_draft(row: dict[str, Any]) -> ScriptDraft:
+        """Convert a storage row to a ScriptDraft domain model."""
+        structured_script: list[ScriptSection] | None = None
+        structured_json = row.get("structured_script_json")
+        if structured_json:
+            try:
+                data = json.loads(structured_json)
+                structured_script = [ScriptSection.model_validate(section) for section in data]
+            except (json.JSONDecodeError, Exception):
+                structured_script = None
+
+        return ScriptDraft(
+            id=row["id"],
+            run_id=row["run_id"],
+            source_type=row["source_type"],
+            markdown_content=row.get("markdown_content"),
+            structured_script=structured_script,
+            version=row.get("version", 1),
+            created_at=row["created_at"],
+        )
+
+
+script_service = ScriptService()

--- a/packages/creator-service/tests/test_markdown_parser.py
+++ b/packages/creator-service/tests/test_markdown_parser.py
@@ -1,0 +1,164 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from markdown_parser import parse_markdown
+
+
+def test_parse_standard_markdown_headings():
+    markdown = """## hook
+Grab attention now.
+
+## intro
+Welcome to the episode.
+
+## body
+Main explanation.
+
+## outro
+Thanks for watching.
+"""
+
+    sections = parse_markdown(markdown)
+
+    assert [section.type for section in sections] == ["hook", "intro", "body", "outro"]
+    assert [section.section_id for section in sections] == ["hook-1", "intro-2", "body-3", "outro-4"]
+    assert [section.text for section in sections] == [
+        "Grab attention now.",
+        "Welcome to the episode.",
+        "Main explanation.",
+        "Thanks for watching.",
+    ]
+    for section in sections:
+        assert section.display_text == section.text
+        assert section.speaker == "host"
+        assert section.duration is None
+        assert section.turn_kind is None
+        assert section.visual_override is None
+
+
+def test_parse_markdown_with_duplicate_heading_types():
+    markdown = """## hook
+Opening A.
+
+## hook
+Opening B.
+
+## body
+Main section.
+"""
+
+    sections = parse_markdown(markdown)
+
+    assert [section.type for section in sections] == ["hook", "hook", "body"]
+    assert [section.section_id for section in sections] == ["hook-1", "hook-2", "body-3"]
+
+
+def test_parse_markdown_without_headings_creates_single_body_section():
+    markdown = "First line.\n\nSecond line."
+
+    sections = parse_markdown(markdown)
+
+    assert len(sections) == 1
+    assert sections[0].type == "body"
+    assert sections[0].section_id == "body-1"
+    assert sections[0].text == "First line.\n\nSecond line."
+
+
+def test_parse_empty_markdown_returns_empty_list():
+    assert parse_markdown("") == []
+    assert parse_markdown("   \n\n  ") == []
+
+
+def test_stable_id_preservation_reuses_existing_ids_for_same_type_and_position():
+    markdown = """## hook
+Original hook.
+
+## intro
+Original intro.
+
+## body
+Original body.
+"""
+    existing = parse_markdown(markdown)
+    existing[0].section_id = "sec-custom-hook"
+    existing[1].section_id = "sec-custom-intro"
+
+    updated_markdown = """## hook
+Updated hook text.
+
+## intro
+Updated intro text.
+
+## body
+Updated body text.
+"""
+    reparsed = parse_markdown(updated_markdown, existing_sections=existing)
+
+    assert [section.section_id for section in reparsed] == [
+        "sec-custom-hook",
+        "sec-custom-intro",
+        "body-3",
+    ]
+
+
+def test_stable_id_changes_when_sections_reordered():
+    original_markdown = """## hook
+Hook text.
+
+## intro
+Intro text.
+
+## body
+Body text.
+"""
+    existing = parse_markdown(original_markdown)
+
+    reordered_markdown = """## intro
+Intro text.
+
+## hook
+Hook text.
+
+## body
+Body text.
+"""
+    reparsed = parse_markdown(reordered_markdown, existing_sections=existing)
+
+    assert [section.section_id for section in reparsed] == ["intro-1", "hook-2", "body-3"]
+    assert reparsed[0].section_id != existing[1].section_id
+    assert reparsed[1].section_id != existing[0].section_id
+
+
+def test_malformed_markdown_best_effort_parsing_handles_partial_headings_and_empty_sections():
+    markdown = """##hook
+Hook line.
+### not-a-level-two-heading
+
+##
+
+##intro
+"""
+
+    sections = parse_markdown(markdown)
+
+    assert [section.type for section in sections] == ["hook", "body", "intro"]
+    assert [section.section_id for section in sections] == ["hook-1", "body-2", "intro-3"]
+    assert sections[0].text == "Hook line.\n### not-a-level-two-heading"
+    assert sections[1].text == ""
+    assert sections[2].text == ""
+
+
+def test_section_ids_are_deterministic_for_same_input():
+    markdown = """## cta
+Like and subscribe.
+
+## body
+One more thing.
+"""
+
+    first = parse_markdown(markdown)
+    second = parse_markdown(markdown)
+
+    assert [section.section_id for section in first] == [section.section_id for section in second]

--- a/packages/creator-service/tests/test_model_catalog_service.py
+++ b/packages/creator-service/tests/test_model_catalog_service.py
@@ -1,0 +1,131 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-provider"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from model_catalog_service import ModelCatalogService
+from model_health_service import ModelHealthResult, ModelStatus
+
+ProviderRegistry = importlib.import_module("registry").ProviderRegistry
+
+
+@pytest.fixture
+def registry():
+    return ProviderRegistry.create_default()
+
+
+@pytest.fixture
+def health_service() -> AsyncMock:
+    service = AsyncMock()
+    status_by_provider = {
+        "ollama": ModelStatus.HEALTHY,
+        "stable-diffusion": ModelStatus.UNHEALTHY,
+        "tts-qwen3": ModelStatus.UNKNOWN,
+        "stt-whisper": ModelStatus.HEALTHY,
+    }
+
+    async def check_model(name: str) -> ModelHealthResult:
+        status = status_by_provider.get(name, ModelStatus.UNKNOWN)
+        return ModelHealthResult(
+            model_name=name,
+            endpoint=f"http://{name}:1234",
+            status=status,
+        )
+
+    service.check_model.side_effect = check_model
+    return service
+
+
+class TestModelCatalogService:
+    @pytest.mark.asyncio
+    async def test_list_models_returns_all_categories(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.list_models()
+
+        assert set(result.keys()) == {"script_models", "image_models", "tts_models", "stt_models"}
+        assert len(result["script_models"]) == 1
+        assert len(result["image_models"]) == 1
+        assert len(result["tts_models"]) == 1
+        assert len(result["stt_models"]) == 1
+
+        script_model = result["script_models"][0]
+        assert script_model["key"] == "qwen3-4b"
+        assert script_model["label"] == "Qwen3 4B (Local)"
+        assert script_model["provider_type"] == "ollama"
+        assert script_model["is_local"] is True
+        assert script_model["requires_gpu"] is True
+        assert script_model["status"] == "available"
+
+        image_model = result["image_models"][0]
+        assert image_model["status"] == "unavailable"
+
+        tts_model = result["tts_models"][0]
+        assert tts_model["status"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_list_models_filters_script_category(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.list_models(category="script")
+
+        assert len(result["script_models"]) == 1
+        assert result["script_models"][0]["key"] == "qwen3-4b"
+        assert result["image_models"] == []
+        assert result["tts_models"] == []
+        assert result["stt_models"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_models_filters_image_category(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.list_models(category="image")
+
+        assert len(result["image_models"]) == 1
+        assert result["image_models"][0]["key"] == "sd15"
+        assert result["script_models"] == []
+        assert result["tts_models"] == []
+        assert result["stt_models"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_status_returns_expected_shape(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.get_status()
+
+        assert set(result.keys()) == {"providers", "gpu_lock"}
+        assert isinstance(result["providers"], list)
+        assert len(result["providers"]) == 4
+
+        provider = result["providers"][0]
+        assert set(provider.keys()) == {"name", "endpoint", "healthy", "loaded_model", "gpu_locked"}
+        assert provider["loaded_model"] is None
+        assert provider["gpu_locked"] is False
+
+        assert result["gpu_lock"] == {
+            "active": False,
+            "holder": None,
+            "ttl_remaining": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_model_entries_have_required_fields(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.list_models()
+
+        required_fields = {"key", "label", "provider_type", "is_local", "requires_gpu", "status"}
+        all_entries = (
+            result["script_models"]
+            + result["image_models"]
+            + result["tts_models"]
+            + result["stt_models"]
+        )
+
+        for entry in all_entries:
+            assert set(entry.keys()) == required_fields

--- a/packages/creator-service/tests/test_model_catalog_service.py
+++ b/packages/creator-service/tests/test_model_catalog_service.py
@@ -64,9 +64,14 @@ class TestModelCatalogService:
 
         image_model = result["image_models"][0]
         assert image_model["status"] == "unavailable"
+        assert image_model["label"] == "Stable Diffusion 1.5 (Local)"
 
         tts_model = result["tts_models"][0]
         assert tts_model["status"] == "unknown"
+        assert tts_model["label"] == "Qwen TTS (Local)"
+
+        stt_model = result["stt_models"][0]
+        assert stt_model["label"] == "Whisper Medium (Local)"
 
     @pytest.mark.asyncio
     async def test_list_models_filters_script_category(self, registry, health_service: AsyncMock):
@@ -107,6 +112,14 @@ class TestModelCatalogService:
         assert provider["loaded_model"] is None
         assert provider["gpu_locked"] is False
 
+        # Provider names should match health service keys (Docker hostnames),
+        # not provider_type values from registry
+        provider_names = {p["name"] for p in result["providers"]}
+        assert provider_names == {"ollama", "stable-diffusion", "tts-qwen3", "stt-whisper"}
+        assert set(provider.keys()) == {"name", "endpoint", "healthy", "loaded_model", "gpu_locked"}
+        assert provider["loaded_model"] is None
+        assert provider["gpu_locked"] is False
+
         assert result["gpu_lock"] == {
             "active": False,
             "holder": None,
@@ -129,3 +142,16 @@ class TestModelCatalogService:
 
         for entry in all_entries:
             assert set(entry.keys()) == required_fields
+
+    @pytest.mark.asyncio
+    async def test_health_key_matches_health_service_keys(
+        self, registry, health_service: AsyncMock
+    ):
+        """Verify _health_key() produces keys that ModelHealthService recognises."""
+        service = ModelCatalogService(registry, health_service)
+
+        await service.list_models()
+
+        called_keys = {call.args[0] for call in health_service.check_model.call_args_list}
+        expected_keys = {"ollama", "stable-diffusion", "tts-qwen3", "stt-whisper"}
+        assert called_keys == expected_keys

--- a/packages/creator-service/tests/test_model_health.py
+++ b/packages/creator-service/tests/test_model_health.py
@@ -1,0 +1,101 @@
+"""Unit tests for model health service."""
+
+import pytest
+from creator_service.model_health_service import (
+    ModelHealthService,
+    ModelHealthResult,
+    ModelStatus,
+)
+
+
+@pytest.fixture
+def health_service():
+    """Create a model health service instance."""
+    return ModelHealthService()
+
+
+class TestModelHealthService:
+    """Test suite for ModelHealthService."""
+
+    def test_initialization_with_default_endpoints(self, health_service):
+        """Test ModelHealthService initializes with default endpoints."""
+        assert health_service.endpoints is not None
+        assert "ollama" in health_service.endpoints
+        assert "stable-diffusion" in health_service.endpoints
+        assert "tts-qwen3" in health_service.endpoints
+        assert "stt-whisper" in health_service.endpoints
+        
+        # Verify default URLs
+        assert health_service.endpoints["ollama"] == "http://ollama:11434"
+        assert health_service.endpoints["stable-diffusion"] == "http://stable-diffusion:7860"
+        assert health_service.endpoints["tts-qwen3"] == "http://tts-qwen3:9880"
+        assert health_service.endpoints["stt-whisper"] == "http://stt-whisper:9000"
+
+    def test_initialization_with_env_variables(self, monkeypatch):
+        """Test ModelHealthService initializes with environment variables."""
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://custom-ollama:11434")
+        monkeypatch.setenv("STABLE_DIFFUSION_BASE_URL", "http://custom-sd:7860")
+        
+        service = ModelHealthService()
+        
+        assert service.endpoints["ollama"] == "http://custom-ollama:11434"
+        assert service.endpoints["stable-diffusion"] == "http://custom-sd:7860"
+
+    @pytest.mark.asyncio
+    async def test_check_model_returns_result_with_correct_model_name(self, health_service):
+        """Test check_model returns result with correct model_name."""
+        result = await health_service.check_model("ollama")
+        
+        assert isinstance(result, ModelHealthResult)
+        assert result.model_name == "ollama"
+        assert result.endpoint == "http://ollama:11434"
+
+    @pytest.mark.asyncio
+    async def test_check_model_returns_unknown_for_invalid_model(self, health_service):
+        """Test check_model returns UNKNOWN status for invalid model."""
+        result = await health_service.check_model("invalid-model")
+        
+        assert result.status == ModelStatus.UNKNOWN
+        assert result.error == "Unknown model"
+        assert result.endpoint == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_check_all_returns_results_for_all_models(self, health_service):
+        """Test check_all returns results for all 4 models."""
+        results = await health_service.check_all()
+        
+        assert isinstance(results, list)
+        assert len(results) == 4
+        
+        model_names = {result.model_name for result in results}
+        expected_models = {"ollama", "stable-diffusion", "tts-qwen3", "stt-whisper"}
+        assert model_names == expected_models
+
+    @pytest.mark.asyncio
+    async def test_check_all_returns_model_health_results(self, health_service):
+        """Test check_all returns ModelHealthResult instances."""
+        results = await health_service.check_all()
+        
+        for result in results:
+            assert isinstance(result, ModelHealthResult)
+            assert result.model_name
+            assert result.endpoint
+            assert result.status in [ModelStatus.HEALTHY, ModelStatus.UNHEALTHY, ModelStatus.UNKNOWN]
+
+    def test_health_paths_configured(self, health_service):
+        """Test health paths are configured for all models."""
+        assert health_service.health_paths is not None
+        assert "ollama" in health_service.health_paths
+        assert "stable-diffusion" in health_service.health_paths
+        assert "tts-qwen3" in health_service.health_paths
+        assert "stt-whisper" in health_service.health_paths
+        
+        # Verify health paths
+        assert health_service.health_paths["ollama"] == "/api/tags"
+        assert health_service.health_paths["stable-diffusion"] == "/sdapi/v1/options"
+
+    def test_model_status_enum_values(self):
+        """Test ModelStatus enum has expected values."""
+        assert ModelStatus.HEALTHY.value == "healthy"
+        assert ModelStatus.UNHEALTHY.value == "unhealthy"
+        assert ModelStatus.UNKNOWN.value == "unknown"

--- a/packages/creator-service/tests/test_project_service.py
+++ b/packages/creator-service/tests/test_project_service.py
@@ -142,3 +142,75 @@ def test_create_project_with_url_missing_source_raises_value_error(service: Proj
 def test_create_project_with_idea_missing_brief_raises_value_error(service: ProjectService) -> None:
     with pytest.raises(ValueError, match="source_type='idea' requires idea_brief"):
         run(service.create_project(title="Bad Idea", source_type="idea"))
+
+
+def test_create_project_idea_with_markdown_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='idea' cannot have markdown_source or url_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="idea",
+                idea_brief="My idea",
+                markdown_source="# This should not be here",
+            )
+        )
+
+
+def test_create_project_idea_with_url_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='idea' cannot have markdown_source or url_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="idea",
+                idea_brief="My idea",
+                url_source="https://example.com",
+            )
+        )
+
+
+def test_create_project_markdown_with_url_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='markdown' cannot have idea_brief or url_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="markdown",
+                markdown_source="# Content",
+                url_source="https://example.com",
+            )
+        )
+
+
+def test_create_project_markdown_with_idea_brief_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='markdown' cannot have idea_brief or url_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="markdown",
+                markdown_source="# Content",
+                idea_brief="My idea",
+            )
+        )
+
+
+def test_create_project_url_with_idea_brief_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='url' cannot have idea_brief or markdown_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="url",
+                url_source="https://example.com",
+                idea_brief="My idea",
+            )
+        )
+
+
+def test_create_project_url_with_markdown_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='url' cannot have idea_brief or markdown_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="url",
+                url_source="https://example.com",
+                markdown_source="# Content",
+            )
+        )

--- a/packages/creator-service/tests/test_project_service.py
+++ b/packages/creator-service/tests/test_project_service.py
@@ -1,0 +1,129 @@
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from project_service import InMemoryProjectStorage, ProjectService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def storage() -> InMemoryProjectStorage:
+    return InMemoryProjectStorage()
+
+
+@pytest.fixture
+def service(storage: InMemoryProjectStorage) -> ProjectService:
+    return ProjectService(storage)
+
+
+def test_create_project_with_idea_source_type(service: ProjectService) -> None:
+    project = run(
+        service.create_project(
+            title="Idea Project",
+            source_type="idea",
+            idea_brief="Build a short-form video script from one concept.",
+        )
+    )
+
+    assert project.id == 1
+    assert project.title == "Idea Project"
+    assert project.source_type == "idea"
+    assert project.idea_brief == "Build a short-form video script from one concept."
+    assert project.markdown_source is None
+    assert project.url_source is None
+    assert project.status == "draft"
+
+
+def test_create_project_with_markdown_source_type(service: ProjectService) -> None:
+    markdown = "# Topic\n\nTurn this into a video script."
+    project = run(
+        service.create_project(
+            title="Markdown Project",
+            source_type="markdown",
+            markdown_source=markdown,
+        )
+    )
+
+    assert project.title == "Markdown Project"
+    assert project.source_type == "markdown"
+    assert project.markdown_source == markdown
+    assert project.idea_brief is None
+    assert project.url_source is None
+
+
+def test_create_project_with_invalid_source_type_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="Unsupported source_type"):
+        run(service.create_project(title="Invalid", source_type=cast(Any, "pdf")))
+
+
+def test_get_project_returns_none_for_missing_project(service: ProjectService) -> None:
+    assert run(service.get_project(9999)) is None
+
+
+def test_get_project_returns_existing_project(service: ProjectService) -> None:
+    created = run(service.create_project(title="Existing", source_type="url", url_source="https://example.com"))
+    fetched = run(service.get_project(created.id))
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.title == "Existing"
+    assert fetched.source_type == "url"
+    assert fetched.url_source == "https://example.com"
+    assert fetched.model_dump()["latest_run"] is None
+
+
+def test_list_projects_returns_newest_first(service: ProjectService) -> None:
+    older = run(service.create_project(title="Older", source_type="idea", idea_brief="old"))
+    newer = run(service.create_project(title="Newer", source_type="idea", idea_brief="new"))
+
+    projects = run(service.list_projects())
+
+    assert [project.id for project in projects[:2]] == [newer.id, older.id]
+
+
+def test_list_projects_respects_limit_and_offset(service: ProjectService) -> None:
+    first = run(service.create_project(title="First", source_type="idea"))
+    second = run(service.create_project(title="Second", source_type="idea"))
+    third = run(service.create_project(title="Third", source_type="idea"))
+
+    projects = run(service.list_projects(limit=1, offset=1))
+
+    assert len(projects) == 1
+    assert projects[0].id == second.id
+    assert projects[0].title == "Second"
+    assert first.id != projects[0].id
+    assert third.id != projects[0].id
+
+
+def test_get_and_list_include_latest_run_summary(
+    service: ProjectService,
+    storage: InMemoryProjectStorage,
+) -> None:
+    project = run(service.create_project(title="With Run", source_type="idea"))
+
+    run(storage.insert_run(project.id, current_stage="script_generating", status="running"))
+    latest = run(storage.insert_run(project.id, current_stage="script_review", status="paused"))
+
+    detailed = run(service.get_project(project.id))
+    listed = run(service.list_projects())
+
+    assert detailed is not None
+    assert detailed.model_dump()["latest_run"] == {
+        "run_id": latest["id"],
+        "current_stage": "script_review",
+        "status": "paused",
+    }
+    assert listed[0].model_dump()["latest_run"] == {
+        "run_id": latest["id"],
+        "current_stage": "script_review",
+        "status": "paused",
+    }

--- a/packages/creator-service/tests/test_project_service.py
+++ b/packages/creator-service/tests/test_project_service.py
@@ -91,9 +91,9 @@ def test_list_projects_returns_newest_first(service: ProjectService) -> None:
 
 
 def test_list_projects_respects_limit_and_offset(service: ProjectService) -> None:
-    first = run(service.create_project(title="First", source_type="idea"))
-    second = run(service.create_project(title="Second", source_type="idea"))
-    third = run(service.create_project(title="Third", source_type="idea"))
+    first = run(service.create_project(title="First", source_type="idea", idea_brief="first idea"))
+    second = run(service.create_project(title="Second", source_type="idea", idea_brief="second idea"))
+    third = run(service.create_project(title="Third", source_type="idea", idea_brief="third idea"))
 
     projects = run(service.list_projects(limit=1, offset=1))
 
@@ -108,7 +108,7 @@ def test_get_and_list_include_latest_run_summary(
     service: ProjectService,
     storage: InMemoryProjectStorage,
 ) -> None:
-    project = run(service.create_project(title="With Run", source_type="idea"))
+    project = run(service.create_project(title="With Run", source_type="idea", idea_brief="test idea"))
 
     run(storage.insert_run(project.id, current_stage="script_generating", status="running"))
     latest = run(storage.insert_run(project.id, current_stage="script_review", status="paused"))
@@ -127,3 +127,18 @@ def test_get_and_list_include_latest_run_summary(
         "current_stage": "script_review",
         "status": "paused",
     }
+
+
+def test_create_project_with_markdown_missing_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='markdown' requires markdown_source"):
+        run(service.create_project(title="Bad Markdown", source_type="markdown"))
+
+
+def test_create_project_with_url_missing_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='url' requires url_source"):
+        run(service.create_project(title="Bad URL", source_type="url"))
+
+
+def test_create_project_with_idea_missing_brief_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='idea' requires idea_brief"):
+        run(service.create_project(title="Bad Idea", source_type="idea"))

--- a/packages/creator-service/tests/test_render_profile.py
+++ b/packages/creator-service/tests/test_render_profile.py
@@ -1,0 +1,214 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from creator_service.render_profile import (
+    RenderProfile, Codec, AudioCodec, TransitionStyle
+)
+from creator_service.ffmpeg_service import FFmpegService, RenderInput
+
+
+class TestRenderProfile(unittest.TestCase):
+    """Tests for RenderProfile dataclass."""
+
+    def test_default_profile(self):
+        """Test default profile values."""
+        profile = RenderProfile.default()
+        
+        self.assertEqual(profile.name, "shorts_default")
+        self.assertEqual(profile.width, 1080)
+        self.assertEqual(profile.height, 1920)
+        self.assertEqual(profile.fps, 30)
+        self.assertEqual(profile.video_codec, Codec.H264)
+        self.assertEqual(profile.audio_codec, AudioCodec.AAC)
+        self.assertEqual(profile.transition_style, TransitionStyle.KEN_BURNS)
+        self.assertEqual(profile.crf, 23)
+        self.assertEqual(profile.preset, "medium")
+        self.assertTrue(profile.burn_subtitles)
+        self.assertEqual(profile.subtitle_font_size, 24)
+
+    def test_high_quality_preset(self):
+        """Test high_quality preset."""
+        profile = RenderProfile.high_quality()
+        
+        self.assertEqual(profile.name, "high_quality")
+        self.assertEqual(profile.crf, 18)
+        self.assertEqual(profile.preset, "slow")
+        # Check that inherited values are still correct
+        self.assertEqual(profile.width, 1080)
+        self.assertEqual(profile.height, 1920)
+
+    def test_fast_preview_preset(self):
+        """Test fast_preview preset."""
+        profile = RenderProfile.fast_preview()
+        
+        self.assertEqual(profile.name, "fast_preview")
+        self.assertEqual(profile.width, 540)
+        self.assertEqual(profile.height, 960)
+        self.assertEqual(profile.fps, 15)
+        self.assertEqual(profile.crf, 28)
+        self.assertEqual(profile.preset, "ultrafast")
+
+    def test_codec_enum_values(self):
+        """Test video codec enum values."""
+        self.assertEqual(Codec.H264.value, "libx264")
+        self.assertEqual(Codec.H265.value, "libx265")
+
+    def test_audio_codec_enum_values(self):
+        """Test audio codec enum values."""
+        self.assertEqual(AudioCodec.AAC.value, "aac")
+        self.assertEqual(AudioCodec.MP3.value, "libmp3lame")
+
+    def test_transition_style_enum_values(self):
+        """Test transition style enum values."""
+        self.assertEqual(TransitionStyle.CUT.value, "cut")
+        self.assertEqual(TransitionStyle.FADE.value, "fade")
+        self.assertEqual(TransitionStyle.KEN_BURNS.value, "ken_burns")
+
+
+class TestFFmpegService(unittest.TestCase):
+    """Tests for FFmpegService."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.profile = RenderProfile.default()
+        self.service = FFmpegService(self.profile)
+
+    def test_build_command_basic(self):
+        """Test build_command produces valid FFmpeg command list."""
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png"), Path("/tmp/img2.png")],
+            audio_path=None,
+            subtitle_path=None,
+            scene_durations=[3.0, 4.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        cmd = self.service.build_command(input_data, output_path)
+        
+        # Verify it's a list of strings
+        self.assertIsInstance(cmd, list)
+        self.assertTrue(all(isinstance(item, str) for item in cmd))
+        
+        # Verify key elements are present
+        self.assertIn("ffmpeg", cmd)
+        self.assertIn("-y", cmd)  # overwrite flag
+        self.assertIn(str(output_path), cmd)
+        
+        # Verify codec settings
+        self.assertIn("-c:v", cmd)
+        self.assertIn(self.profile.video_codec.value, cmd)
+        self.assertIn("-crf", cmd)
+        self.assertIn(str(self.profile.crf), cmd)
+        self.assertIn("-preset", cmd)
+        self.assertIn(self.profile.preset, cmd)
+
+    def test_build_command_with_audio(self):
+        """Test build_command includes audio mapping."""
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=Path("/tmp/audio.mp3"),
+            subtitle_path=None,
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        cmd = self.service.build_command(input_data, output_path)
+        
+        # Verify audio codec is set
+        self.assertIn("-c:a", cmd)
+        self.assertIn(self.profile.audio_codec.value, cmd)
+
+    def test_build_command_with_subtitles(self):
+        """Test build_command includes subtitle filter."""
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=None,
+            subtitle_path=Path("/tmp/subs.srt"),
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        cmd = self.service.build_command(input_data, output_path)
+        
+        # Verify subtitle filter is present
+        self.assertIn("-vf", cmd)
+        # Find the -vf value
+        vf_idx = cmd.index("-vf")
+        vf_filter = cmd[vf_idx + 1]
+        self.assertIn("subtitles", vf_filter)
+
+    def test_custom_profile(self):
+        """Test FFmpegService with custom profile."""
+        custom_profile = RenderProfile(
+            name="custom",
+            width=720,
+            height=1280,
+            fps=24,
+            crf=20,
+            preset="fast"
+        )
+        service = FFmpegService(custom_profile)
+        
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=None,
+            subtitle_path=None,
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        cmd = service.build_command(input_data, output_path)
+        
+        # Verify custom settings are in command
+        self.assertIn("720", cmd)
+        self.assertIn("1280", cmd)
+        self.assertIn("24", cmd)
+        self.assertIn("20", cmd)
+        self.assertIn("fast", cmd)
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.mkdir")
+    def test_render_success(self, mock_mkdir, mock_run):
+        """Test render method on success."""
+        mock_run.return_value = MagicMock(returncode=0)
+        
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=None,
+            subtitle_path=None,
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        result = self.service.render(input_data, output_path)
+        
+        self.assertEqual(result, output_path)
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.mkdir")
+    def test_render_failure(self, mock_mkdir, mock_run):
+        """Test render method on FFmpeg failure."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="FFmpeg error message"
+        )
+        
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=None,
+            subtitle_path=None,
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        with self.assertRaises(RuntimeError) as cm:
+            self.service.render(input_data, output_path)
+        
+        self.assertIn("FFmpeg render failed", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/creator-service/tests/test_run_service.py
+++ b/packages/creator-service/tests/test_run_service.py
@@ -106,11 +106,12 @@ def test_restart_run_rejects_invalid_stage_transition() -> None:
         )
     )
 
-    with pytest.raises(ValueError, match="Cannot restart run"):
+    with pytest.raises(ValueError, match="Cannot transition"):
         asyncio.run(service.restart_run(created.id, RunStage.PUBLISHED.value))
 
 
-def test_restart_run_allows_review_stage_restart() -> None:
+def test_restart_run_rejects_review_stage_from_non_review_stage() -> None:
+    """Verify that IDEA_READY cannot jump directly to SCRIPT_REVIEW (was incorrectly allowed)."""
     service = RunService(InMemoryRunStorage())
     created = asyncio.run(
         service.create_run(
@@ -120,7 +121,39 @@ def test_restart_run_allows_review_stage_restart() -> None:
         )
     )
 
-    restarted = asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_REVIEW.value))
+    with pytest.raises(ValueError, match="Cannot transition"):
+        asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_REVIEW.value))
 
-    assert restarted.current_stage == RunStage.SCRIPT_REVIEW.value
-    assert restarted.restart_from == RunStage.SCRIPT_REVIEW.value
+
+def test_restart_run_allows_valid_review_stage_restart() -> None:
+    """Verify that review stages can restart to their generating stage via TRANSITIONS."""
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=13,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    # First transition to SCRIPT_GENERATING (valid from IDEA_READY)
+    stage1 = asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_GENERATING.value))
+    assert stage1.current_stage == RunStage.SCRIPT_GENERATING.value
+
+    # Now manually set the stage to SCRIPT_REVIEW for testing (simulate it was reviewed)
+    # We need to restart from SCRIPT_GENERATING to SCRIPT_REVIEW first
+    # But since we can't directly manipulate, let's test SCRIPT_GENERATING -> SCRIPT_REVIEW transition
+    # by using the fact that stage1 is now in SCRIPT_GENERATING
+    
+    # Test: from SCRIPT_REVIEW, can restart to SCRIPT_GENERATING (the generating stage)
+    # We'll create a test scenario differently:
+    storage = InMemoryRunStorage()
+    service2 = RunService(storage)
+    created2 = asyncio.run(service2.create_run(project_id=14, model_defaults={"script_model": "qwen3-4b"}, style_preset="default"))
+    
+    # Simulate being in SCRIPT_REVIEW by manually updating storage
+    asyncio.run(storage.update_run(created2.id, {"current_stage": RunStage.SCRIPT_REVIEW.value}))
+    
+    # Now restart from SCRIPT_REVIEW to SCRIPT_GENERATING should succeed (per TRANSITIONS dict)
+    restarted = asyncio.run(service2.restart_run(created2.id, RunStage.SCRIPT_GENERATING.value))
+    assert restarted.current_stage == RunStage.SCRIPT_GENERATING.value

--- a/packages/creator-service/tests/test_run_service.py
+++ b/packages/creator-service/tests/test_run_service.py
@@ -1,0 +1,126 @@
+import asyncio
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from run_service import InMemoryRunStorage, RunService
+
+domain_models = importlib.import_module("models")
+ModelSelection = domain_models.ModelSelection
+RunStage = domain_models.RunStage
+
+
+def test_create_run_with_model_defaults_and_style_preset() -> None:
+    service = RunService(InMemoryRunStorage())
+
+    run = asyncio.run(
+        service.create_run(
+            project_id=7,
+            model_defaults=ModelSelection(script_model="qwen3-4b", image_model="sd15"),
+            style_preset="cinematic",
+        )
+    )
+
+    assert run.project_id == 7
+    assert run.current_stage == RunStage.IDEA_READY.value
+    assert run.status == "pending"
+    assert run.style_preset == "cinematic"
+    assert run.model_defaults is not None
+    assert run.model_defaults.script_model == "qwen3-4b"
+    assert run.model_defaults.image_model == "sd15"
+
+
+def test_create_run_stores_metadata_in_metadata_json() -> None:
+    storage = InMemoryRunStorage()
+    service = RunService(storage)
+    metadata = {"origin": "manual", "attempt": 1}
+
+    run = asyncio.run(
+        service.create_run(
+            project_id=8,
+            model_defaults={"script_model": "qwen3-8b"},
+            style_preset="default",
+            metadata=metadata,
+        )
+    )
+    row = asyncio.run(storage.get_run(run.id))
+
+    assert row is not None
+    assert row["metadata_json"] == json.dumps(metadata)
+
+
+def test_get_run_returns_none_for_missing() -> None:
+    service = RunService(InMemoryRunStorage())
+
+    run = asyncio.run(service.get_run(9999))
+
+    assert run is None
+
+
+def test_get_run_returns_existing_run() -> None:
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=9,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    fetched = asyncio.run(service.get_run(created.id))
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.project_id == 9
+
+
+def test_restart_run_transitions_correctly() -> None:
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=10,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    restarted = asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_GENERATING.value))
+
+    assert restarted.current_stage == RunStage.SCRIPT_GENERATING.value
+    assert restarted.restart_from == RunStage.SCRIPT_GENERATING.value
+
+
+def test_restart_run_rejects_invalid_stage_transition() -> None:
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=11,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    with pytest.raises(ValueError, match="Cannot restart run"):
+        asyncio.run(service.restart_run(created.id, RunStage.PUBLISHED.value))
+
+
+def test_restart_run_allows_review_stage_restart() -> None:
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=12,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    restarted = asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_REVIEW.value))
+
+    assert restarted.current_stage == RunStage.SCRIPT_REVIEW.value
+    assert restarted.restart_from == RunStage.SCRIPT_REVIEW.value

--- a/packages/creator-service/tests/test_script_service.py
+++ b/packages/creator-service/tests/test_script_service.py
@@ -1,0 +1,129 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from markdown_parser import parse_markdown
+from models.script_draft import ScriptSection  # type: ignore[reportMissingImports]
+from script_service import InMemoryScriptStorage, ScriptService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def storage() -> InMemoryScriptStorage:
+    return InMemoryScriptStorage()
+
+
+@pytest.fixture
+def service(storage: InMemoryScriptStorage) -> ScriptService:
+    return ScriptService(storage)
+
+
+def test_save_draft_creates_version_1(service: ScriptService) -> None:
+    draft = run(
+        service.save_draft(
+            run_id=101,
+            source_type="pasted_markdown",
+            markdown_content="## hook\nHello",
+        )
+    )
+
+    assert draft.run_id == 101
+    assert draft.version == 1
+
+
+def test_save_draft_increments_version(service: ScriptService) -> None:
+    run(service.save_draft(run_id=102, source_type="pasted_markdown", markdown_content="## hook\nFirst"))
+    second = run(
+        service.save_draft(
+            run_id=102,
+            source_type="edited_manually",
+            markdown_content="## hook\nSecond",
+        )
+    )
+
+    assert second.version == 2
+
+
+def test_save_draft_parses_markdown_when_no_structured_script(service: ScriptService) -> None:
+    markdown = "## hook\nHook line\n\n## body\nBody line"
+
+    draft = run(service.save_draft(run_id=103, source_type="pasted_markdown", markdown_content=markdown))
+
+    assert draft.structured_script is not None
+    assert draft.structured_script == parse_markdown(markdown)
+
+
+def test_save_draft_preserves_explicit_structured_script(service: ScriptService) -> None:
+    explicit = [
+        ScriptSection(
+            section_id="custom-1",
+            type="custom",
+            text="Explicit text",
+            display_text="Explicit display",
+            speaker="host",
+            duration=None,
+            turn_kind=None,
+            visual_override=None,
+        )
+    ]
+
+    draft = run(
+        service.save_draft(
+            run_id=104,
+            source_type="edited_manually",
+            markdown_content="## hook\nIgnored by explicit sections",
+            structured_script=explicit,
+        )
+    )
+
+    assert draft.structured_script is not None
+    assert [section.section_id for section in draft.structured_script] == ["custom-1"]
+    assert [section.type for section in draft.structured_script] == ["custom"]
+    assert [section.text for section in draft.structured_script] == ["Explicit text"]
+
+
+def test_save_draft_stable_section_ids(service: ScriptService) -> None:
+    first_markdown = "## hook\nFirst hook\n\n## intro\nFirst intro"
+    second_markdown = "## hook\nUpdated hook\n\n## intro\nUpdated intro"
+
+    first = run(service.save_draft(run_id=105, source_type="pasted_markdown", markdown_content=first_markdown))
+    second = run(service.save_draft(run_id=105, source_type="edited_manually", markdown_content=second_markdown))
+
+    assert first.structured_script is not None
+    assert second.structured_script is not None
+    assert [section.section_id for section in second.structured_script] == [
+        section.section_id for section in first.structured_script
+    ]
+
+
+def test_get_active_draft_returns_latest(service: ScriptService) -> None:
+    run(service.save_draft(run_id=106, source_type="pasted_markdown", markdown_content="## hook\nV1"))
+    run(service.save_draft(run_id=106, source_type="edited_manually", markdown_content="## hook\nV2"))
+
+    active = run(service.get_active_draft(106))
+
+    assert active is not None
+    assert active.version == 2
+    assert active.markdown_content == "## hook\nV2"
+
+
+def test_get_active_draft_returns_none_for_missing(service: ScriptService) -> None:
+    assert run(service.get_active_draft(9999)) is None
+
+
+def test_list_draft_versions_returns_newest_first(service: ScriptService) -> None:
+    run(service.save_draft(run_id=107, source_type="pasted_markdown", markdown_content="## hook\nV1"))
+    run(service.save_draft(run_id=107, source_type="edited_manually", markdown_content="## hook\nV2"))
+    run(service.save_draft(run_id=107, source_type="edited_manually", markdown_content="## hook\nV3"))
+
+    drafts = run(service.list_draft_versions(107))
+
+    assert [draft.version for draft in drafts] == [3, 2, 1]

--- a/packages/creator-service/tests/test_script_service.py
+++ b/packages/creator-service/tests/test_script_service.py
@@ -127,3 +127,18 @@ def test_list_draft_versions_returns_newest_first(service: ScriptService) -> Non
     drafts = run(service.list_draft_versions(107))
 
     assert [draft.version for draft in drafts] == [3, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_produce_unique_versions() -> None:
+    """Two concurrent saves for the same run_id must produce distinct versions."""
+    storage = InMemoryScriptStorage()
+    service = ScriptService(storage)
+
+    results = await asyncio.gather(
+        service.save_draft(run_id=200, source_type="pasted_markdown", markdown_content="## hook\nA"),
+        service.save_draft(run_id=200, source_type="pasted_markdown", markdown_content="## hook\nB"),
+    )
+
+    versions = sorted(d.version for d in results)
+    assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"

--- a/packages/creator-service/tests/test_script_service.py
+++ b/packages/creator-service/tests/test_script_service.py
@@ -142,3 +142,19 @@ async def test_concurrent_saves_produce_unique_versions() -> None:
 
     versions = sorted(d.version for d in results)
     assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_across_service_instances() -> None:
+    """Two ScriptService instances sharing one storage must still produce unique versions."""
+    storage = InMemoryScriptStorage()
+    service_a = ScriptService(storage)
+    service_b = ScriptService(storage)
+
+    results = await asyncio.gather(
+        service_a.save_draft(run_id=201, source_type="pasted_markdown", markdown_content="## hook\nA"),
+        service_b.save_draft(run_id=201, source_type="pasted_markdown", markdown_content="## hook\nB"),
+    )
+
+    versions = sorted(d.version for d in results)
+    assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,9 @@
+target-version = "py312"
+line-length = 100
+
+[lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[format]
+quote-style = "double"

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
-ignore = ["E501"]
+ignore = ["E501", "UP017"]
 
 [format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
- Implements `generate_script` Celery task with full provider resolution, GPU lock management, and audit metadata
- Flow: resolve LLM provider → acquire GPU lock (if local) → generate script → save draft → update run stage
- On success: stage → SCRIPT_REVIEW; on failure: stage → FAILED, GPU lock always released in `finally`
- Returns comprehensive audit metadata (timestamps, provider info, prompt summary, duration)

## Test Coverage
- 8 test cases: happy path (local/external), provider resolution failure, LLM failure, GPU lock timeout, lock release on failure, save failure, custom instructions

## Closes #25