### PR TITLE
feat(api): add generate-audio endpoint (#60)

### DIFF
--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -49,6 +49,18 @@ def dispatch_generate_visual_plan(
     tasks = import_module("tasks.generate_visual_plan")
     result = tasks.generate_visual_plan.delay(run_id, model_key, style_preset)
     return str(result.id)
+
+
+def dispatch_generate_audio(run_id: int, tts_model: str, voice: str) -> str:
+    """Dispatch generate_audio Celery task. Returns task id.
+
+    Separated into a function so tests can monkeypatch without importing Celery.
+    """
+    from importlib import import_module
+
+    tasks = import_module("tasks.generate_audio")
+    result = tasks.generate_audio.delay(run_id, tts_model=tts_model, voice=voice)
+    return str(result.id)
 router = APIRouter(tags=["runs"])
 
 
@@ -79,6 +91,12 @@ class GenerateScriptRequest(BaseModel):
 class GenerateVisualPlanRequest(BaseModel):
     model_key: str = "qwen3-4b"
     style_preset: str | None = None
+
+
+class GenerateAudioRequest(BaseModel):
+    tts_model: str = "piper"
+    voice: str = "en_US-lessac-medium"
+
 @router.post("/projects/{project_id}/runs", status_code=201)
 async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
     run = await run_service.create_run(
@@ -532,3 +550,62 @@ async def select_active_asset(run_id: int, scene_id: str, asset_id: int) -> dict
         raise HTTPException(status_code=400, detail=detail) from exc
 
     return asset.model_dump(mode="json")
+
+
+@router.post("/runs/{run_id}/generate-audio", status_code=202)
+async def generate_audio_trigger(run_id: int, request: GenerateAudioRequest) -> dict[str, object]:
+    """Trigger TTS audio generation for a run."""
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Validate stage — VISUAL_ASSET_REVIEW (after approval) or AUDIO_GENERATING (retry)
+    allowed_stages = frozenset({"VISUAL_ASSET_REVIEW", "AUDIO_GENERATING"})
+    if run.current_stage not in allowed_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed_stages)}",
+        )
+
+    # 3. Atomically advance to AUDIO_GENERATING via CAS
+    updates: dict[str, object] = {"current_stage": "AUDIO_GENERATING"}
+    if run.current_stage == "AUDIO_GENERATING":
+        updates["restart_from"] = "AUDIO_GENERATING"
+
+    ok, row = await run_service.storage.conditional_update_run(
+        run_id, updates, expected_stages=allowed_stages,
+    )
+    if not ok:
+        if row is None:
+            raise HTTPException(status_code=404, detail="Run not found")
+        raise HTTPException(
+            status_code=409,
+            detail=f"Stage conflict: run is now in '{row.get('current_stage')}'",
+        )
+
+    # 4. Dispatch Celery task — if this fails, roll back stage
+    try:
+        task_id = dispatch_generate_audio(
+            run_id=run_id,
+            tts_model=request.tts_model,
+            voice=request.voice,
+        )
+    except Exception:
+        # Best-effort rollback: restore original stage so run isn't stuck
+        await run_service.storage.conditional_update_run(
+            run_id,
+            {"current_stage": run.current_stage, "restart_from": run.restart_from},
+            expected_stages=frozenset({"AUDIO_GENERATING"}),
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue audio generation task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "current_stage": "AUDIO_GENERATING",
+    }

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -177,7 +177,7 @@ def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
     service = StubRunService()
 
     for route in runs_router.routes:
-        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "generate_visual_plan_trigger", "list_runs_for_project"}:
+        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "generate_visual_plan_trigger", "generate_audio_trigger", "list_runs_for_project"}:
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
 
     return service
@@ -1813,3 +1813,211 @@ async def test_select_active_asset_during_generating(client, stub_select_service
     )
     assert response.status_code == 200
     assert response.json()["id"] == 60
+
+
+class StubAudioDispatcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.task_id = "test-audio-task-id-abc"
+
+    def __call__(self, run_id: int, tts_model: str, voice: str) -> str:
+        self.calls.append({
+            "run_id": run_id,
+            "tts_model": tts_model,
+            "voice": voice,
+        })
+        return self.task_id
+
+
+@pytest.fixture
+def stub_generate_audio_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubAudioDispatcher]:
+    run_svc = StubRunService()
+    dispatcher = StubAudioDispatcher()
+
+    for route in runs_router.routes:
+        if route.name == "generate_audio_trigger":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "dispatch_generate_audio", dispatcher)
+
+    return run_svc, dispatcher
+
+
+def _make_audio_run(run_id: int, stage: str = "VISUAL_ASSET_REVIEW") -> StubPipelineRun:
+    """Helper to create a run in audio-relevant stage."""
+    now = datetime.now(timezone.utc)
+    return StubPipelineRun(
+        id=run_id,
+        project_id=1,
+        current_stage=stage,
+        status="running",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=now,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_from_visual_asset_review(client, stub_generate_audio_services):
+    run_svc, dispatcher = stub_generate_audio_services
+    run_svc.runs[110] = _make_audio_run(110, "VISUAL_ASSET_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/110/generate-audio",
+        json={"tts_model": "piper", "voice": "en_US-lessac-medium"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["task_id"] == "test-audio-task-id-abc"
+    assert body["run_id"] == 110
+    assert body["current_stage"] == "AUDIO_GENERATING"
+    # CAS was called for VISUAL_ASSET_REVIEW → AUDIO_GENERATING (no restart_from)
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 110
+    assert cas_calls[0]["updates"] == {"current_stage": "AUDIO_GENERATING"}
+    assert "VISUAL_ASSET_REVIEW" in cas_calls[0]["expected_stages"]
+    assert dispatcher.calls == [{
+        "run_id": 110,
+        "tts_model": "piper",
+        "voice": "en_US-lessac-medium",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_retry_from_generating(client, stub_generate_audio_services):
+    run_svc, dispatcher = stub_generate_audio_services
+    run_svc.runs[111] = _make_audio_run(111, "AUDIO_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/111/generate-audio",
+        json={"tts_model": "piper", "voice": "en_US-lessac-medium"},
+    )
+
+    assert response.status_code == 202
+    # CAS was called for AUDIO_GENERATING → AUDIO_GENERATING with restart_from
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 111
+    assert cas_calls[0]["updates"] == {
+        "current_stage": "AUDIO_GENERATING",
+        "restart_from": "AUDIO_GENERATING",
+    }
+    assert "AUDIO_GENERATING" in cas_calls[0]["expected_stages"]
+    assert len(dispatcher.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_default_model(client, stub_generate_audio_services):
+    run_svc, dispatcher = stub_generate_audio_services
+    run_svc.runs[112] = _make_audio_run(112, "VISUAL_ASSET_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/112/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["tts_model"] == "piper"
+    assert dispatcher.calls[0]["voice"] == "en_US-lessac-medium"
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_run_not_found(client, stub_generate_audio_services):
+    _, _ = stub_generate_audio_services
+    response = await client.post(
+        "/api/creator/runs/999/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_wrong_stage(client, stub_generate_audio_services):
+    run_svc, _ = stub_generate_audio_services
+    run_svc.runs[113] = _make_audio_run(113, "IDEA_READY")
+
+    response = await client.post(
+        "/api/creator/runs/113/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "IDEA_READY" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_wrong_stage_script_review(client, stub_generate_audio_services):
+    run_svc, _ = stub_generate_audio_services
+    run_svc.runs[114] = _make_audio_run(114, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/114/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "SCRIPT_REVIEW" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_cas_conflict(client, stub_generate_audio_services):
+    """CAS fails because stage changed between initial check and CAS."""
+    run_svc, dispatcher = stub_generate_audio_services
+    run_svc.runs[115] = _make_audio_run(115, "VISUAL_ASSET_REVIEW")
+
+    async def cas_conflict(run_id, updates, expected_stages):
+        return False, {"current_stage": "AUDIO_GENERATING", "id": run_id}
+
+    run_svc.storage.conditional_update_run = cas_conflict
+
+    response = await client.post(
+        "/api/creator/runs/115/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_dispatch_failure_rollback(client, stub_generate_audio_services):
+    """Celery dispatch failure triggers rollback to original stage."""
+    run_svc, _ = stub_generate_audio_services
+    run_svc.runs[116] = _make_audio_run(116, "VISUAL_ASSET_REVIEW")
+
+    def failing_dispatcher(run_id, tts_model, voice):
+        raise RuntimeError("Celery broker down")
+
+    from shorts_api.main import runs_router as _r
+    for route in _r.routes:
+        if route.name == "generate_audio_trigger":
+            route.endpoint.__globals__["dispatch_generate_audio"] = failing_dispatcher
+
+    response = await client.post(
+        "/api/creator/runs/116/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 503
+    assert "enqueue" in response.json()["detail"].lower()
+
+    # Rollback: CAS was called twice — first to advance, then to rollback
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 2
+    # Second CAS = rollback to VISUAL_ASSET_REVIEW
+    rollback = cas_calls[1]
+    assert rollback["updates"]["current_stage"] == "VISUAL_ASSET_REVIEW"
+    assert rollback["expected_stages"] == frozenset({"AUDIO_GENERATING"})
+
+    # Verify run was actually rolled back to VISUAL_ASSET_REVIEW
+    assert run_svc.runs[116].current_stage == "VISUAL_ASSET_REVIEW"


### PR DESCRIPTION
## Summary
- Add `POST /api/creator/runs/{run_id}/generate-audio` endpoint accepting `tts_model` and `voice` params
- Validates run stage (VISUAL_ASSET_REVIEW or AUDIO_GENERATING for retry), atomically advances via CAS
- Dispatches `generate_audio` Celery task with rollback on dispatch failure
- 8 comprehensive tests: happy path, retry, defaults, not found, wrong stage (×2), CAS conflict, dispatch rollback

## Acceptance Criteria
- [x] `POST /api/creator/runs/{run_id}/generate-audio` accepts `tts_model` and `voice`
- [x] Endpoint validates run prerequisites and enqueues the task
- [x] Run stage/state updates to reflect audio generation

## Test Results
78/78 tests pass (8 new + 70 existing)

Closes #60