### PR TITLE
feat(studio-web): add ReviewPage component for run review (#67)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Python dependencies
+        run: python3 -m pip install -r apps/api/requirements.txt -r apps/worker-orchestrator/requirements.txt
+      - name: Install Node dependencies
+        run: npm --prefix apps/studio-web install
+      - name: Lint Python
+        run: |
+          ruff check apps packages
+          python3 -m compileall apps packages
+      - name: Lint TypeScript
+        run: npm --prefix apps/studio-web run lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Python dependencies
+        run: python3 -m pip install -r apps/api/requirements.txt -r apps/worker-orchestrator/requirements.txt
+      - name: Install Node dependencies
+        run: npm --prefix apps/studio-web install
+      - name: Test API
+        run: cd apps/api && python3 -m pytest tests/ -v
+      - name: Test Worker
+        run: cd apps/worker-orchestrator && python3 -m pytest tests/ -v
+      - name: Test Frontend
+        run: npm --prefix apps/studio-web run test

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ Thumbs.db
 # Artifacts
 data/artifacts/**
 !data/artifacts/.gitkeep
+packages/creator-domain/creator-domain
+packages/creator-service/creator-service
+packages/creator_domain
+packages/creator_provider
+packages/creator_service

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,13 @@ dev:
 	@echo "- Web: npm --prefix apps/studio-web run dev"
 
 lint:
+	ruff check apps packages
 	python3 -m compileall apps packages
 	@if [ -d apps/studio-web/node_modules ]; then npm --prefix apps/studio-web run lint; else echo "Skipping studio-web lint (run make install first)"; fi
+
+format:
+	ruff format apps packages
+	@if [ -d apps/studio-web/node_modules ]; then npm --prefix apps/studio-web run format; else echo "Skipping studio-web format (run make install first)"; fi
 
 test:
 	@echo "No tests scaffolded yet."

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ format:
 	@if [ -d apps/studio-web/node_modules ]; then npm --prefix apps/studio-web run format; else echo "Skipping studio-web format (run make install first)"; fi
 
 test:
-	@echo "No tests scaffolded yet."
+	cd apps/api && python3 -m pytest tests/ -v
+	cd apps/worker-orchestrator && python3 -m pytest tests/ -v
+	@if [ -d apps/studio-web/node_modules ]; then npm --prefix apps/studio-web run test; else echo "Skipping studio-web tests (run make install first)"; fi
 
 build:
 	python3 -m compileall apps packages

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -10,6 +10,8 @@ FROM python:3.12-slim AS runtime
 WORKDIR /app
 COPY --from=builder /install /usr/local
 COPY apps/api/src ./src
+COPY apps/api/alembic.ini ./alembic.ini
+COPY apps/api/migrations ./migrations
 COPY packages ./packages
 ENV PYTHONPATH=/app/src:/app
 EXPOSE 8000

--- a/apps/api/alembic.ini
+++ b/apps/api/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = postgresql://short_form_user:short_form_password@postgres:5432/short_form_pipeline
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/apps/api/migrations/env.py
+++ b/apps/api/migrations/env.py
@@ -1,0 +1,43 @@
+"""Alembic environment configuration."""
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+import os
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Override URL from environment if available
+db_url = os.getenv("DATABASE_URL")
+if not db_url:
+    user = os.getenv("POSTGRES_USER", "short_form_user")
+    password = os.getenv("POSTGRES_PASSWORD", "short_form_password")
+    host = os.getenv("POSTGRES_HOST", "postgres")
+    port = os.getenv("POSTGRES_PORT", "5432")
+    db = os.getenv("POSTGRES_DB", "short_form_pipeline")
+    db_url = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+if db_url:
+    config.set_main_option("sqlalchemy.url", db_url)
+
+target_metadata = None
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    section = config.get_section(config.config_ini_section) or {}
+    connectable = engine_from_config(section, prefix="sqlalchemy.", poolclass=pool.NullPool)
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/apps/api/migrations/script.py.mako
+++ b/apps/api/migrations/script.py.mako
@@ -1,0 +1,22 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/apps/api/migrations/versions/001_create_creator_projects.py
+++ b/apps/api/migrations/versions/001_create_creator_projects.py
@@ -1,0 +1,66 @@
+"""Create creator_projects table.
+
+Revision ID: 001
+Revises: None
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_projects",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("source_type", sa.String(length=50), nullable=False, server_default="idea"),
+        sa.Column("idea_brief", sa.Text(), nullable=True),
+        sa.Column("markdown_source", sa.Text(), nullable=True),
+        sa.Column("url_source", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="draft"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_check_constraint(
+        "ck_creator_projects_source_type",
+        "creator_projects",
+        "source_type IN ('idea', 'markdown', 'url')",
+    )
+    op.create_check_constraint(
+        "ck_creator_projects_status",
+        "creator_projects",
+        "status IN ('draft', 'active', 'completed', 'archived')",
+    )
+
+    op.execute(
+        """
+    CREATE OR REPLACE FUNCTION update_updated_at_column()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        NEW.updated_at = NOW();
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    """
+    )
+    op.execute(
+        """
+    CREATE TRIGGER set_updated_at
+    BEFORE UPDATE ON creator_projects
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+    """
+    )
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS set_updated_at ON creator_projects")
+    op.execute("DROP FUNCTION IF EXISTS update_updated_at_column()")
+    op.drop_constraint("ck_creator_projects_source_type", "creator_projects")
+    op.drop_constraint("ck_creator_projects_status", "creator_projects")
+    op.drop_table("creator_projects")

--- a/apps/api/migrations/versions/002_create_creator_runs.py
+++ b/apps/api/migrations/versions/002_create_creator_runs.py
@@ -1,0 +1,58 @@
+"""Create creator_runs table.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_runs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_id", sa.Integer(), sa.ForeignKey("creator_projects.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("current_stage", sa.String(length=50), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="pending"),
+        sa.Column("review_stage", sa.String(length=50), nullable=True),
+        sa.Column("restart_from", sa.String(length=50), nullable=True),
+        sa.Column("model_defaults_json", sa.Text(), nullable=True),
+        sa.Column("metadata_json", sa.Text(), nullable=True),
+        sa.Column("style_preset", sa.String(length=100), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    # CHECK constraint for status
+    op.create_check_constraint(
+        "ck_creator_runs_status",
+        "creator_runs",
+        "status IN ('pending', 'running', 'paused', 'completed', 'failed', 'cancelled')",
+    )
+
+    # Index on project_id for FK lookups
+    op.create_index("ix_creator_runs_project_id", "creator_runs", ["project_id"])
+
+    # Reuse the update_updated_at_column() function from migration 001
+    op.execute(
+        """
+    CREATE TRIGGER set_updated_at_creator_runs
+    BEFORE UPDATE ON creator_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+    """
+    )
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS set_updated_at_creator_runs ON creator_runs")
+    op.drop_constraint("ck_creator_runs_status", "creator_runs")
+    op.drop_index("ix_creator_runs_project_id")
+    op.drop_table("creator_runs")

--- a/apps/api/migrations/versions/003_create_creator_stage_reviews.py
+++ b/apps/api/migrations/versions/003_create_creator_stage_reviews.py
@@ -1,0 +1,45 @@
+"""Create creator_stage_reviews table.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "003"
+down_revision: Union[str, None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_stage_reviews",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("creator_runs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("stage_name", sa.String(length=50), nullable=False),
+        sa.Column("review_status", sa.String(length=50), nullable=False, server_default="pending"),
+        sa.Column("reviewer", sa.String(length=100), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    # CHECK constraint for review_status
+    op.create_check_constraint(
+        "ck_creator_stage_reviews_review_status",
+        "creator_stage_reviews",
+        "review_status IN ('pending', 'approved', 'rejected', 'skipped')",
+    )
+
+    # Composite index for lookups by run + stage
+    op.create_index(
+        "ix_creator_stage_reviews_run_stage",
+        "creator_stage_reviews",
+        ["run_id", "stage_name"],
+    )
+
+def downgrade() -> None:
+    op.drop_index("ix_creator_stage_reviews_run_stage")
+    op.drop_constraint("ck_creator_stage_reviews_review_status", "creator_stage_reviews")
+    op.drop_table("creator_stage_reviews")

--- a/apps/api/migrations/versions/004_create_creator_scene_assets.py
+++ b/apps/api/migrations/versions/004_create_creator_scene_assets.py
@@ -1,0 +1,66 @@
+"""Create creator_scene_assets table.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_scene_assets",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("creator_runs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("scene_id", sa.String(length=100), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("asset_path", sa.Text(), nullable=False),
+        sa.Column("prompt_snapshot", sa.Text(), nullable=True),
+        sa.Column("model_used", sa.String(length=100), nullable=True),
+        sa.Column("provider", sa.String(length=50), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+    # Index for lookups by run + scene
+    op.create_index(
+        "ix_creator_scene_assets_run_scene",
+        "creator_scene_assets",
+        ["run_id", "scene_id"],
+    )
+
+    # Index for active asset lookups
+    op.create_index(
+        "ix_creator_scene_assets_active",
+        "creator_scene_assets",
+        ["run_id", "scene_id", "is_active"],
+    )
+
+    # Unique constraint: no duplicate version per scene
+    op.create_unique_constraint(
+        "uq_creator_scene_assets_run_scene_version",
+        "creator_scene_assets",
+        ["run_id", "scene_id", "version"],
+    )
+
+    # Partial unique index: only one active asset per scene
+    op.execute(
+        """
+    CREATE UNIQUE INDEX uq_creator_scene_assets_active
+    ON creator_scene_assets (run_id, scene_id)
+    WHERE is_active = true;
+    """
+    )
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_creator_scene_assets_active")
+    op.drop_constraint("uq_creator_scene_assets_run_scene_version", "creator_scene_assets")
+    op.drop_index("ix_creator_scene_assets_active")
+    op.drop_index("ix_creator_scene_assets_run_scene")
+    op.drop_table("creator_scene_assets")

--- a/apps/api/migrations/versions/005_expand_artifact_typing_and_indexes.py
+++ b/apps/api/migrations/versions/005_expand_artifact_typing_and_indexes.py
@@ -55,6 +55,13 @@ def upgrade() -> None:
         ")",
     )
 
+    # Conditional CHECK: visual_asset requires scene_id
+    op.create_check_constraint(
+        "ck_creator_artifacts_visual_asset_scene_id",
+        "creator_artifacts",
+        "artifact_type <> 'visual_asset' OR scene_id IS NOT NULL",
+    )
+
     # updated_at trigger (reuses function from migration 001)
     op.execute(
         """
@@ -99,6 +106,8 @@ def upgrade() -> None:
         "creator_runs",
         ["current_stage"],
     )
+    # Drop redundant single-column index from 002 — superseded by composite above
+    op.drop_index("ix_creator_runs_project_id", "creator_runs")
 
 
 def downgrade() -> None:
@@ -106,6 +115,8 @@ def downgrade() -> None:
     op.drop_index("ix_creator_runs_current_stage", "creator_runs")
     op.drop_index("ix_creator_runs_project_created_desc", "creator_runs")
     op.drop_index("ix_creator_projects_created_at_desc", "creator_projects")
+    # Re-create the single-column index that was dropped in upgrade
+    op.create_index("ix_creator_runs_project_id", "creator_runs", ["project_id"])
 
     # Drop creator_artifacts indexes, trigger, constraint, table
     op.drop_index("ix_creator_artifacts_run_type_created", "creator_artifacts")
@@ -113,5 +124,6 @@ def downgrade() -> None:
     op.execute(
         "DROP TRIGGER IF EXISTS set_updated_at_creator_artifacts ON creator_artifacts"
     )
+    op.drop_constraint("ck_creator_artifacts_visual_asset_scene_id", "creator_artifacts")
     op.drop_constraint("ck_creator_artifacts_artifact_type", "creator_artifacts")
     op.drop_table("creator_artifacts")

--- a/apps/api/migrations/versions/005_expand_artifact_typing_and_indexes.py
+++ b/apps/api/migrations/versions/005_expand_artifact_typing_and_indexes.py
@@ -1,0 +1,117 @@
+"""Expand artifact typing and add creator indexes.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "005"
+down_revision: Union[str, None] = "004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- 1. Create creator_artifacts table ---
+    op.create_table(
+        "creator_artifacts",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "run_id",
+            sa.Integer(),
+            sa.ForeignKey("creator_runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("artifact_type", sa.String(length=50), nullable=False),
+        sa.Column("scene_id", sa.String(length=100), nullable=True),
+        sa.Column("file_path", sa.Text(), nullable=False),
+        sa.Column("file_size_bytes", sa.BigInteger(), nullable=True),
+        sa.Column("mime_type", sa.String(length=100), nullable=True),
+        sa.Column("metadata_json", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    # CHECK constraint for artifact_type
+    op.create_check_constraint(
+        "ck_creator_artifacts_artifact_type",
+        "creator_artifacts",
+        "artifact_type IN ("
+        "'idea', 'script', 'visual_plan', 'visual_asset', "
+        "'audio', 'subtitle', 'video', 'render_manifest'"
+        ")",
+    )
+
+    # updated_at trigger (reuses function from migration 001)
+    op.execute(
+        """
+    CREATE TRIGGER set_updated_at_creator_artifacts
+    BEFORE UPDATE ON creator_artifacts
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+    """
+    )
+
+    # --- 2. Indexes on creator_artifacts (from DB_MIGRATION.md §6) ---
+    op.create_index(
+        "ix_creator_artifacts_run_type",
+        "creator_artifacts",
+        ["run_id", "artifact_type"],
+    )
+    op.execute(
+        """
+    CREATE INDEX ix_creator_artifacts_run_type_created
+    ON creator_artifacts (run_id, artifact_type, created_at DESC);
+    """
+    )
+
+    # --- 3. Missing indexes on existing creator tables (from DB_MIGRATION.md §6) ---
+    # creator_projects: sort by newest first
+    op.execute(
+        """
+    CREATE INDEX ix_creator_projects_created_at_desc
+    ON creator_projects (created_at DESC);
+    """
+    )
+    # creator_runs: lookup by project sorted by newest first
+    op.execute(
+        """
+    CREATE INDEX ix_creator_runs_project_created_desc
+    ON creator_runs (project_id, created_at DESC);
+    """
+    )
+    # creator_runs: filter by current_stage
+    op.create_index(
+        "ix_creator_runs_current_stage",
+        "creator_runs",
+        ["current_stage"],
+    )
+
+
+def downgrade() -> None:
+    # Drop indexes on existing tables (reverse order)
+    op.drop_index("ix_creator_runs_current_stage", "creator_runs")
+    op.drop_index("ix_creator_runs_project_created_desc", "creator_runs")
+    op.drop_index("ix_creator_projects_created_at_desc", "creator_projects")
+
+    # Drop creator_artifacts indexes, trigger, constraint, table
+    op.drop_index("ix_creator_artifacts_run_type_created", "creator_artifacts")
+    op.drop_index("ix_creator_artifacts_run_type", "creator_artifacts")
+    op.execute(
+        "DROP TRIGGER IF EXISTS set_updated_at_creator_artifacts ON creator_artifacts"
+    )
+    op.drop_constraint("ck_creator_artifacts_artifact_type", "creator_artifacts")
+    op.drop_table("creator_artifacts")

--- a/apps/api/pytest.ini
+++ b/apps/api/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+pythonpath = src

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -6,3 +6,6 @@ redis
 
 # Dev dependencies
 ruff
+pytest
+httpx
+pytest-asyncio

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,3 +2,7 @@ fastapi
 uvicorn
 celery
 redis
+
+
+# Dev dependencies
+ruff

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,6 +2,9 @@ fastapi
 uvicorn
 celery
 redis
+alembic
+sqlalchemy
+psycopg2-binary
 
 
 # Dev dependencies

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -20,7 +20,7 @@ except ImportError:
 from shorts_api.routes.creator_models import router as models_router
 from shorts_api.routes.creator_projects import router as projects_router
 from shorts_api.routes.creator_runs import router as runs_router
-from shorts_api.routes.creator_script import router as script_router
+from shorts_api.routes.creator_script import router as script_router, run_script_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
@@ -31,6 +31,7 @@ app.include_router(models_router, prefix="/api/creator")
 app.include_router(projects_router, prefix="/api/creator")
 app.include_router(runs_router, prefix="/api/creator")
 app.include_router(script_router, prefix="/api/creator")
+app.include_router(run_script_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     from logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
+from shorts_api.routes.creator_projects import router as projects_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="short-form-pipeline API")
 app.include_router(models_router, prefix="/api/creator")
+app.include_router(projects_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     from logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
+from shorts_api.routes.creator_runs import router as runs_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="short-form-pipeline API")
 app.include_router(models_router, prefix="/api/creator")
+app.include_router(runs_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -10,12 +10,14 @@ from fastapi import FastAPI
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
 
 from creator_service.logging_config import setup_json_logging
+from shorts_api.routes.creator_models import router as models_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="short-form-pipeline API")
+app.include_router(models_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -21,6 +21,7 @@ from shorts_api.routes.creator_models import router as models_router
 from shorts_api.routes.creator_projects import router as projects_router
 from shorts_api.routes.creator_runs import router as runs_router
 from shorts_api.routes.creator_script import router as script_router, run_script_router
+from shorts_api.routes.creator_visual_plan import router as visual_plan_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
@@ -32,6 +33,7 @@ app.include_router(projects_router, prefix="/api/creator")
 app.include_router(runs_router, prefix="/api/creator")
 app.include_router(script_router, prefix="/api/creator")
 app.include_router(run_script_router, prefix="/api/creator")
+app.include_router(visual_plan_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -1,4 +1,5 @@
 """FastAPI entrypoint for shorts_api."""
+# pyright: reportMissingImports=false
 
 import logging
 import os
@@ -7,9 +8,15 @@ import sys
 from fastapi import FastAPI
 
 # Add packages to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
 
-from creator_service.logging_config import setup_json_logging
+try:
+    from creator_service.logging_config import setup_json_logging
+except ImportError:
+    from logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
 
 # Configure structured JSON logging

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -1,6 +1,19 @@
 """FastAPI entrypoint for shorts_api."""
 
+import logging
+import os
+import sys
+
 from fastapi import FastAPI
+
+# Add packages to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
+
+from creator_service.logging_config import setup_json_logging
+
+# Configure structured JSON logging
+setup_json_logging(service_name="api", level="INFO")
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="short-form-pipeline API")
 

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -20,6 +20,7 @@ except ImportError:
 from shorts_api.routes.creator_models import router as models_router
 from shorts_api.routes.creator_projects import router as projects_router
 from shorts_api.routes.creator_runs import router as runs_router
+from shorts_api.routes.creator_script import router as script_router
 
 # Configure structured JSON logging
 setup_json_logging(service_name="api", level="INFO")
@@ -29,6 +30,7 @@ app = FastAPI(title="short-form-pipeline API")
 app.include_router(models_router, prefix="/api/creator")
 app.include_router(projects_router, prefix="/api/creator")
 app.include_router(runs_router, prefix="/api/creator")
+app.include_router(script_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/routes/creator_models.py
+++ b/apps/api/src/shorts_api/routes/creator_models.py
@@ -1,43 +1,51 @@
 """Routes for creator model management."""
+# pyright: reportMissingImports=false
 
 import logging
-import sys
 import os
-from fastapi import APIRouter
+import sys
+
+from fastapi import APIRouter, HTTPException, Query
 
 # Add packages to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
 
-from creator_service.model_health_service import ModelHealthService, ModelHealthResult
+try:
+    from creator_provider.registry import ProviderRegistry
+    from creator_service.model_catalog_service import ModelCatalogService
+    from creator_service.model_health_service import ModelHealthService
+except ImportError:
+    from model_catalog_service import ModelCatalogService
+    from model_health_service import ModelHealthService
+    from registry import ProviderRegistry
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/models", tags=["models"])
 
+VALID_CATEGORIES = {"script", "image", "tts", "stt"}
+model_catalog_service = ModelCatalogService(
+    registry=ProviderRegistry.create_default(),
+    health_service=ModelHealthService(),
+)
+
+
+@router.get("")
+async def list_models(category: str | None = Query(default=None)) -> dict[str, list[dict[str, object]]]:
+    """List available creator models by category."""
+    if category is not None and category not in VALID_CATEGORIES:
+        raise HTTPException(status_code=400, detail="Invalid category")
+
+    return await model_catalog_service.list_models(category=category)
+
 
 @router.get("/status")
-async def get_model_status() -> dict:
-    """Get health status of all model serving containers.
-    
-    Returns:
-        Dictionary containing list of model health results.
-    """
+async def get_model_status() -> dict[str, object]:
+    """Return provider-level status and GPU lock state."""
     logger.info("Model status check requested")
-    
-    health_service = ModelHealthService()
-    results = await health_service.check_all()
-    
-    # Convert enum values to strings for JSON serialization
-    results_dict = [
-        {
-            "model_name": result.model_name,
-            "endpoint": result.endpoint,
-            "status": result.status.value,
-            "response_time_ms": result.response_time_ms,
-            "error": result.error,
-        }
-        for result in results
-    ]
-    
-    logger.info(f"Model status check completed with {len(results)} models checked")
-    return {"models": results_dict}
+    status = await model_catalog_service.get_status()
+    logger.info("Model status check completed")
+    return status

--- a/apps/api/src/shorts_api/routes/creator_models.py
+++ b/apps/api/src/shorts_api/routes/creator_models.py
@@ -1,1 +1,43 @@
-"""Placeholder for creator_models."""
+"""Routes for creator model management."""
+
+import logging
+import sys
+import os
+from fastapi import APIRouter
+
+# Add packages to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../..", "packages"))
+
+from creator_service.model_health_service import ModelHealthService, ModelHealthResult
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/models", tags=["models"])
+
+
+@router.get("/status")
+async def get_model_status() -> dict:
+    """Get health status of all model serving containers.
+    
+    Returns:
+        Dictionary containing list of model health results.
+    """
+    logger.info("Model status check requested")
+    
+    health_service = ModelHealthService()
+    results = await health_service.check_all()
+    
+    # Convert enum values to strings for JSON serialization
+    results_dict = [
+        {
+            "model_name": result.model_name,
+            "endpoint": result.endpoint,
+            "status": result.status.value,
+            "response_time_ms": result.response_time_ms,
+            "error": result.error,
+        }
+        for result in results
+    ]
+    
+    logger.info(f"Model status check completed with {len(results)} models checked")
+    return {"models": results_dict}

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -6,7 +6,7 @@ import sys
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 # Add packages to path for imports
 _PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
@@ -31,12 +31,7 @@ class CreateProjectRequest(BaseModel):
 
 
 @router.post("", status_code=201)
-async def create_project(payload: dict[str, object]) -> dict[str, object]:
-    try:
-        request = CreateProjectRequest.model_validate(payload)
-    except ValidationError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
+async def create_project(request: CreateProjectRequest) -> dict[str, object]:
     try:
         project = await project_service.create_project(
             title=request.title,
@@ -66,7 +61,8 @@ async def list_projects(
     offset: int = Query(default=0, ge=0),
 ) -> dict[str, object]:
     projects = await project_service.list_projects(limit=limit, offset=offset)
+    total = await project_service.count_projects()
     return {
         "projects": [project.model_dump(mode="json") for project in projects],
-        "total": len(projects),
+        "total": total,
     }

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -1,1 +1,72 @@
-"""Placeholder for creator_projects."""
+"""Routes for creator project management."""
+# pyright: reportMissingImports=false
+
+import os
+import sys
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, ValidationError
+
+# Add packages to path for imports
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
+
+try:
+    from creator_service.project_service import project_service
+except ImportError:
+    from project_service import project_service
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+class CreateProjectRequest(BaseModel):
+    title: str
+    source_type: Literal["idea", "markdown", "url"]
+    idea_brief: str | None = None
+    markdown_source: str | None = None
+    url_source: str | None = None
+
+
+@router.post("", status_code=201)
+async def create_project(payload: dict[str, object]) -> dict[str, object]:
+    try:
+        request = CreateProjectRequest.model_validate(payload)
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        project = await project_service.create_project(
+            title=request.title,
+            source_type=request.source_type,
+            idea_brief=request.idea_brief,
+            markdown_source=request.markdown_source,
+            url_source=request.url_source,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return project.model_dump(mode="json")
+
+
+@router.get("/{project_id}")
+async def get_project_detail(project_id: int) -> dict[str, object]:
+    project = await project_service.get_project(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    return project.model_dump(mode="json")
+
+
+@router.get("")
+async def list_projects(
+    limit: int = Query(default=20, ge=0),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, object]:
+    projects = await project_service.list_projects(limit=limit, offset=offset)
+    return {
+        "projects": [project.model_dump(mode="json") for project in projects],
+        "total": len(projects),
+    }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -29,10 +29,7 @@ def dispatch_generate_script(
 
     Separated into a function so tests can monkeypatch without importing Celery.
     """
-    # Lazy import — Celery is not available in test/API-only environments
     from importlib import import_module
-
-    from celery import Celery  # noqa: F401
 
     tasks = import_module("tasks.generate_script")
     result = tasks.generate_script.delay(run_id, idea_brief, model_key, instructions)
@@ -122,49 +119,61 @@ async def generate_script_trigger(run_id: int, request: GenerateScriptRequest) -
         raise HTTPException(status_code=404, detail="Run not found")
 
     # 2. Validate stage — only IDEA_READY and SCRIPT_REVIEW can trigger generation
-    allowed = {"IDEA_READY", "SCRIPT_REVIEW"}
-    if run.current_stage not in allowed:
+    allowed_stages = frozenset({"IDEA_READY", "SCRIPT_REVIEW"})
+    if run.current_stage not in allowed_stages:
         raise HTTPException(
             status_code=400,
             detail=f"Run is in stage '{run.current_stage}', "
-            f"expected one of {sorted(allowed)}",
+            f"expected one of {sorted(allowed_stages)}",
         )
 
-    # 3. Advance to SCRIPT_GENERATING
-    #    - IDEA_READY → forward progression (advance_stage)
-    #    - SCRIPT_REVIEW → re-generation (restart_run sets restart_from)
-    try:
-        if run.current_stage == "IDEA_READY":
-            updated_run = await run_service.advance_stage(
-                run_id=run_id, target_stage="SCRIPT_GENERATING"
-            )
-        else:
-            updated_run = await run_service.restart_run(
-                run_id=run_id, from_stage="SCRIPT_GENERATING"
-            )
-    except ValueError as exc:
-        detail = str(exc)
-        if "not found" in detail.lower():
-            raise HTTPException(status_code=404, detail=detail) from exc
-        raise HTTPException(status_code=400, detail=detail) from exc
-
-    # 4. Get project for idea_brief
-    project = await project_service.get_project(updated_run.project_id)
+    # 3. Resolve all preconditions BEFORE mutating state
+    project = await project_service.get_project(run.project_id)
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
     idea_brief = project.idea_brief or project.title or ""
 
-    # 5. Dispatch Celery task
-    task_id = dispatch_generate_script(
-        run_id=run_id,
-        idea_brief=idea_brief,
-        model_key=request.model_key,
-        instructions=request.instructions,
+    # 4. Atomically advance to SCRIPT_GENERATING via CAS
+    #    Prevents duplicate dispatch from concurrent requests.
+    #    For SCRIPT_REVIEW restarts, also set restart_from.
+    updates: dict[str, object] = {"current_stage": "SCRIPT_GENERATING"}
+    if run.current_stage == "SCRIPT_REVIEW":
+        updates["restart_from"] = "SCRIPT_GENERATING"
+
+    ok, row = await run_service.storage.conditional_update_run(
+        run_id, updates, expected_stages=allowed_stages,
     )
+    if not ok:
+        if row is None:
+            raise HTTPException(status_code=404, detail="Run not found")
+        raise HTTPException(
+            status_code=409,
+            detail=f"Stage conflict: run is now in '{row.get('current_stage')}'",
+        )
+
+    # 5. Dispatch Celery task — if this fails, roll back stage
+    try:
+        task_id = dispatch_generate_script(
+            run_id=run_id,
+            idea_brief=idea_brief,
+            model_key=request.model_key,
+            instructions=request.instructions,
+        )
+    except Exception:
+        # Best-effort rollback: restore original stage so run isn't stuck
+        await run_service.storage.conditional_update_run(
+            run_id,
+            {"current_stage": run.current_stage, "restart_from": run.restart_from},
+            expected_stages=frozenset({"SCRIPT_GENERATING"}),
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue script generation task",
+        ) from None
 
     return {
         "task_id": task_id,
         "run_id": run_id,
-        "current_stage": updated_run.current_stage,
+        "current_stage": "SCRIPT_GENERATING",
     }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -13,11 +13,30 @@ sys.path.insert(0, _PACKAGES_DIR)
 sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
 
 try:
+    from creator_service.project_service import project_service
     from creator_service.run_service import run_service
     from creator_service.stage_review_service import stage_review_service
 except ImportError:
+    from project_service import project_service
     from run_service import run_service
     from stage_review_service import stage_review_service
+
+
+def dispatch_generate_script(
+    run_id: int, idea_brief: str, model_key: str, instructions: str | None
+) -> str:
+    """Dispatch generate_script Celery task. Returns task id.
+
+    Separated into a function so tests can monkeypatch without importing Celery.
+    """
+    # Lazy import — Celery is not available in test/API-only environments
+    from importlib import import_module
+
+    from celery import Celery  # noqa: F401
+
+    tasks = import_module("tasks.generate_script")
+    result = tasks.generate_script.delay(run_id, idea_brief, model_key, instructions)
+    return str(result.id)
 
 router = APIRouter(tags=["runs"])
 
@@ -36,6 +55,10 @@ class ApproveScriptRequest(BaseModel):
     reviewer: str = "agent"
     notes: str | None = None
 
+
+class GenerateScriptRequest(BaseModel):
+    model_key: str = "qwen3-4b"
+    instructions: str | None = None
 
 @router.post("/projects/{project_id}/runs", status_code=201)
 async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
@@ -89,3 +112,59 @@ async def approve_script(run_id: int, request: ApproveScriptRequest) -> dict[str
         raise HTTPException(status_code=400, detail=detail) from exc
 
     return updated_run.model_dump(mode="json")
+
+
+@router.post("/runs/{run_id}/generate-script", status_code=202)
+async def generate_script_trigger(run_id: int, request: GenerateScriptRequest) -> dict[str, object]:
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Validate stage — only IDEA_READY and SCRIPT_REVIEW can trigger generation
+    allowed = {"IDEA_READY", "SCRIPT_REVIEW"}
+    if run.current_stage not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed)}",
+        )
+
+    # 3. Advance to SCRIPT_GENERATING
+    #    - IDEA_READY → forward progression (advance_stage)
+    #    - SCRIPT_REVIEW → re-generation (restart_run sets restart_from)
+    try:
+        if run.current_stage == "IDEA_READY":
+            updated_run = await run_service.advance_stage(
+                run_id=run_id, target_stage="SCRIPT_GENERATING"
+            )
+        else:
+            updated_run = await run_service.restart_run(
+                run_id=run_id, from_stage="SCRIPT_GENERATING"
+            )
+    except ValueError as exc:
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
+
+    # 4. Get project for idea_brief
+    project = await project_service.get_project(updated_run.project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    idea_brief = project.idea_brief or project.title or ""
+
+    # 5. Dispatch Celery task
+    task_id = dispatch_generate_script(
+        run_id=run_id,
+        idea_brief=idea_brief,
+        model_key=request.model_key,
+        instructions=request.instructions,
+    )
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "current_stage": updated_run.current_stage,
+    }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -71,35 +71,21 @@ async def restart_run(run_id: int, request: RestartRunRequest) -> dict[str, obje
 
 @router.post("/runs/{run_id}/approve-script")
 async def approve_script(run_id: int, request: ApproveScriptRequest) -> dict[str, object]:
-    # 1. Check run exists
-    run = await run_service.get_run(run_id)
-    if run is None:
-        raise HTTPException(status_code=404, detail="Run not found")
-
-    # 2. Check run is in SCRIPT_REVIEW stage
-    if run.current_stage != "SCRIPT_REVIEW":
-        raise HTTPException(
-            status_code=400,
-            detail=f"Run is in stage '{run.current_stage}', expected 'SCRIPT_REVIEW'",
-        )
-
-    # 3. Record approval
     try:
-        await stage_review_service.record_approval(
+        updated_run = await stage_review_service.approve_and_advance(
+            run_service=run_service,
             run_id=run_id,
             stage_name="SCRIPT_REVIEW",
+            target_stage="VISUAL_PLAN_GENERATING",
             reviewer=request.reviewer,
             notes=request.notes,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    # 4. Advance stage: SCRIPT_REVIEW → VISUAL_PLAN_GENERATING
-    try:
-        updated_run = await run_service.advance_stage(
-            run_id=run_id, target_stage="VISUAL_PLAN_GENERATING"
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=500, detail=f"Failed to advance stage: {exc}") from exc
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        if "conflict" in detail.lower():
+            raise HTTPException(status_code=409, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
 
     return updated_run.model_dump(mode="json")

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -1,1 +1,59 @@
-"""Placeholder for creator_runs."""
+"""Routes for creator run management."""
+# pyright: reportMissingImports=false
+
+import os
+import sys
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+# Add packages to path for imports
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+
+try:
+    from creator_service.run_service import run_service
+except ImportError:
+    from run_service import run_service
+
+router = APIRouter(tags=["runs"])
+
+
+class CreateRunRequest(BaseModel):
+    model_defaults: dict[str, str] | None = None
+    style_preset: str = "default"
+    metadata: dict[str, object] | None = None
+
+
+class RestartRunRequest(BaseModel):
+    stage: str
+
+
+@router.post("/projects/{project_id}/runs", status_code=201)
+async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
+    run = await run_service.create_run(
+        project_id=project_id,
+        model_defaults=request.model_defaults,
+        style_preset=request.style_preset,
+        metadata=request.metadata,
+    )
+    return run.model_dump(mode="json")
+
+
+@router.get("/runs/{run_id}")
+async def get_run_detail(run_id: int) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return run.model_dump(mode="json")
+
+
+@router.post("/runs/{run_id}/restart")
+async def restart_run(run_id: int, request: RestartRunRequest) -> dict[str, object]:
+    try:
+        run = await run_service.restart_run(run_id=run_id, from_stage=request.stage)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return run.model_dump(mode="json")

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -17,11 +17,17 @@ try:
     from creator_service.run_service import run_service
     from creator_service.stage_review_service import stage_review_service
     from creator_service.visual_asset_service import visual_asset_service
+    from creator_service.render_service import render_service
+    from creator_service.audio_service import audio_service
+    from creator_service.subtitle_service import subtitle_service
 except ImportError:
     from project_service import project_service
     from run_service import run_service
     from stage_review_service import stage_review_service
     from visual_asset_service import visual_asset_service
+    from render_service import render_service
+    from audio_service import audio_service
+    from subtitle_service import subtitle_service
 
 
 def dispatch_generate_script(
@@ -73,6 +79,18 @@ def dispatch_generate_subtitles(run_id: int, subtitle_model: str, subtitle_forma
     tasks = import_module("tasks.generate_subtitles")
     result = tasks.generate_subtitles.delay(run_id, subtitle_model=subtitle_model, subtitle_format=subtitle_format)
     return str(result.id)
+
+
+def dispatch_render_video(run_id: int, render_profile: str) -> str:
+    """Dispatch render_video Celery task. Returns task id.
+
+    Separated into a function so tests can monkeypatch without importing Celery.
+    """
+    from importlib import import_module
+
+    tasks = import_module("tasks.render_video")
+    result = tasks.render_video.delay(run_id, render_profile=render_profile)
+    return str(result.id)
 router = APIRouter(tags=["runs"])
 
 
@@ -113,6 +131,11 @@ class GenerateAudioRequest(BaseModel):
 class GenerateSubtitlesRequest(BaseModel):
     subtitle_model: str = "whisper-tiny"
     subtitle_format: str = "srt"
+
+
+class RenderRequest(BaseModel):
+    render_profile: str = "shorts_default"
+
 @router.post("/projects/{project_id}/runs", status_code=201)
 async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
     run = await run_service.create_run(
@@ -683,4 +706,97 @@ async def generate_subtitles_trigger(run_id: int, request: GenerateSubtitlesRequ
         "task_id": task_id,
         "run_id": run_id,
         "current_stage": "SUBTITLE_GENERATING",
+    }
+
+
+@router.post("/runs/{run_id}/render", status_code=202)
+async def render_trigger(run_id: int, request: RenderRequest) -> dict[str, object]:
+    """Trigger video rendering for a run."""
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Validate stage — SUBTITLE_GENERATING (after subtitles done) or RENDER_GENERATING (retry)
+    allowed_stages = frozenset({"SUBTITLE_GENERATING", "RENDER_GENERATING"})
+    if run.current_stage not in allowed_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed_stages)}",
+        )
+
+    # 3. Atomically advance to RENDER_GENERATING via CAS
+    updates: dict[str, object] = {"current_stage": "RENDER_GENERATING"}
+    if run.current_stage == "RENDER_GENERATING":
+        updates["restart_from"] = "RENDER_GENERATING"
+
+    ok, row = await run_service.storage.conditional_update_run(
+        run_id, updates, expected_stages=allowed_stages,
+    )
+    if not ok:
+        if row is None:
+            raise HTTPException(status_code=404, detail="Run not found")
+        raise HTTPException(
+            status_code=409,
+            detail="Stage conflict: run is now in '" + str(row.get('current_stage')) + "'",
+        )
+
+    # 4. Dispatch Celery task — if this fails, roll back stage
+    try:
+        task_id = dispatch_render_video(
+            run_id=run_id,
+            render_profile=request.render_profile,
+        )
+    except Exception:
+        # Best-effort rollback: restore original stage so run isn't stuck
+        await run_service.storage.conditional_update_run(
+            run_id,
+            {"current_stage": run.current_stage, "restart_from": run.restart_from},
+            expected_stages=frozenset({"RENDER_GENERATING"}),
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue render task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "current_stage": "RENDER_GENERATING",
+    }
+
+
+@router.get("/runs/{run_id}/preview")
+async def get_preview(run_id: int) -> dict[str, object]:
+    """Return latest video, audio, and subtitle artifact metadata for preview."""
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    video = await render_service.get_latest(run_id)
+    audio = await audio_service.get_latest(run_id)
+    subtitle = await subtitle_service.get_latest(run_id)
+
+    return {
+        "run_id": run_id,
+        "current_stage": run.current_stage,
+        "video": {
+            "id": video.id,
+            "path": video.path,
+            "render_profile": video.render_profile,
+            "created_at": str(video.created_at),
+        } if video else None,
+        "audio": {
+            "id": audio.id,
+            "path": audio.path,
+            "model_used": audio.model_used,
+            "created_at": str(audio.created_at),
+        } if audio else None,
+        "subtitle": {
+            "id": subtitle.id,
+            "path": subtitle.path,
+            "format": subtitle.format,
+            "created_at": str(subtitle.created_at),
+        } if subtitle else None,
     }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -68,6 +68,15 @@ async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, ob
     return run.model_dump(mode="json")
 
 
+@router.get("/projects/{project_id}/runs")
+async def list_runs_for_project(project_id: int) -> dict[str, object]:
+    runs = await run_service.list_runs_by_project(project_id)
+    return {
+        "runs": [r.model_dump(mode="json") for r in runs],
+        "total": len(runs),
+    }
+
+
 @router.get("/runs/{run_id}")
 async def get_run_detail(run_id: int) -> dict[str, object]:
     run = await run_service.get_run(run_id)

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -505,3 +505,30 @@ async def list_visual_assets_by_scene(run_id: int, scene_id: str) -> dict[str, o
         "assets": [a.model_dump(mode="json") for a in assets],
         "total": len(assets),
     }
+
+
+@router.post("/runs/{run_id}/visual-assets/{scene_id}/select/{asset_id}")
+async def select_active_asset(run_id: int, scene_id: str, asset_id: int) -> dict[str, object]:
+    """Set the given asset as active for its scene, deactivating others."""
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # Only allow selection during asset review
+    allowed_stages = frozenset({"VISUAL_ASSET_REVIEW", "VISUAL_ASSET_GENERATING"})
+    if run.current_stage not in allowed_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed_stages)}",
+        )
+
+    try:
+        asset = await visual_asset_service.select_active(run_id, scene_id, asset_id)
+    except ValueError as exc:
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
+
+    return asset.model_dump(mode="json")

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -14,8 +14,10 @@ sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
 
 try:
     from creator_service.run_service import run_service
+    from creator_service.stage_review_service import stage_review_service
 except ImportError:
     from run_service import run_service
+    from stage_review_service import stage_review_service
 
 router = APIRouter(tags=["runs"])
 
@@ -28,6 +30,11 @@ class CreateRunRequest(BaseModel):
 
 class RestartRunRequest(BaseModel):
     stage: str
+
+
+class ApproveScriptRequest(BaseModel):
+    reviewer: str = "agent"
+    notes: str | None = None
 
 
 @router.post("/projects/{project_id}/runs", status_code=201)
@@ -60,3 +67,39 @@ async def restart_run(run_id: int, request: RestartRunRequest) -> dict[str, obje
         raise HTTPException(status_code=400, detail=detail) from exc
 
     return run.model_dump(mode="json")
+
+
+@router.post("/runs/{run_id}/approve-script")
+async def approve_script(run_id: int, request: ApproveScriptRequest) -> dict[str, object]:
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Check run is in SCRIPT_REVIEW stage
+    if run.current_stage != "SCRIPT_REVIEW":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', expected 'SCRIPT_REVIEW'",
+        )
+
+    # 3. Record approval
+    try:
+        await stage_review_service.record_approval(
+            run_id=run_id,
+            stage_name="SCRIPT_REVIEW",
+            reviewer=request.reviewer,
+            notes=request.notes,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # 4. Advance stage: SCRIPT_REVIEW → VISUAL_PLAN_GENERATING
+    try:
+        updated_run = await run_service.restart_run(
+            run_id=run_id, from_stage="VISUAL_PLAN_GENERATING"
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to advance stage: {exc}") from exc
+
+    return updated_run.model_dump(mode="json")

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -285,3 +285,87 @@ async def generate_visual_plan_trigger(run_id: int, request: GenerateVisualPlanR
         "run_id": run_id,
         "current_stage": "VISUAL_PLAN_GENERATING",
     }
+
+
+class GenerateVisualAssetsRequest(BaseModel):
+    model_key: str = "sd15"
+
+
+def dispatch_generate_scene_image(
+    run_id: int, model_key: str, scene_id: str | None, prompt_override: str | None, is_active: bool
+) -> str:
+    """Dispatch generate_scene_image Celery task. Returns task id.
+
+    Separated into a function so tests can monkeypatch without importing Celery.
+    """
+    from importlib import import_module
+
+    tasks = import_module("tasks.generate_scene_image")
+    result = tasks.generate_scene_image.delay(
+        run_id, scene_id=scene_id, model_key=model_key,
+        prompt_override=prompt_override, is_active=is_active,
+    )
+    return str(result.id)
+
+
+@router.post("/runs/{run_id}/generate-visual-assets", status_code=202)
+async def generate_visual_assets_trigger(
+    run_id: int, request: GenerateVisualAssetsRequest
+) -> dict[str, object]:
+    """Generate images for all scenes in the approved visual plan."""
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Validate stage
+    allowed_stages = frozenset({"VISUAL_PLAN_REVIEW", "VISUAL_ASSET_GENERATING"})
+    if run.current_stage not in allowed_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed_stages)}",
+        )
+
+    # 3. Atomically advance to VISUAL_ASSET_GENERATING via CAS
+    updates: dict[str, object] = {"current_stage": "VISUAL_ASSET_GENERATING"}
+    if run.current_stage == "VISUAL_ASSET_GENERATING":
+        updates["restart_from"] = "VISUAL_ASSET_GENERATING"
+
+    ok, row = await run_service.storage.conditional_update_run(
+        run_id, updates, expected_stages=allowed_stages,
+    )
+    if not ok:
+        if row is None:
+            raise HTTPException(status_code=404, detail="Run not found")
+        raise HTTPException(
+            status_code=409,
+            detail=f"Stage conflict: run is now in '{row.get('current_stage')}'",
+        )
+
+    # 4. Dispatch Celery task — if this fails, roll back stage
+    try:
+        task_id = dispatch_generate_scene_image(
+            run_id=run_id,
+            model_key=request.model_key,
+            scene_id=None,  # all scenes
+            prompt_override=None,
+            is_active=True,
+        )
+    except Exception:
+        # Best-effort rollback: restore original stage so run isn't stuck
+        await run_service.storage.conditional_update_run(
+            run_id,
+            {"current_stage": run.current_stage, "restart_from": run.restart_from},
+            expected_stages=frozenset({"VISUAL_ASSET_GENERATING"}),
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue image generation task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "current_stage": "VISUAL_ASSET_GENERATING",
+    }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -96,8 +96,8 @@ async def approve_script(run_id: int, request: ApproveScriptRequest) -> dict[str
 
     # 4. Advance stage: SCRIPT_REVIEW → VISUAL_PLAN_GENERATING
     try:
-        updated_run = await run_service.restart_run(
-            run_id=run_id, from_stage="VISUAL_PLAN_GENERATING"
+        updated_run = await run_service.advance_stage(
+            run_id=run_id, target_stage="VISUAL_PLAN_GENERATING"
         )
     except ValueError as exc:
         raise HTTPException(status_code=500, detail=f"Failed to advance stage: {exc}") from exc

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -61,6 +61,18 @@ def dispatch_generate_audio(run_id: int, tts_model: str, voice: str) -> str:
     tasks = import_module("tasks.generate_audio")
     result = tasks.generate_audio.delay(run_id, tts_model=tts_model, voice=voice)
     return str(result.id)
+
+
+def dispatch_generate_subtitles(run_id: int, subtitle_model: str, subtitle_format: str) -> str:
+    """Dispatch generate_subtitles Celery task. Returns task id.
+
+    Separated into a function so tests can monkeypatch without importing Celery.
+    """
+    from importlib import import_module
+
+    tasks = import_module("tasks.generate_subtitles")
+    result = tasks.generate_subtitles.delay(run_id, subtitle_model=subtitle_model, subtitle_format=subtitle_format)
+    return str(result.id)
 router = APIRouter(tags=["runs"])
 
 
@@ -97,6 +109,10 @@ class GenerateAudioRequest(BaseModel):
     tts_model: str = "piper"
     voice: str = "en_US-lessac-medium"
 
+
+class GenerateSubtitlesRequest(BaseModel):
+    subtitle_model: str = "whisper-tiny"
+    subtitle_format: str = "srt"
 @router.post("/projects/{project_id}/runs", status_code=201)
 async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
     run = await run_service.create_run(
@@ -608,4 +624,63 @@ async def generate_audio_trigger(run_id: int, request: GenerateAudioRequest) -> 
         "task_id": task_id,
         "run_id": run_id,
         "current_stage": "AUDIO_GENERATING",
+    }
+
+
+@router.post("/runs/{run_id}/generate-subtitles", status_code=202)
+async def generate_subtitles_trigger(run_id: int, request: GenerateSubtitlesRequest) -> dict[str, object]:
+    """Trigger subtitle generation for a run."""
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Validate stage — AUDIO_GENERATING (after audio done) or SUBTITLE_GENERATING (retry)
+    allowed_stages = frozenset({"AUDIO_GENERATING", "SUBTITLE_GENERATING"})
+    if run.current_stage not in allowed_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed_stages)}",
+        )
+
+    # 3. Atomically advance to SUBTITLE_GENERATING via CAS
+    updates: dict[str, object] = {"current_stage": "SUBTITLE_GENERATING"}
+    if run.current_stage == "SUBTITLE_GENERATING":
+        updates["restart_from"] = "SUBTITLE_GENERATING"
+
+    ok, row = await run_service.storage.conditional_update_run(
+        run_id, updates, expected_stages=allowed_stages,
+    )
+    if not ok:
+        if row is None:
+            raise HTTPException(status_code=404, detail="Run not found")
+        raise HTTPException(
+            status_code=409,
+            detail="Stage conflict: run is now in '" + str(row.get('current_stage')) + "'",
+        )
+
+    # 4. Dispatch Celery task — if this fails, roll back stage
+    try:
+        task_id = dispatch_generate_subtitles(
+            run_id=run_id,
+            subtitle_model=request.subtitle_model,
+            subtitle_format=request.subtitle_format,
+        )
+    except Exception:
+        # Best-effort rollback: restore original stage so run isn't stuck
+        await run_service.storage.conditional_update_run(
+            run_id,
+            {"current_stage": run.current_stage, "restart_from": run.restart_from},
+            expected_stages=frozenset({"SUBTITLE_GENERATING"}),
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue subtitle generation task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "current_stage": "SUBTITLE_GENERATING",
     }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -49,6 +49,18 @@ def dispatch_generate_visual_plan(
     tasks = import_module("tasks.generate_visual_plan")
     result = tasks.generate_visual_plan.delay(run_id, model_key, style_preset)
     return str(result.id)
+
+
+def dispatch_generate_audio(run_id: int, tts_model: str, voice: str) -> str:
+    """Dispatch generate_audio Celery task. Returns task id.
+
+    Separated into a function so tests can monkeypatch without importing Celery.
+    """
+    from importlib import import_module
+
+    tasks = import_module("tasks.generate_audio")
+    result = tasks.generate_audio.delay(run_id, tts_model=tts_model, voice=voice)
+    return str(result.id)
 router = APIRouter(tags=["runs"])
 
 
@@ -79,6 +91,12 @@ class GenerateScriptRequest(BaseModel):
 class GenerateVisualPlanRequest(BaseModel):
     model_key: str = "qwen3-4b"
     style_preset: str | None = None
+
+
+class GenerateAudioRequest(BaseModel):
+    tts_model: str = "piper"
+    voice: str = "en_US-lessac-medium"
+
 @router.post("/projects/{project_id}/runs", status_code=201)
 async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
     run = await run_service.create_run(
@@ -532,3 +550,62 @@ async def select_active_asset(run_id: int, scene_id: str, asset_id: int) -> dict
         raise HTTPException(status_code=400, detail=detail) from exc
 
     return asset.model_dump(mode="json")
+
+
+@router.post("/runs/{run_id}/generate-audio", status_code=202)
+async def generate_audio_trigger(run_id: int, request: GenerateAudioRequest) -> dict[str, object]:
+    """Trigger TTS audio generation for a run."""
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Validate stage — VISUAL_ASSET_REVIEW (after approval) or AUDIO_GENERATING (retry)
+    allowed_stages = frozenset({"VISUAL_ASSET_REVIEW", "AUDIO_GENERATING"})
+    if run.current_stage not in allowed_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed_stages)}",
+        )
+
+    # 3. Atomically advance to AUDIO_GENERATING via CAS
+    updates: dict[str, object] = {"current_stage": "AUDIO_GENERATING"}
+    if run.current_stage == "AUDIO_GENERATING":
+        updates["restart_from"] = "AUDIO_GENERATING"
+
+    ok, row = await run_service.storage.conditional_update_run(
+        run_id, updates, expected_stages=allowed_stages,
+    )
+    if not ok:
+        if row is None:
+            raise HTTPException(status_code=404, detail="Run not found")
+        raise HTTPException(
+            status_code=409,
+            detail=f"Stage conflict: run is now in '{row.get('current_stage')}'",
+        )
+
+    # 4. Dispatch Celery task — if this fails, roll back stage
+    try:
+        task_id = dispatch_generate_audio(
+            run_id=run_id,
+            tts_model=request.tts_model,
+            voice=request.voice,
+        )
+    except Exception:
+        # Best-effort rollback: restore original stage so run isn't stuck
+        await run_service.storage.conditional_update_run(
+            run_id,
+            {"current_stage": run.current_stage, "restart_from": run.restart_from},
+            expected_stages=frozenset({"AUDIO_GENERATING"}),
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue audio generation task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "current_stage": "AUDIO_GENERATING",
+    }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -16,10 +16,12 @@ try:
     from creator_service.project_service import project_service
     from creator_service.run_service import run_service
     from creator_service.stage_review_service import stage_review_service
+    from creator_service.visual_asset_service import visual_asset_service
 except ImportError:
     from project_service import project_service
     from run_service import run_service
     from stage_review_service import stage_review_service
+    from visual_asset_service import visual_asset_service
 
 
 def dispatch_generate_script(
@@ -467,4 +469,39 @@ async def regenerate_scene_image_endpoint(
         "run_id": run_id,
         "scene_id": scene_id,
         "current_stage": run.current_stage,
+    }
+
+
+@router.get("/runs/{run_id}/visual-assets")
+async def list_visual_assets_by_run(run_id: int) -> dict[str, object]:
+    """List all visual assets for a run, grouped by scene_id."""
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    grouped = await visual_asset_service.list_by_run(run_id)
+    return {
+        "run_id": run_id,
+        "scenes": {
+            scene_id: [a.model_dump(mode="json") for a in assets]
+            for scene_id, assets in grouped.items()
+        },
+        "total_scenes": len(grouped),
+        "total_assets": sum(len(assets) for assets in grouped.values()),
+    }
+
+
+@router.get("/runs/{run_id}/visual-assets/{scene_id}")
+async def list_visual_assets_by_scene(run_id: int, scene_id: str) -> dict[str, object]:
+    """List all asset versions for a single scene, newest first."""
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    assets = await visual_asset_service.list_by_scene(run_id, scene_id)
+    return {
+        "run_id": run_id,
+        "scene_id": scene_id,
+        "assets": [a.model_dump(mode="json") for a in assets],
+        "total": len(assets),
     }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -64,6 +64,10 @@ class ApproveScriptRequest(BaseModel):
     reviewer: str = "agent"
     notes: str | None = None
 
+class ApproveVisualPlanRequest(BaseModel):
+    reviewer: str = "agent"
+    notes: str | None = None
+
 
 class GenerateScriptRequest(BaseModel):
     model_key: str = "qwen3-4b"
@@ -135,6 +139,27 @@ async def approve_script(run_id: int, request: ApproveScriptRequest) -> dict[str
 
     return updated_run.model_dump(mode="json")
 
+
+@router.post("/runs/{run_id}/approve-visual-plan")
+async def approve_visual_plan(run_id: int, request: ApproveVisualPlanRequest) -> dict[str, object]:
+    try:
+        updated_run = await stage_review_service.approve_and_advance(
+            run_service=run_service,
+            run_id=run_id,
+            stage_name="VISUAL_PLAN_REVIEW",
+            target_stage="VISUAL_ASSET_GENERATING",
+            reviewer=request.reviewer,
+            notes=request.notes,
+        )
+    except ValueError as exc:
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        if "conflict" in detail.lower():
+            raise HTTPException(status_code=409, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
+
+    return updated_run.model_dump(mode="json")
 
 @router.post("/runs/{run_id}/generate-script", status_code=202)
 async def generate_script_trigger(run_id: int, request: GenerateScriptRequest) -> dict[str, object]:

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -369,3 +369,102 @@ async def generate_visual_assets_trigger(
         "run_id": run_id,
         "current_stage": "VISUAL_ASSET_GENERATING",
     }
+
+
+class RegenerateSceneImageRequest(BaseModel):
+    model_key: str = "sd15"
+    prompt_override: str | None = None
+
+
+@router.post(
+    "/runs/{run_id}/visual-plan/scenes/{scene_id}/generate-image",
+    status_code=202,
+)
+async def generate_scene_image_endpoint(
+    run_id: int, scene_id: str
+) -> dict[str, object]:
+    """Generate an image for a single scene that hasn't been generated yet."""
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Validate stage
+    allowed_stages = frozenset({"VISUAL_PLAN_REVIEW", "VISUAL_ASSET_GENERATING", "VISUAL_ASSET_REVIEW"})
+    if run.current_stage not in allowed_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed_stages)}",
+        )
+
+    # 3. Dispatch single-scene generation (no stage transition — stays in current stage)
+    try:
+        task_id = dispatch_generate_scene_image(
+            run_id=run_id,
+            model_key="sd15",
+            scene_id=scene_id,
+            prompt_override=None,
+            is_active=True,
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue image generation task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "scene_id": scene_id,
+        "current_stage": run.current_stage,
+    }
+
+
+@router.post(
+    "/runs/{run_id}/visual-plan/scenes/{scene_id}/regenerate-image",
+    status_code=202,
+)
+async def regenerate_scene_image_endpoint(
+    run_id: int, scene_id: str, request: RegenerateSceneImageRequest
+) -> dict[str, object]:
+    """Regenerate an image for a single scene with optional model/prompt override.
+
+    Regenerated assets are created as inactive by default so the user can
+    compare versions before selecting the active one.
+    """
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Validate stage — regeneration only allowed during asset review
+    allowed_stages = frozenset({"VISUAL_ASSET_REVIEW", "VISUAL_ASSET_GENERATING"})
+    if run.current_stage not in allowed_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed_stages)}",
+        )
+
+    # 3. Dispatch single-scene regeneration (inactive by default)
+    try:
+        task_id = dispatch_generate_scene_image(
+            run_id=run_id,
+            model_key=request.model_key,
+            scene_id=scene_id,
+            prompt_override=request.prompt_override,
+            is_active=False,  # regenerated assets are inactive until selected
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue image generation task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "scene_id": scene_id,
+        "current_stage": run.current_stage,
+    }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -35,6 +35,18 @@ def dispatch_generate_script(
     result = tasks.generate_script.delay(run_id, idea_brief, model_key, instructions)
     return str(result.id)
 
+def dispatch_generate_visual_plan(
+    run_id: int, model_key: str, style_preset: str | None
+) -> str:
+    """Dispatch generate_visual_plan Celery task. Returns task id.
+
+    Separated into a function so tests can monkeypatch without importing Celery.
+    """
+    from importlib import import_module
+
+    tasks = import_module("tasks.generate_visual_plan")
+    result = tasks.generate_visual_plan.delay(run_id, model_key, style_preset)
+    return str(result.id)
 router = APIRouter(tags=["runs"])
 
 
@@ -57,6 +69,10 @@ class GenerateScriptRequest(BaseModel):
     model_key: str = "qwen3-4b"
     instructions: str | None = None
 
+
+class GenerateVisualPlanRequest(BaseModel):
+    model_key: str = "qwen3-4b"
+    style_preset: str | None = None
 @router.post("/projects/{project_id}/runs", status_code=201)
 async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
     run = await run_service.create_run(
@@ -185,4 +201,62 @@ async def generate_script_trigger(run_id: int, request: GenerateScriptRequest) -
         "task_id": task_id,
         "run_id": run_id,
         "current_stage": "SCRIPT_GENERATING",
+    }
+
+
+@router.post("/runs/{run_id}/generate-visual-plan", status_code=202)
+async def generate_visual_plan_trigger(run_id: int, request: GenerateVisualPlanRequest) -> dict[str, object]:
+    # 1. Check run exists
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Validate stage — SCRIPT_REVIEW (after approval) or VISUAL_PLAN_GENERATING (retry)
+    allowed_stages = frozenset({"SCRIPT_REVIEW", "VISUAL_PLAN_GENERATING"})
+    if run.current_stage not in allowed_stages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Run is in stage '{run.current_stage}', "
+            f"expected one of {sorted(allowed_stages)}",
+        )
+
+    # 3. Atomically advance to VISUAL_PLAN_GENERATING via CAS
+    updates: dict[str, object] = {"current_stage": "VISUAL_PLAN_GENERATING"}
+    if run.current_stage == "VISUAL_PLAN_GENERATING":
+        updates["restart_from"] = "VISUAL_PLAN_GENERATING"
+
+    ok, row = await run_service.storage.conditional_update_run(
+        run_id, updates, expected_stages=allowed_stages,
+    )
+    if not ok:
+        if row is None:
+            raise HTTPException(status_code=404, detail="Run not found")
+        raise HTTPException(
+            status_code=409,
+            detail=f"Stage conflict: run is now in '{row.get('current_stage')}'",
+        )
+
+    # 4. Dispatch Celery task — if this fails, roll back stage
+    try:
+        task_id = dispatch_generate_visual_plan(
+            run_id=run_id,
+            model_key=request.model_key,
+            style_preset=request.style_preset,
+        )
+    except Exception:
+        # Best-effort rollback: restore original stage so run isn't stuck
+        await run_service.storage.conditional_update_run(
+            run_id,
+            {"current_stage": run.current_stage, "restart_from": run.restart_from},
+            expected_stages=frozenset({"VISUAL_PLAN_GENERATING"}),
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue visual plan generation task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "current_stage": "VISUAL_PLAN_GENERATING",
     }

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -54,6 +54,9 @@ async def restart_run(run_id: int, request: RestartRunRequest) -> dict[str, obje
     try:
         run = await run_service.restart_run(run_id=run_id, from_stage=request.stage)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
 
     return run.model_dump(mode="json")

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -1,1 +1,67 @@
-"""Placeholder for creator_script."""
+"""Routes for creator script management."""
+# pyright: reportMissingImports=false
+
+import os
+import sys
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+# Add packages to path for imports
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
+
+try:
+    from creator_service.project_service import project_service
+except ImportError:
+    from project_service import project_service
+
+try:
+    from creator_service.run_service import run_service
+except ImportError:
+    from run_service import run_service
+
+try:
+    from creator_service.script_service import script_service
+except ImportError:
+    from script_service import script_service
+
+router = APIRouter(prefix="/projects/{project_id}/script", tags=["script"])
+
+
+class ImportMarkdownRequest(BaseModel):
+    markdown: str
+    model_defaults: dict[str, str] | None = None
+    style_preset: str = "default"
+
+
+@router.post("/import-markdown", status_code=201)
+async def import_markdown(project_id: int, request: ImportMarkdownRequest) -> dict[str, object]:
+    if not request.markdown.strip():
+        raise HTTPException(status_code=400, detail="markdown content must not be empty")
+
+    project = await project_service.get_project(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    try:
+        run = await run_service.create_run(
+            project_id=project_id,
+            model_defaults=request.model_defaults,
+            style_preset=request.style_preset,
+        )
+        draft = await script_service.save_draft(
+            run_id=run.id,
+            source_type="pasted_markdown",
+            markdown_content=request.markdown,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "project_id": project_id,
+        "run_id": run.id,
+        "draft": draft.model_dump(mode="json"),
+    }

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -5,13 +5,14 @@ import os
 import sys
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 # Add packages to path for imports
 _PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
 sys.path.insert(0, _PACKAGES_DIR)
 sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
 sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-domain"))
 
 try:
     from creator_service.project_service import project_service
@@ -27,6 +28,11 @@ try:
     from creator_service.script_service import script_service
 except ImportError:
     from script_service import script_service
+
+try:
+    from creator_domain.models.script_draft import ScriptSection
+except ImportError:
+    from models.script_draft import ScriptSection
 
 router = APIRouter(prefix="/projects/{project_id}/script", tags=["script"])
 run_script_router = APIRouter(prefix="/runs/{run_id}/script", tags=["script"])
@@ -72,6 +78,10 @@ class UpdateMarkdownRequest(BaseModel):
     markdown: str
 
 
+class UpdateStructuredRequest(BaseModel):
+    sections: list[dict[str, object]]
+
+
 @run_script_router.get("/markdown")
 async def get_script_markdown(run_id: int) -> dict[str, object]:
     run = await run_service.get_run(run_id)
@@ -85,6 +95,23 @@ async def get_script_markdown(run_id: int) -> dict[str, object]:
     return {
         "run_id": run_id,
         "markdown": draft.markdown_content,
+        "version": draft.version,
+    }
+
+
+@run_script_router.get("/structured")
+async def get_script_structured(run_id: int) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    draft = await script_service.get_active_draft(run_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="No script draft found for this run")
+
+    return {
+        "run_id": run_id,
+        "sections": [s.model_dump(mode="json") for s in draft.structured_script] if draft.structured_script else [],
         "version": draft.version,
     }
 
@@ -106,6 +133,32 @@ async def update_script_markdown(run_id: int, request: UpdateMarkdownRequest) ->
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "run_id": run_id,
+        "draft": draft.model_dump(mode="json"),
+    }
+
+
+@run_script_router.put("/structured")
+async def update_script_structured(run_id: int, request: UpdateStructuredRequest) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    try:
+        sections = [ScriptSection.model_validate(section) for section in request.sections]
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    rebuilt_markdown = "\n\n".join([f"## {section.type}\n\n{section.text}" for section in sections])
+
+    draft = await script_service.save_draft(
+        run_id=run_id,
+        source_type="edited_manually",
+        markdown_content=rebuilt_markdown,
+        structured_script=sections,
+    )
 
     return {
         "run_id": run_id,

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -74,6 +74,10 @@ class UpdateMarkdownRequest(BaseModel):
 
 @run_script_router.get("/markdown")
 async def get_script_markdown(run_id: int) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
     draft = await script_service.get_active_draft(run_id)
     if draft is None:
         raise HTTPException(status_code=404, detail="No script draft found for this run")
@@ -89,6 +93,10 @@ async def get_script_markdown(run_id: int) -> dict[str, object]:
 async def update_script_markdown(run_id: int, request: UpdateMarkdownRequest) -> dict[str, object]:
     if not request.markdown.strip():
         raise HTTPException(status_code=400, detail="markdown content must not be empty")
+
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
 
     try:
         draft = await script_service.save_draft(

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -190,7 +190,7 @@ async def parse_script_markdown(run_id: int) -> dict[str, object]:
 
     saved_draft = await script_service.save_draft(
         run_id=run_id,
-        source_type="edited_manually",
+        source_type=draft.source_type,
         markdown_content=draft.markdown_content,
         structured_script=sections,
     )

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -29,6 +29,7 @@ except ImportError:
     from script_service import script_service
 
 router = APIRouter(prefix="/projects/{project_id}/script", tags=["script"])
+run_script_router = APIRouter(prefix="/runs/{run_id}/script", tags=["script"])
 
 
 class ImportMarkdownRequest(BaseModel):
@@ -63,5 +64,42 @@ async def import_markdown(project_id: int, request: ImportMarkdownRequest) -> di
     return {
         "project_id": project_id,
         "run_id": run.id,
+        "draft": draft.model_dump(mode="json"),
+    }
+
+
+class UpdateMarkdownRequest(BaseModel):
+    markdown: str
+
+
+@run_script_router.get("/markdown")
+async def get_script_markdown(run_id: int) -> dict[str, object]:
+    draft = await script_service.get_active_draft(run_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="No script draft found for this run")
+
+    return {
+        "run_id": run_id,
+        "markdown": draft.markdown_content,
+        "version": draft.version,
+    }
+
+
+@run_script_router.put("/markdown")
+async def update_script_markdown(run_id: int, request: UpdateMarkdownRequest) -> dict[str, object]:
+    if not request.markdown.strip():
+        raise HTTPException(status_code=400, detail="markdown content must not be empty")
+
+    try:
+        draft = await script_service.save_draft(
+            run_id=run_id,
+            source_type="edited_manually",
+            markdown_content=request.markdown,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "run_id": run_id,
         "draft": draft.model_dump(mode="json"),
     }

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -30,6 +30,11 @@ except ImportError:
     from script_service import script_service
 
 try:
+    from creator_service.markdown_parser import parse_markdown
+except ImportError:
+    from markdown_parser import parse_markdown
+
+try:
     from creator_domain.models.script_draft import ScriptSection
 except ImportError:
     from models.script_draft import ScriptSection
@@ -163,4 +168,35 @@ async def update_script_structured(run_id: int, request: UpdateStructuredRequest
     return {
         "run_id": run_id,
         "draft": draft.model_dump(mode="json"),
+    }
+
+
+@run_script_router.post("/parse-markdown")
+async def parse_script_markdown(run_id: int) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    draft = await script_service.get_active_draft(run_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="No script draft found for this run")
+
+    if not draft.markdown_content or not draft.markdown_content.strip():
+        raise HTTPException(status_code=400, detail="Draft has no markdown content to parse")
+
+    sections = parse_markdown(
+        draft.markdown_content, existing_sections=draft.structured_script
+    )
+
+    saved_draft = await script_service.save_draft(
+        run_id=run_id,
+        source_type="edited_manually",
+        markdown_content=draft.markdown_content,
+        structured_script=sections,
+    )
+
+    return {
+        "run_id": run_id,
+        "sections": [s.model_dump(mode="json") for s in sections],
+        "version": saved_draft.version,
     }

--- a/apps/api/src/shorts_api/routes/creator_visual_plan.py
+++ b/apps/api/src/shorts_api/routes/creator_visual_plan.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 # Add packages to path for imports
 _PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
@@ -19,9 +19,9 @@ except ImportError:
     from run_service import run_service
 
 try:
-    from creator_service.visual_plan_service import visual_plan_service
+    from creator_service.visual_plan_service import VersionConflictError, visual_plan_service
 except ImportError:
-    from visual_plan_service import visual_plan_service
+    from visual_plan_service import VersionConflictError, visual_plan_service
 
 try:
     from creator_domain.models.visual_plan import VisualScene
@@ -68,6 +68,60 @@ async def replace_visual_plan(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     plan = await visual_plan_service.save_plan(run_id, scenes)
+
+    return {
+        "run_id": run_id,
+        "version": plan.version,
+        "scenes": [s.model_dump(mode="json") for s in plan.scenes],
+    }
+
+
+class PatchSceneRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    prompt: str | None = None
+    prompt_edited: bool | None = None
+    prompt_source: str | None = None
+    style_tags: list[str] | None = None
+    mood: str | None = None
+    composition: str | None = None
+    expected_version: int | None = None
+
+
+@router.patch("/scenes/{scene_id}")
+async def patch_scene(
+    run_id: int, scene_id: str, request: PatchSceneRequest
+) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    # Build updates dict from non-None fields (exclude expected_version)
+    updates = {
+        k: v
+        for k, v in request.model_dump(exclude={"expected_version"}).items()
+        if v is not None
+    }
+    if not updates:
+        raise HTTPException(status_code=400, detail="No patchable fields provided")
+
+    try:
+        plan = await visual_plan_service.patch_scene(
+            run_id=run_id,
+            scene_id=scene_id,
+            updates=updates,
+            expected_version=request.expected_version,
+        )
+    except VersionConflictError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        detail = str(exc)
+        if "not found" in detail.lower() or "no active" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
 
     return {
         "run_id": run_id,

--- a/apps/api/src/shorts_api/routes/creator_visual_plan.py
+++ b/apps/api/src/shorts_api/routes/creator_visual_plan.py
@@ -1,1 +1,76 @@
-"""Placeholder for creator_visual_plan."""
+"""Routes for creator visual plan management."""
+# pyright: reportMissingImports=false
+
+import os
+import sys
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ValidationError
+
+# Add packages to path for imports
+_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
+sys.path.insert(0, _PACKAGES_DIR)
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
+sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-domain"))
+
+try:
+    from creator_service.run_service import run_service
+except ImportError:
+    from run_service import run_service
+
+try:
+    from creator_service.visual_plan_service import visual_plan_service
+except ImportError:
+    from visual_plan_service import visual_plan_service
+
+try:
+    from creator_domain.models.visual_plan import VisualScene
+except ImportError:
+    from models.visual_plan import VisualScene
+
+router = APIRouter(prefix="/runs/{run_id}/visual-plan", tags=["visual-plan"])
+
+
+class ReplaceVisualPlanRequest(BaseModel):
+    scenes: list[dict[str, object]]
+
+
+@router.get("")
+async def get_visual_plan(run_id: int) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    plan = await visual_plan_service.get_active_plan(run_id)
+    if plan is None:
+        raise HTTPException(
+            status_code=404, detail="No visual plan found for this run"
+        )
+
+    return {
+        "run_id": run_id,
+        "version": plan.version,
+        "scenes": [s.model_dump(mode="json") for s in plan.scenes],
+    }
+
+
+@router.put("")
+async def replace_visual_plan(
+    run_id: int, request: ReplaceVisualPlanRequest
+) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    try:
+        scenes = [VisualScene.model_validate(scene) for scene in request.scenes]
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    plan = await visual_plan_service.save_plan(run_id, scenes)
+
+    return {
+        "run_id": run_id,
+        "version": plan.version,
+        "scenes": [s.model_dump(mode="json") for s in plan.scenes],
+    }

--- a/apps/api/tests/__init__.py
+++ b/apps/api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test module for shorts_api."""

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest fixtures for API tests."""
+import pytest
+from httpx import AsyncClient, ASGITransport
+from shorts_api.main import app
+
+
+@pytest.fixture
+async def client():
+    """AsyncClient fixture for testing FastAPI app."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac

--- a/apps/api/tests/test_creator_models.py
+++ b/apps/api/tests/test_creator_models.py
@@ -1,0 +1,139 @@
+# pyright: reportMissingImports=false
+
+import pytest
+from shorts_api.main import models_router
+
+
+class StubModelCatalogService:
+    def __init__(self) -> None:
+        self.list_models_calls: list[str | None] = []
+        self.status_calls = 0
+
+    async def list_models(self, category: str | None = None) -> dict[str, list[dict[str, object]]]:
+        self.list_models_calls.append(category)
+        base = {
+            "script_models": [
+                {
+                    "key": "qwen3-4b",
+                    "label": "Qwen3 4B (Local)",
+                    "provider_type": "ollama",
+                    "is_local": True,
+                    "requires_gpu": True,
+                    "status": "available",
+                }
+            ],
+            "image_models": [
+                {
+                    "key": "sd15",
+                    "label": "Stable Diffusion 1.5 (Local)",
+                    "provider_type": "sd_local",
+                    "is_local": True,
+                    "requires_gpu": True,
+                    "status": "available",
+                }
+            ],
+            "tts_models": [
+                {
+                    "key": "qwen-tts",
+                    "label": "Qwen TTS (Local)",
+                    "provider_type": "qwen_tts",
+                    "is_local": True,
+                    "requires_gpu": True,
+                    "status": "available",
+                }
+            ],
+            "stt_models": [
+                {
+                    "key": "whisper-medium",
+                    "label": "Whisper Medium (Local)",
+                    "provider_type": "whisper",
+                    "is_local": True,
+                    "requires_gpu": True,
+                    "status": "available",
+                }
+            ],
+        }
+
+        if category == "script":
+            return {
+                "script_models": base["script_models"],
+                "image_models": [],
+                "tts_models": [],
+                "stt_models": [],
+            }
+
+        return base
+
+    async def get_status(self) -> dict[str, object]:
+        self.status_calls += 1
+        return {
+            "providers": [
+                {
+                    "name": "ollama",
+                    "endpoint": "http://ollama:11434",
+                    "healthy": True,
+                    "loaded_model": "qwen3-4b",
+                    "gpu_locked": False,
+                }
+            ],
+            "gpu_lock": {
+                "active": False,
+                "holder": None,
+                "ttl_remaining": None,
+            },
+        }
+
+
+@pytest.fixture
+def stub_catalog_service(monkeypatch: pytest.MonkeyPatch) -> StubModelCatalogService:
+    service = StubModelCatalogService()
+
+    for route in models_router.routes:
+        if route.name in {"list_models", "get_model_status"}:
+            monkeypatch.setitem(route.endpoint.__globals__, "model_catalog_service", service)
+
+    return service
+
+
+@pytest.mark.asyncio
+async def test_list_models_returns_all_categories(client, stub_catalog_service: StubModelCatalogService):
+    response = await client.get("/api/creator/models")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body) == {"script_models", "image_models", "tts_models", "stt_models"}
+    assert stub_catalog_service.list_models_calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_list_models_filters_by_script_category(client, stub_catalog_service: StubModelCatalogService):
+    response = await client.get("/api/creator/models?category=script")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["script_models"]) == 1
+    assert body["image_models"] == []
+    assert body["tts_models"] == []
+    assert body["stt_models"] == []
+    assert stub_catalog_service.list_models_calls == ["script"]
+
+
+@pytest.mark.asyncio
+async def test_list_models_rejects_invalid_category(client, stub_catalog_service: StubModelCatalogService):
+    response = await client.get("/api/creator/models?category=invalid")
+
+    assert response.status_code == 400
+    assert stub_catalog_service.list_models_calls == []
+
+
+@pytest.mark.asyncio
+async def test_model_status_returns_provider_and_gpu_lock(client, stub_catalog_service: StubModelCatalogService):
+    response = await client.get("/api/creator/models/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "providers" in body
+    assert "gpu_lock" in body
+    assert isinstance(body["providers"], list)
+    assert isinstance(body["gpu_lock"], dict)
+    assert stub_catalog_service.status_calls == 1

--- a/apps/api/tests/test_creator_projects.py
+++ b/apps/api/tests/test_creator_projects.py
@@ -108,6 +108,9 @@ class StubProjectService:
         return ordered[offset : offset + limit]
 
 
+    async def count_projects(self) -> int:
+        return len(self._projects)
+
 @pytest.fixture
 def stub_project_service(monkeypatch: pytest.MonkeyPatch) -> StubProjectService:
     service = StubProjectService()
@@ -154,12 +157,11 @@ async def test_create_project_invalid_source_type(client):
         json={"title": "Bad", "source_type": "invalid", "idea_brief": "Bad source"},
     )
 
-    assert response.status_code == 400
-    assert "Input should be 'idea', 'markdown' or 'url'" in response.json()["detail"]
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio
-async def test_create_project_missing_required_field(client):
+async def test_create_project_missing_required_field(client, stub_project_service: StubProjectService):
     response = await client.post(
         "/api/creator/projects",
         json={"title": "Missing", "source_type": "idea"},
@@ -207,5 +209,5 @@ async def test_list_projects_with_pagination(client, stub_project_service: StubP
     assert response.status_code == 200
     body = response.json()
     assert len(body["projects"]) == 1
-    assert body["total"] == 1
+    assert body["total"] == 2  # total count, not page size
     assert stub_project_service.list_projects_calls == [(1, 1)]

--- a/apps/api/tests/test_creator_projects.py
+++ b/apps/api/tests/test_creator_projects.py
@@ -1,0 +1,211 @@
+# pyright: reportMissingImports=false
+
+from datetime import datetime, timezone
+from typing import Literal, cast
+
+import pytest
+from pydantic import BaseModel
+from shorts_api.main import projects_router
+
+
+class StubProject(BaseModel):
+    id: int
+    title: str
+    source_type: Literal["idea", "markdown", "url"]
+    idea_brief: str | None = None
+    markdown_source: str | None = None
+    url_source: str | None = None
+    status: str = "draft"
+    created_at: datetime
+    updated_at: datetime
+    latest_run: dict[str, int | str | None] | None = None
+
+
+class StubProjectService:
+    def __init__(self) -> None:
+        self.create_project_calls: list[dict[str, object]] = []
+        self.get_project_calls: list[int] = []
+        self.list_projects_calls: list[tuple[int, int]] = []
+
+        now = datetime.now(timezone.utc)
+        self._projects = {
+            1: StubProject(
+                id=1,
+                title="Idea Project",
+                source_type="idea",
+                idea_brief="Build a daily shorts workflow",
+                status="draft",
+                created_at=now,
+                updated_at=now,
+                latest_run={"run_id": 11, "current_stage": "script", "status": "completed"},
+            ),
+            2: StubProject(
+                id=2,
+                title="Markdown Project",
+                source_type="markdown",
+                markdown_source="# Notes",
+                status="draft",
+                created_at=now,
+                updated_at=now,
+                latest_run=None,
+            ),
+        }
+        self._next_id = 3
+
+    async def create_project(
+        self,
+        title: str,
+        source_type: str,
+        idea_brief: str | None = None,
+        markdown_source: str | None = None,
+        url_source: str | None = None,
+    ) -> StubProject:
+        self.create_project_calls.append(
+            {
+                "title": title,
+                "source_type": source_type,
+                "idea_brief": idea_brief,
+                "markdown_source": markdown_source,
+                "url_source": url_source,
+            }
+        )
+
+        if source_type not in {"idea", "markdown", "url"}:
+            raise ValueError(f"Unsupported source_type '{source_type}'")
+        if source_type == "idea" and idea_brief is None:
+            raise ValueError("source_type='idea' requires idea_brief to be provided")
+        if source_type == "markdown" and markdown_source is None:
+            raise ValueError("source_type='markdown' requires markdown_source to be provided")
+        if source_type == "url" and url_source is None:
+            raise ValueError("source_type='url' requires url_source to be provided")
+
+        resolved_source_type = cast(Literal["idea", "markdown", "url"], source_type)
+
+        now = datetime.now(timezone.utc)
+        project = StubProject(
+            id=self._next_id,
+            title=title,
+            source_type=resolved_source_type,
+            idea_brief=idea_brief,
+            markdown_source=markdown_source,
+            url_source=url_source,
+            status="draft",
+            created_at=now,
+            updated_at=now,
+            latest_run=None,
+        )
+        self._projects[self._next_id] = project
+        self._next_id += 1
+        return project
+
+    async def get_project(self, project_id: int) -> StubProject | None:
+        self.get_project_calls.append(project_id)
+        return self._projects.get(project_id)
+
+    async def list_projects(self, limit: int = 20, offset: int = 0) -> list[StubProject]:
+        self.list_projects_calls.append((limit, offset))
+        ordered = sorted(self._projects.values(), key=lambda project: project.id)
+        return ordered[offset : offset + limit]
+
+
+@pytest.fixture
+def stub_project_service(monkeypatch: pytest.MonkeyPatch) -> StubProjectService:
+    service = StubProjectService()
+
+    for route in projects_router.routes:
+        if route.name in {"create_project", "get_project_detail", "list_projects"}:
+            monkeypatch.setitem(route.endpoint.__globals__, "project_service", service)
+
+    return service
+
+
+@pytest.mark.asyncio
+async def test_create_project_idea(client, stub_project_service: StubProjectService):
+    response = await client.post(
+        "/api/creator/projects",
+        json={"title": "Idea", "source_type": "idea", "idea_brief": "Use hooks"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["source_type"] == "idea"
+    assert body["idea_brief"] == "Use hooks"
+    assert stub_project_service.create_project_calls[0]["source_type"] == "idea"
+
+
+@pytest.mark.asyncio
+async def test_create_project_markdown(client, stub_project_service: StubProjectService):
+    response = await client.post(
+        "/api/creator/projects",
+        json={"title": "Doc", "source_type": "markdown", "markdown_source": "# Script"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["source_type"] == "markdown"
+    assert body["markdown_source"] == "# Script"
+    assert stub_project_service.create_project_calls[0]["source_type"] == "markdown"
+
+
+@pytest.mark.asyncio
+async def test_create_project_invalid_source_type(client):
+    response = await client.post(
+        "/api/creator/projects",
+        json={"title": "Bad", "source_type": "invalid", "idea_brief": "Bad source"},
+    )
+
+    assert response.status_code == 400
+    assert "Input should be 'idea', 'markdown' or 'url'" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_project_missing_required_field(client):
+    response = await client.post(
+        "/api/creator/projects",
+        json={"title": "Missing", "source_type": "idea"},
+    )
+
+    assert response.status_code == 400
+    assert "requires idea_brief" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_project_found(client, stub_project_service: StubProjectService):
+    response = await client.get("/api/creator/projects/1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 1
+    assert body["latest_run"]["run_id"] == 11
+    assert stub_project_service.get_project_calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_get_project_not_found(client, stub_project_service: StubProjectService):
+    response = await client.get("/api/creator/projects/999")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Project not found"}
+    assert stub_project_service.get_project_calls == [999]
+
+
+@pytest.mark.asyncio
+async def test_list_projects_default(client, stub_project_service: StubProjectService):
+    response = await client.get("/api/creator/projects")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body["projects"], list)
+    assert body["total"] == 2
+    assert stub_project_service.list_projects_calls == [(20, 0)]
+
+
+@pytest.mark.asyncio
+async def test_list_projects_with_pagination(client, stub_project_service: StubProjectService):
+    response = await client.get("/api/creator/projects?limit=1&offset=1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["projects"]) == 1
+    assert body["total"] == 1
+    assert stub_project_service.list_projects_calls == [(1, 1)]

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -1,0 +1,252 @@
+# pyright: reportMissingImports=false
+
+from datetime import datetime, timezone
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from shorts_api.main import runs_router
+
+
+class StubPipelineRun(BaseModel):
+    id: int
+    project_id: int
+    current_stage: str | None = None
+    status: Literal["pending", "running", "paused", "completed", "failed", "cancelled"] = "pending"
+    review_stage: str | None = None
+    restart_from: str | None = None
+    model_defaults: dict[str, str] | None = None
+    metadata: dict[str, object] | None = None
+    style_preset: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class StubRunService:
+    def __init__(self) -> None:
+        self.create_run_calls: list[dict[str, object]] = []
+        self.get_run_calls: list[int] = []
+        self.restart_run_calls: list[dict[str, object]] = []
+        self.runs: dict[int, StubPipelineRun] = {}
+        self._next_id = 1
+
+    async def create_run(
+        self,
+        project_id: int,
+        model_defaults: dict[str, str] | None,
+        style_preset: str,
+        metadata: dict[str, object] | None,
+    ) -> StubPipelineRun:
+        self.create_run_calls.append(
+            {
+                "project_id": project_id,
+                "model_defaults": model_defaults,
+                "style_preset": style_preset,
+                "metadata": metadata,
+            }
+        )
+
+        now = datetime.now(timezone.utc)
+        run = StubPipelineRun(
+            id=self._next_id,
+            project_id=project_id,
+            current_stage="IDEA_READY",
+            status="pending",
+            review_stage=None,
+            restart_from=None,
+            model_defaults=model_defaults,
+            metadata=metadata,
+            style_preset=style_preset,
+            started_at=None,
+            finished_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        self.runs[self._next_id] = run
+        self._next_id += 1
+        return run
+
+    async def get_run(self, run_id: int) -> StubPipelineRun | None:
+        self.get_run_calls.append(run_id)
+        return self.runs.get(run_id)
+
+    async def restart_run(self, run_id: int, from_stage: str) -> StubPipelineRun:
+        self.restart_run_calls.append({"run_id": run_id, "from_stage": from_stage})
+
+        run = self.runs.get(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        if from_stage not in {"SCRIPT_GENERATING", "VISUAL_PLAN_GENERATING"}:
+            raise ValueError(f"Invalid stage '{from_stage}'")
+
+        updated = run.model_copy(update={"restart_from": from_stage, "current_stage": from_stage})
+        self.runs[run_id] = updated
+        return updated
+
+
+@pytest.fixture
+def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
+    service = StubRunService()
+
+    for route in runs_router.routes:
+        if route.name in {"create_run", "get_run_detail", "restart_run"}:
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
+
+    return service
+
+
+@pytest.mark.asyncio
+async def test_create_run(client, stub_run_service: StubRunService):
+    response = await client.post(
+        "/api/creator/projects/7/runs",
+        json={
+            "model_defaults": {
+                "script_model": "qwen3-4b",
+                "image_model": "sd15",
+            },
+            "style_preset": "cinematic",
+            "metadata": {"episode": 1},
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["project_id"] == 7
+    assert body["model_defaults"] == {"script_model": "qwen3-4b", "image_model": "sd15"}
+    assert body["style_preset"] == "cinematic"
+    assert body["metadata"] == {"episode": 1}
+    assert stub_run_service.create_run_calls == [
+        {
+            "project_id": 7,
+            "model_defaults": {"script_model": "qwen3-4b", "image_model": "sd15"},
+            "style_preset": "cinematic",
+            "metadata": {"episode": 1},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_run_minimal(client, stub_run_service: StubRunService):
+    _ = stub_run_service
+    response = await client.post(
+        "/api/creator/projects/8/runs",
+        json={"style_preset": "default"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["project_id"] == 8
+    assert body["model_defaults"] is None
+    assert body["metadata"] is None
+    assert body["style_preset"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_get_run_found(client, stub_run_service: StubRunService):
+    now = datetime.now(timezone.utc)
+    stub_run_service.runs[33] = StubPipelineRun(
+        id=33,
+        project_id=3,
+        current_stage="SCRIPT_REVIEW",
+        status="running",
+        review_stage="SCRIPT_REVIEW",
+        restart_from="SCRIPT_GENERATING",
+        model_defaults={"script_model": "qwen3-4b", "image_model": "sd15"},
+        metadata={"attempt": 2},
+        style_preset="dynamic",
+        started_at=now,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    response = await client.get("/api/creator/runs/33")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 33
+    assert body["project_id"] == 3
+    assert body["current_stage"] == "SCRIPT_REVIEW"
+    assert body["status"] == "running"
+    assert body["review_stage"] == "SCRIPT_REVIEW"
+    assert body["restart_from"] == "SCRIPT_GENERATING"
+    assert body["model_defaults"] == {"script_model": "qwen3-4b", "image_model": "sd15"}
+    assert body["metadata"] == {"attempt": 2}
+    assert body["style_preset"] == "dynamic"
+    assert "created_at" in body
+    assert "updated_at" in body
+
+
+@pytest.mark.asyncio
+async def test_get_run_not_found(client, stub_run_service: StubRunService):
+    _ = stub_run_service
+    response = await client.get("/api/creator/runs/999")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run not found"}
+
+
+@pytest.mark.asyncio
+async def test_restart_run_valid(client, stub_run_service: StubRunService):
+    now = datetime.now(timezone.utc)
+    stub_run_service.runs[4] = StubPipelineRun(
+        id=4,
+        project_id=1,
+        current_stage="IDEA_READY",
+        status="pending",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=None,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    response = await client.post("/api/creator/runs/4/restart", json={"stage": "SCRIPT_GENERATING"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 4
+    assert body["current_stage"] == "SCRIPT_GENERATING"
+    assert body["restart_from"] == "SCRIPT_GENERATING"
+    assert stub_run_service.restart_run_calls == [{"run_id": 4, "from_stage": "SCRIPT_GENERATING"}]
+
+
+@pytest.mark.asyncio
+async def test_restart_run_invalid_stage(client, stub_run_service: StubRunService):
+    now = datetime.now(timezone.utc)
+    stub_run_service.runs[5] = StubPipelineRun(
+        id=5,
+        project_id=2,
+        current_stage="IDEA_READY",
+        status="pending",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=None,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    response = await client.post("/api/creator/runs/5/restart", json={"stage": "INVALID_STAGE"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid stage 'INVALID_STAGE'"}
+
+
+@pytest.mark.asyncio
+async def test_restart_run_not_found(client, stub_run_service: StubRunService):
+    _ = stub_run_service
+    response = await client.post("/api/creator/runs/4242/restart", json={"stage": "SCRIPT_GENERATING"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Run 4242 not found"}

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -1258,3 +1258,207 @@ async def test_generate_visual_assets_dispatch_failure_rollback(client, stub_gen
 
     # Verify run was actually rolled back to VISUAL_PLAN_REVIEW
     assert run_svc.runs[66].current_stage == "VISUAL_PLAN_REVIEW"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Single-scene generate-image tests (Issue #52)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def stub_single_scene_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubImageDispatcher]:
+    run_svc = StubRunService()
+    dispatcher = StubImageDispatcher()
+
+    for route in runs_router.routes:
+        if route.name in ("generate_scene_image_endpoint", "regenerate_scene_image_endpoint"):
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "dispatch_generate_scene_image", dispatcher)
+
+    return run_svc, dispatcher
+
+
+@pytest.mark.asyncio
+async def test_generate_scene_image_from_visual_plan_review(client, stub_single_scene_services):
+    run_svc, dispatcher = stub_single_scene_services
+    run_svc.runs[70] = _make_run(70, "VISUAL_PLAN_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/70/visual-plan/scenes/scene-sec-0/generate-image",
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["task_id"] == "test-img-task-id-789"
+    assert body["run_id"] == 70
+    assert body["scene_id"] == "scene-sec-0"
+    assert body["current_stage"] == "VISUAL_PLAN_REVIEW"
+    assert dispatcher.calls == [{
+        "run_id": 70,
+        "model_key": "sd15",
+        "scene_id": "scene-sec-0",
+        "prompt_override": None,
+        "is_active": True,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_generate_scene_image_from_asset_review(client, stub_single_scene_services):
+    """Generate-image is also allowed during VISUAL_ASSET_REVIEW (fill missing scenes)."""
+    run_svc, dispatcher = stub_single_scene_services
+    run_svc.runs[71] = _make_run(71, "VISUAL_ASSET_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/71/visual-plan/scenes/scene-sec-1/generate-image",
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["scene_id"] == "scene-sec-1"
+    assert dispatcher.calls[0]["is_active"] is True
+
+
+@pytest.mark.asyncio
+async def test_generate_scene_image_run_not_found(client, stub_single_scene_services):
+    response = await client.post(
+        "/api/creator/runs/999/visual-plan/scenes/scene-sec-0/generate-image",
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_generate_scene_image_wrong_stage(client, stub_single_scene_services):
+    run_svc, dispatcher = stub_single_scene_services
+    run_svc.runs[72] = _make_run(72, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/72/visual-plan/scenes/scene-sec-0/generate-image",
+    )
+
+    assert response.status_code == 400
+    assert "SCRIPT_REVIEW" in response.json()["detail"]
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_scene_image_dispatch_failure(client, stub_single_scene_services):
+    run_svc, _ = stub_single_scene_services
+    run_svc.runs[73] = _make_run(73, "VISUAL_PLAN_REVIEW")
+
+    def failing_dispatcher(run_id, model_key, scene_id, prompt_override, is_active):
+        raise RuntimeError("Celery broker down")
+
+    for route in runs_router.routes:
+        if route.name == "generate_scene_image_endpoint":
+            route.endpoint.__globals__["dispatch_generate_scene_image"] = failing_dispatcher
+
+    response = await client.post(
+        "/api/creator/runs/73/visual-plan/scenes/scene-sec-0/generate-image",
+    )
+
+    assert response.status_code == 503
+    assert "enqueue" in response.json()["detail"].lower()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Single-scene regenerate-image tests (Issue #52)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_regenerate_scene_image_success(client, stub_single_scene_services):
+    run_svc, dispatcher = stub_single_scene_services
+    run_svc.runs[80] = _make_run(80, "VISUAL_ASSET_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/80/visual-plan/scenes/scene-sec-0/regenerate-image",
+        json={"model_key": "sd15", "prompt_override": "A dark moody scene"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["task_id"] == "test-img-task-id-789"
+    assert body["run_id"] == 80
+    assert body["scene_id"] == "scene-sec-0"
+    assert body["current_stage"] == "VISUAL_ASSET_REVIEW"
+    assert dispatcher.calls == [{
+        "run_id": 80,
+        "model_key": "sd15",
+        "scene_id": "scene-sec-0",
+        "prompt_override": "A dark moody scene",
+        "is_active": False,  # regenerated assets are inactive
+    }]
+
+
+@pytest.mark.asyncio
+async def test_regenerate_scene_image_default_model(client, stub_single_scene_services):
+    run_svc, dispatcher = stub_single_scene_services
+    run_svc.runs[81] = _make_run(81, "VISUAL_ASSET_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/81/visual-plan/scenes/scene-sec-0/regenerate-image",
+        json={},
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["model_key"] == "sd15"
+    assert dispatcher.calls[0]["prompt_override"] is None
+    assert dispatcher.calls[0]["is_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_regenerate_scene_image_run_not_found(client, stub_single_scene_services):
+    response = await client.post(
+        "/api/creator/runs/999/visual-plan/scenes/scene-sec-0/regenerate-image",
+        json={},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_regenerate_scene_image_wrong_stage(client, stub_single_scene_services):
+    run_svc, dispatcher = stub_single_scene_services
+    run_svc.runs[82] = _make_run(82, "VISUAL_PLAN_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/82/visual-plan/scenes/scene-sec-0/regenerate-image",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "VISUAL_PLAN_REVIEW" in response.json()["detail"]
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_regenerate_scene_image_wrong_stage_script(client, stub_single_scene_services):
+    run_svc, dispatcher = stub_single_scene_services
+    run_svc.runs[83] = _make_run(83, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/83/visual-plan/scenes/scene-sec-0/regenerate-image",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_regenerate_scene_image_dispatch_failure(client, stub_single_scene_services):
+    run_svc, _ = stub_single_scene_services
+    run_svc.runs[84] = _make_run(84, "VISUAL_ASSET_REVIEW")
+
+    def failing_dispatcher(run_id, model_key, scene_id, prompt_override, is_active):
+        raise RuntimeError("Celery broker down")
+
+    for route in runs_router.routes:
+        if route.name == "regenerate_scene_image_endpoint":
+            route.endpoint.__globals__["dispatch_generate_scene_image"] = failing_dispatcher
+
+    response = await client.post(
+        "/api/creator/runs/84/visual-plan/scenes/scene-sec-0/regenerate-image",
+        json={"prompt_override": "New prompt"},
+    )
+
+    assert response.status_code == 503
+    assert "enqueue" in response.json()["detail"].lower()

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -100,6 +100,13 @@ class StubRunService:
         self.runs[run_id] = updated
         return updated
 
+    async def list_runs_by_project(self, project_id: int) -> list[StubPipelineRun]:
+        return sorted(
+            [r for r in self.runs.values() if r.project_id == project_id],
+            key=lambda r: r.id,
+            reverse=True,
+        )
+
 
 class StubRunStorage:
     """Minimal storage stub that supports conditional_update_run."""
@@ -170,7 +177,7 @@ def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
     service = StubRunService()
 
     for route in runs_router.routes:
-        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger"}:
+        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "list_runs_for_project"}:
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
 
     return service
@@ -715,3 +722,32 @@ async def test_generate_script_project_not_found(client, stub_generate_services)
     assert len(run_svc.storage.conditional_update_calls) == 0
     # No dispatch
     assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_runs_for_project(client, stub_run_service: StubRunService):
+    # Create 2 runs for project 7 and 1 for project 8
+    await stub_run_service.create_run(project_id=7, model_defaults=None, style_preset="default", metadata=None)
+    await stub_run_service.create_run(project_id=7, model_defaults=None, style_preset="default", metadata=None)
+    await stub_run_service.create_run(project_id=8, model_defaults=None, style_preset="default", metadata=None)
+
+    response = await client.get("/api/creator/projects/7/runs")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert len(body["runs"]) == 2
+    # Newest first
+    assert body["runs"][0]["id"] > body["runs"][1]["id"]
+    assert all(r["project_id"] == 7 for r in body["runs"])
+
+
+@pytest.mark.asyncio
+async def test_list_runs_for_project_empty(client, stub_run_service: StubRunService):
+    _ = stub_run_service
+    response = await client.get("/api/creator/projects/999/runs")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["runs"] == []

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -2235,3 +2235,329 @@ async def test_generate_subtitles_dispatch_failure_rollback(client, stub_generat
 
     # Verify run was actually rolled back to AUDIO_GENERATING
     assert run_svc.runs[126].current_stage == "AUDIO_GENERATING"
+
+
+# ── Render endpoint tests ──────────────────────────────────────────
+
+
+class StubRenderDispatcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.task_id = "test-render-task-id-xyz"
+
+    def __call__(self, run_id: int, render_profile: str) -> str:
+        self.calls.append({
+            "run_id": run_id,
+            "render_profile": render_profile,
+        })
+        return self.task_id
+
+
+@pytest.fixture
+def stub_generate_render_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubRenderDispatcher]:
+    run_svc = StubRunService()
+    dispatcher = StubRenderDispatcher()
+
+    for route in runs_router.routes:
+        if route.name == "render_trigger":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "dispatch_render_video", dispatcher)
+
+    return run_svc, dispatcher
+
+
+def _make_render_run(run_id: int, stage: str = "SUBTITLE_GENERATING") -> StubPipelineRun:
+    """Helper to create a run in render-relevant stage."""
+    now = datetime.now(timezone.utc)
+    return StubPipelineRun(
+        id=run_id,
+        project_id=1,
+        current_stage=stage,
+        status="running",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=now,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_render_from_subtitle_generating(client, stub_generate_render_services):
+    run_svc, dispatcher = stub_generate_render_services
+    run_svc.runs[130] = _make_render_run(130, "SUBTITLE_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/130/render",
+        json={"render_profile": "high_quality"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["task_id"] == "test-render-task-id-xyz"
+    assert body["run_id"] == 130
+    assert body["current_stage"] == "RENDER_GENERATING"
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 130
+    assert cas_calls[0]["updates"] == {"current_stage": "RENDER_GENERATING"}
+    assert "SUBTITLE_GENERATING" in cas_calls[0]["expected_stages"]
+    assert dispatcher.calls == [{
+        "run_id": 130,
+        "render_profile": "high_quality",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_render_retry_from_generating(client, stub_generate_render_services):
+    run_svc, dispatcher = stub_generate_render_services
+    run_svc.runs[131] = _make_render_run(131, "RENDER_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/131/render",
+        json={"render_profile": "shorts_default"},
+    )
+
+    assert response.status_code == 202
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["updates"] == {
+        "current_stage": "RENDER_GENERATING",
+        "restart_from": "RENDER_GENERATING",
+    }
+    assert "RENDER_GENERATING" in cas_calls[0]["expected_stages"]
+    assert len(dispatcher.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_render_default_profile(client, stub_generate_render_services):
+    run_svc, dispatcher = stub_generate_render_services
+    run_svc.runs[132] = _make_render_run(132, "SUBTITLE_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/132/render",
+        json={},
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["render_profile"] == "shorts_default"
+
+
+@pytest.mark.asyncio
+async def test_render_run_not_found(client, stub_generate_render_services):
+    _, _ = stub_generate_render_services
+    response = await client.post(
+        "/api/creator/runs/999/render",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_render_wrong_stage(client, stub_generate_render_services):
+    run_svc, _ = stub_generate_render_services
+    run_svc.runs[133] = _make_render_run(133, "IDEA_READY")
+
+    response = await client.post(
+        "/api/creator/runs/133/render",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "IDEA_READY" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_render_cas_conflict(client, stub_generate_render_services):
+    run_svc, dispatcher = stub_generate_render_services
+    run_svc.runs[134] = _make_render_run(134, "SUBTITLE_GENERATING")
+
+    async def cas_conflict(run_id, updates, expected_stages):
+        return False, {"current_stage": "RENDER_GENERATING", "id": run_id}
+
+    run_svc.storage.conditional_update_run = cas_conflict
+
+    response = await client.post(
+        "/api/creator/runs/134/render",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_render_dispatch_failure_rollback(client, stub_generate_render_services):
+    run_svc, _ = stub_generate_render_services
+    run_svc.runs[135] = _make_render_run(135, "SUBTITLE_GENERATING")
+
+    def failing_dispatcher(run_id, render_profile):
+        raise RuntimeError("Celery broker down")
+
+    from shorts_api.main import runs_router as _r
+    for route in _r.routes:
+        if route.name == "render_trigger":
+            route.endpoint.__globals__["dispatch_render_video"] = failing_dispatcher
+
+    response = await client.post(
+        "/api/creator/runs/135/render",
+        json={},
+    )
+
+    assert response.status_code == 503
+    assert "enqueue" in response.json()["detail"].lower()
+
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 2
+    rollback = cas_calls[1]
+    assert rollback["updates"]["current_stage"] == "SUBTITLE_GENERATING"
+    assert rollback["expected_stages"] == frozenset({"RENDER_GENERATING"})
+
+    assert run_svc.runs[135].current_stage == "SUBTITLE_GENERATING"
+
+
+# ── Preview endpoint tests ────────────────────────────────────────
+
+
+class StubVideoArtifact:
+    def __init__(self, id: int, path: str, render_profile: str | None, created_at: datetime) -> None:
+        self.id = id
+        self.path = path
+        self.render_profile = render_profile
+        self.created_at = created_at
+
+
+class StubAudioArtifact:
+    def __init__(self, id: int, path: str, model_used: str, created_at: datetime) -> None:
+        self.id = id
+        self.path = path
+        self.model_used = model_used
+        self.created_at = created_at
+
+
+class StubSubtitleArtifact:
+    def __init__(self, id: int, path: str, fmt: str, created_at: datetime) -> None:
+        self.id = id
+        self.path = path
+        self.format = fmt
+        self.created_at = created_at
+
+
+class StubPreviewRenderService:
+    def __init__(self, artifact: StubVideoArtifact | None = None) -> None:
+        self.artifact = artifact
+
+    async def get_latest(self, run_id: int) -> StubVideoArtifact | None:
+        return self.artifact
+
+
+class StubPreviewAudioService:
+    def __init__(self, artifact: StubAudioArtifact | None = None) -> None:
+        self.artifact = artifact
+
+    async def get_latest(self, run_id: int) -> StubAudioArtifact | None:
+        return self.artifact
+
+
+class StubPreviewSubtitleService:
+    def __init__(self, artifact: StubSubtitleArtifact | None = None) -> None:
+        self.artifact = artifact
+
+    async def get_latest(self, run_id: int) -> StubSubtitleArtifact | None:
+        return self.artifact
+
+
+@pytest.fixture
+def stub_preview_services(monkeypatch: pytest.MonkeyPatch):
+    now = datetime.now(timezone.utc)
+    run_svc = StubRunService()
+    render_svc = StubPreviewRenderService(
+        StubVideoArtifact(1, "data/artifacts/200/render/output.mp4", "shorts_default", now)
+    )
+    audio_svc = StubPreviewAudioService(
+        StubAudioArtifact(2, "data/artifacts/200/audio/audio.wav", "piper", now)
+    )
+    subtitle_svc = StubPreviewSubtitleService(
+        StubSubtitleArtifact(3, "data/artifacts/200/subtitles/subtitles.srt", "srt", now)
+    )
+
+    for route in runs_router.routes:
+        if route.name == "get_preview":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "render_service", render_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "audio_service", audio_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "subtitle_service", subtitle_svc)
+
+    return run_svc, render_svc, audio_svc, subtitle_svc
+
+
+def _make_preview_run(run_id: int, stage: str = "FINAL_REVIEW") -> StubPipelineRun:
+    now = datetime.now(timezone.utc)
+    return StubPipelineRun(
+        id=run_id,
+        project_id=1,
+        current_stage=stage,
+        status="running",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=now,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_full_artifacts(client, stub_preview_services):
+    run_svc, _, _, _ = stub_preview_services
+    run_svc.runs[200] = _make_preview_run(200, "FINAL_REVIEW")
+
+    response = await client.get("/api/creator/runs/200/preview")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 200
+    assert body["current_stage"] == "FINAL_REVIEW"
+    assert body["video"]["id"] == 1
+    assert body["video"]["path"] == "data/artifacts/200/render/output.mp4"
+    assert body["video"]["render_profile"] == "shorts_default"
+    assert body["audio"]["id"] == 2
+    assert body["audio"]["model_used"] == "piper"
+    assert body["subtitle"]["id"] == 3
+    assert body["subtitle"]["format"] == "srt"
+
+
+@pytest.mark.asyncio
+async def test_preview_no_artifacts(client, stub_preview_services):
+    run_svc, render_svc, audio_svc, subtitle_svc = stub_preview_services
+    render_svc.artifact = None
+    audio_svc.artifact = None
+    subtitle_svc.artifact = None
+    run_svc.runs[201] = _make_preview_run(201, "RENDER_GENERATING")
+
+    response = await client.get("/api/creator/runs/201/preview")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["video"] is None
+    assert body["audio"] is None
+    assert body["subtitle"] is None
+
+
+@pytest.mark.asyncio
+async def test_preview_run_not_found(client, stub_preview_services):
+    _, _, _, _ = stub_preview_services
+    response = await client.get("/api/creator/runs/999/preview")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -177,7 +177,7 @@ def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
     service = StubRunService()
 
     for route in runs_router.routes:
-        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "list_runs_for_project"}:
+        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "generate_visual_plan_trigger", "list_runs_for_project"}:
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
 
     return service
@@ -751,3 +751,193 @@ async def test_list_runs_for_project_empty(client, stub_run_service: StubRunServ
     body = response.json()
     assert body["total"] == 0
     assert body["runs"] == []
+
+
+class StubVisualPlanDispatcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.task_id = "test-vp-task-id-456"
+
+    def __call__(
+        self, run_id: int, model_key: str, style_preset: str | None
+    ) -> str:
+        self.calls.append({
+            "run_id": run_id,
+            "model_key": model_key,
+            "style_preset": style_preset,
+        })
+        return self.task_id
+
+
+@pytest.fixture
+def stub_generate_visual_plan_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubVisualPlanDispatcher]:
+    run_svc = StubRunService()
+    dispatcher = StubVisualPlanDispatcher()
+
+    for route in runs_router.routes:
+        if route.name == "generate_visual_plan_trigger":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "dispatch_generate_visual_plan", dispatcher)
+
+    return run_svc, dispatcher
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_plan_from_script_review(client, stub_generate_visual_plan_services):
+    run_svc, dispatcher = stub_generate_visual_plan_services
+    run_svc.runs[30] = _make_run(30, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/30/generate-visual-plan",
+        json={"model_key": "qwen3-4b", "style_preset": "cinematic"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["task_id"] == "test-vp-task-id-456"
+    assert body["run_id"] == 30
+    assert body["current_stage"] == "VISUAL_PLAN_GENERATING"
+    # CAS was called for SCRIPT_REVIEW → VISUAL_PLAN_GENERATING (no restart_from)
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 30
+    assert cas_calls[0]["updates"] == {"current_stage": "VISUAL_PLAN_GENERATING"}
+    assert "SCRIPT_REVIEW" in cas_calls[0]["expected_stages"]
+    assert dispatcher.calls == [{
+        "run_id": 30,
+        "model_key": "qwen3-4b",
+        "style_preset": "cinematic",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_plan_retry_from_generating(client, stub_generate_visual_plan_services):
+    run_svc, dispatcher = stub_generate_visual_plan_services
+    run_svc.runs[31] = _make_run(31, "VISUAL_PLAN_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/31/generate-visual-plan",
+        json={"model_key": "qwen3-4b"},
+    )
+
+    assert response.status_code == 202
+    # CAS was called for VISUAL_PLAN_GENERATING → VISUAL_PLAN_GENERATING with restart_from
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 31
+    assert cas_calls[0]["updates"] == {
+        "current_stage": "VISUAL_PLAN_GENERATING",
+        "restart_from": "VISUAL_PLAN_GENERATING",
+    }
+    assert "VISUAL_PLAN_GENERATING" in cas_calls[0]["expected_stages"]
+    assert len(dispatcher.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_plan_default_model(client, stub_generate_visual_plan_services):
+    run_svc, dispatcher = stub_generate_visual_plan_services
+    run_svc.runs[32] = _make_run(32, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/32/generate-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["model_key"] == "qwen3-4b"
+    assert dispatcher.calls[0]["style_preset"] is None
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_plan_run_not_found(client, stub_generate_visual_plan_services):
+    _, _ = stub_generate_visual_plan_services
+    response = await client.post(
+        "/api/creator/runs/999/generate-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_plan_wrong_stage(client, stub_generate_visual_plan_services):
+    run_svc, _ = stub_generate_visual_plan_services
+    run_svc.runs[33] = _make_run(33, "IDEA_READY")
+
+    response = await client.post(
+        "/api/creator/runs/33/generate-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "IDEA_READY" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_plan_wrong_stage_visual_review(client, stub_generate_visual_plan_services):
+    run_svc, _ = stub_generate_visual_plan_services
+    run_svc.runs[34] = _make_run(34, "VISUAL_PLAN_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/34/generate-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "VISUAL_PLAN_REVIEW" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_plan_cas_conflict(client, stub_generate_visual_plan_services):
+    """CAS fails because stage changed between initial check and CAS."""
+    run_svc, dispatcher = stub_generate_visual_plan_services
+    run_svc.runs[35] = _make_run(35, "SCRIPT_REVIEW")
+
+    async def cas_conflict(run_id, updates, expected_stages):
+        return False, {"current_stage": "VISUAL_PLAN_GENERATING", "id": run_id}
+
+    run_svc.storage.conditional_update_run = cas_conflict
+
+    response = await client.post(
+        "/api/creator/runs/35/generate-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_plan_dispatch_failure_rollback(client, stub_generate_visual_plan_services):
+    """Celery dispatch failure triggers rollback to original stage."""
+    run_svc, _ = stub_generate_visual_plan_services
+    run_svc.runs[36] = _make_run(36, "SCRIPT_REVIEW")
+
+    def failing_dispatcher(run_id, model_key, style_preset):
+        raise RuntimeError("Celery broker down")
+
+    from shorts_api.main import runs_router as _r
+    for route in _r.routes:
+        if route.name == "generate_visual_plan_trigger":
+            route.endpoint.__globals__["dispatch_generate_visual_plan"] = failing_dispatcher
+
+    response = await client.post(
+        "/api/creator/runs/36/generate-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 503
+    assert "enqueue" in response.json()["detail"].lower()
+
+    # Rollback: CAS was called twice — first to advance, then to rollback
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 2
+    # Second CAS = rollback to SCRIPT_REVIEW
+    rollback = cas_calls[1]
+    assert rollback["updates"]["current_stage"] == "SCRIPT_REVIEW"
+    assert rollback["expected_stages"] == frozenset({"VISUAL_PLAN_GENERATING"})
+
+    # Verify run was actually rolled back to SCRIPT_REVIEW
+    assert run_svc.runs[36].current_stage == "SCRIPT_REVIEW"

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -31,6 +31,7 @@ class StubRunService:
         self.restart_run_calls: list[dict[str, object]] = []
         self.advance_stage_calls: list[dict[str, object]] = []
         self.runs: dict[int, StubPipelineRun] = {}
+        self.storage = StubRunStorage(self)
         self._next_id = 1
 
     async def create_run(
@@ -99,6 +100,35 @@ class StubRunService:
         self.runs[run_id] = updated
         return updated
 
+
+class StubRunStorage:
+    """Minimal storage stub that supports conditional_update_run."""
+
+    def __init__(self, run_svc: "StubRunService") -> None:
+        self._run_svc = run_svc
+        self.conditional_update_calls: list[dict[str, object]] = []
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self.conditional_update_calls.append({
+            "run_id": run_id,
+            "updates": dict(updates),
+            "expected_stages": expected_stages,
+        })
+
+        run = self._run_svc.runs.get(run_id)
+        if run is None:
+            return False, None
+        if run.current_stage not in expected_stages:
+            return False, run.model_dump(mode="json")
+
+        updated = run.model_copy(update=updates)
+        self._run_svc.runs[run_id] = updated
+        return True, updated.model_dump(mode="json")
 class StubStageReviewService:
     def __init__(self, run_svc: StubRunService) -> None:
         self.approve_calls: list[dict[str, object]] = []
@@ -488,8 +518,12 @@ async def test_generate_script_from_idea_ready(client, stub_generate_services):
     assert body["task_id"] == "test-task-id-123"
     assert body["run_id"] == 10
     assert body["current_stage"] == "SCRIPT_GENERATING"
-    assert run_svc.advance_stage_calls == [{"run_id": 10, "target_stage": "SCRIPT_GENERATING"}]
-    assert len(run_svc.restart_run_calls) == 0
+    # CAS was called for IDEA_READY → SCRIPT_GENERATING (no restart_from)
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 10
+    assert cas_calls[0]["updates"] == {"current_stage": "SCRIPT_GENERATING"}
+    assert "IDEA_READY" in cas_calls[0]["expected_stages"]
     assert dispatcher.calls == [{
         "run_id": 10,
         "idea_brief": "Create a cooking tutorial",
@@ -510,11 +544,15 @@ async def test_generate_script_from_script_review(client, stub_generate_services
     )
 
     assert response.status_code == 202
-    body = response.json()
-    assert body["current_stage"] == "SCRIPT_GENERATING"
-    assert len(run_svc.restart_run_calls) == 1
-    assert run_svc.restart_run_calls[0] == {"run_id": 11, "from_stage": "SCRIPT_GENERATING"}
-    assert len(run_svc.advance_stage_calls) == 0
+    # CAS was called for SCRIPT_REVIEW → SCRIPT_GENERATING with restart_from
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 11
+    assert cas_calls[0]["updates"] == {
+        "current_stage": "SCRIPT_GENERATING",
+        "restart_from": "SCRIPT_GENERATING",
+    }
+    assert "SCRIPT_REVIEW" in cas_calls[0]["expected_stages"]
     assert dispatcher.calls[0]["idea_brief"] == "Science explainer"
 
 
@@ -591,3 +629,89 @@ async def test_generate_script_idea_brief_fallback_to_title(client, stub_generat
 
     assert response.status_code == 202
     assert dispatcher.calls[0]["idea_brief"] == "Fallback Title"
+
+
+@pytest.mark.asyncio
+async def test_generate_script_cas_conflict(client, stub_generate_services):
+    """CAS fails because stage changed between initial check and CAS."""
+    run_svc, project_svc, dispatcher = stub_generate_services
+    # Set stage to IDEA_READY so the initial check passes
+    run_svc.runs[20] = _make_run(20, "IDEA_READY")
+    project_svc.projects[1] = _make_project(1, "Conflict test")
+
+    # Simulate a concurrent stage change: after the initial read, change stage
+    # so CAS will find mismatch.  We do this by mutating the run between the
+    # initial get_run and the CAS call.  Because the route reads once then CAS,
+    # we override conditional_update_run to simulate conflict.
+
+    async def cas_conflict(run_id, updates, expected_stages):
+        # Return conflict: stage changed to SCRIPT_GENERATING
+        return False, {"current_stage": "SCRIPT_GENERATING", "id": run_id}
+
+    run_svc.storage.conditional_update_run = cas_conflict
+
+    response = await client.post(
+        "/api/creator/runs/20/generate-script",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
+    # Dispatcher was NOT called
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_script_dispatch_failure_rollback(client, stub_generate_services):
+    """Celery dispatch failure triggers rollback to original stage."""
+    run_svc, project_svc, _ = stub_generate_services
+    run_svc.runs[21] = _make_run(21, "IDEA_READY")
+    project_svc.projects[1] = _make_project(1, "Dispatch fail test")
+
+    def failing_dispatcher(run_id, idea_brief, model_key, instructions):
+        raise RuntimeError("Celery broker down")
+
+    # Patch the dispatcher for this test
+    from shorts_api.main import runs_router as _r
+    for route in _r.routes:
+        if route.name == "generate_script_trigger":
+            route.endpoint.__globals__["dispatch_generate_script"] = failing_dispatcher
+
+    response = await client.post(
+        "/api/creator/runs/21/generate-script",
+        json={},
+    )
+
+    assert response.status_code == 503
+    assert "enqueue" in response.json()["detail"].lower()
+
+    # Rollback: CAS was called twice — first to advance, then to rollback
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 2
+    # Second CAS = rollback to IDEA_READY
+    rollback = cas_calls[1]
+    assert rollback["updates"]["current_stage"] == "IDEA_READY"
+    assert rollback["expected_stages"] == frozenset({"SCRIPT_GENERATING"})
+
+    # Verify run was actually rolled back to IDEA_READY
+    assert run_svc.runs[21].current_stage == "IDEA_READY"
+
+
+@pytest.mark.asyncio
+async def test_generate_script_project_not_found(client, stub_generate_services):
+    """Project not found returns 404 BEFORE any state mutation."""
+    run_svc, project_svc, dispatcher = stub_generate_services
+    run_svc.runs[22] = _make_run(22, "IDEA_READY")
+    # Do NOT add project — project_svc.projects is empty
+
+    response = await client.post(
+        "/api/creator/runs/22/generate-script",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert "project" in response.json()["detail"].lower()
+    # No CAS call — precondition failed before mutation
+    assert len(run_svc.storage.conditional_update_calls) == 0
+    # No dispatch
+    assert len(dispatcher.calls) == 0

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -177,7 +177,7 @@ def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
     service = StubRunService()
 
     for route in runs_router.routes:
-        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "generate_visual_plan_trigger", "list_runs_for_project"}:
+        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "generate_visual_plan_trigger", "generate_audio_trigger", "list_runs_for_project"}:
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
 
     return service
@@ -1813,3 +1813,211 @@ async def test_select_active_asset_during_generating(client, stub_select_service
     )
     assert response.status_code == 200
     assert response.json()["id"] == 60
+
+
+class StubAudioDispatcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.task_id = "test-audio-task-id-abc"
+
+    def __call__(self, run_id: int, tts_model: str, voice: str) -> str:
+        self.calls.append({
+            "run_id": run_id,
+            "tts_model": tts_model,
+            "voice": voice,
+        })
+        return self.task_id
+
+
+@pytest.fixture
+def stub_generate_audio_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubAudioDispatcher]:
+    run_svc = StubRunService()
+    dispatcher = StubAudioDispatcher()
+
+    for route in runs_router.routes:
+        if route.name == "generate_audio_trigger":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "dispatch_generate_audio", dispatcher)
+
+    return run_svc, dispatcher
+
+
+def _make_audio_run(run_id: int, stage: str = "VISUAL_ASSET_REVIEW") -> StubPipelineRun:
+    """Helper to create a run in audio-relevant stage."""
+    now = datetime.now(timezone.utc)
+    return StubPipelineRun(
+        id=run_id,
+        project_id=1,
+        current_stage=stage,
+        status="running",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=now,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_from_visual_asset_review(client, stub_generate_audio_services):
+    run_svc, dispatcher = stub_generate_audio_services
+    run_svc.runs[110] = _make_audio_run(110, "VISUAL_ASSET_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/110/generate-audio",
+        json={"tts_model": "piper", "voice": "en_US-lessac-medium"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["task_id"] == "test-audio-task-id-abc"
+    assert body["run_id"] == 110
+    assert body["current_stage"] == "AUDIO_GENERATING"
+    # CAS was called for VISUAL_ASSET_REVIEW → AUDIO_GENERATING (no restart_from)
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 110
+    assert cas_calls[0]["updates"] == {"current_stage": "AUDIO_GENERATING"}
+    assert "VISUAL_ASSET_REVIEW" in cas_calls[0]["expected_stages"]
+    assert dispatcher.calls == [{
+        "run_id": 110,
+        "tts_model": "piper",
+        "voice": "en_US-lessac-medium",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_retry_from_generating(client, stub_generate_audio_services):
+    run_svc, dispatcher = stub_generate_audio_services
+    run_svc.runs[111] = _make_audio_run(111, "AUDIO_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/111/generate-audio",
+        json={"tts_model": "piper", "voice": "en_US-lessac-medium"},
+    )
+
+    assert response.status_code == 202
+    # CAS was called for AUDIO_GENERATING → AUDIO_GENERATING with restart_from
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 111
+    assert cas_calls[0]["updates"] == {
+        "current_stage": "AUDIO_GENERATING",
+        "restart_from": "AUDIO_GENERATING",
+    }
+    assert "AUDIO_GENERATING" in cas_calls[0]["expected_stages"]
+    assert len(dispatcher.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_default_model(client, stub_generate_audio_services):
+    run_svc, dispatcher = stub_generate_audio_services
+    run_svc.runs[112] = _make_audio_run(112, "VISUAL_ASSET_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/112/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["tts_model"] == "piper"
+    assert dispatcher.calls[0]["voice"] == "en_US-lessac-medium"
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_run_not_found(client, stub_generate_audio_services):
+    _, _ = stub_generate_audio_services
+    response = await client.post(
+        "/api/creator/runs/999/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_wrong_stage(client, stub_generate_audio_services):
+    run_svc, _ = stub_generate_audio_services
+    run_svc.runs[113] = _make_audio_run(113, "IDEA_READY")
+
+    response = await client.post(
+        "/api/creator/runs/113/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "IDEA_READY" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_wrong_stage_script_review(client, stub_generate_audio_services):
+    run_svc, _ = stub_generate_audio_services
+    run_svc.runs[114] = _make_audio_run(114, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/114/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "SCRIPT_REVIEW" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_cas_conflict(client, stub_generate_audio_services):
+    """CAS fails because stage changed between initial check and CAS."""
+    run_svc, dispatcher = stub_generate_audio_services
+    run_svc.runs[115] = _make_audio_run(115, "VISUAL_ASSET_REVIEW")
+
+    async def cas_conflict(run_id, updates, expected_stages):
+        return False, {"current_stage": "AUDIO_GENERATING", "id": run_id}
+
+    run_svc.storage.conditional_update_run = cas_conflict
+
+    response = await client.post(
+        "/api/creator/runs/115/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_dispatch_failure_rollback(client, stub_generate_audio_services):
+    """Celery dispatch failure triggers rollback to original stage."""
+    run_svc, _ = stub_generate_audio_services
+    run_svc.runs[116] = _make_audio_run(116, "VISUAL_ASSET_REVIEW")
+
+    def failing_dispatcher(run_id, tts_model, voice):
+        raise RuntimeError("Celery broker down")
+
+    from shorts_api.main import runs_router as _r
+    for route in _r.routes:
+        if route.name == "generate_audio_trigger":
+            route.endpoint.__globals__["dispatch_generate_audio"] = failing_dispatcher
+
+    response = await client.post(
+        "/api/creator/runs/116/generate-audio",
+        json={},
+    )
+
+    assert response.status_code == 503
+    assert "enqueue" in response.json()["detail"].lower()
+
+    # Rollback: CAS was called twice — first to advance, then to rollback
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 2
+    # Second CAS = rollback to VISUAL_ASSET_REVIEW
+    rollback = cas_calls[1]
+    assert rollback["updates"]["current_stage"] == "VISUAL_ASSET_REVIEW"
+    assert rollback["expected_stages"] == frozenset({"AUDIO_GENERATING"})
+
+    # Verify run was actually rolled back to VISUAL_ASSET_REVIEW
+    assert run_svc.runs[116].current_stage == "VISUAL_ASSET_REVIEW"

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -177,7 +177,7 @@ def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
     service = StubRunService()
 
     for route in runs_router.routes:
-        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "generate_visual_plan_trigger", "generate_audio_trigger", "list_runs_for_project"}:
+        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "generate_visual_plan_trigger", "generate_audio_trigger", "generate_subtitles_trigger", "list_runs_for_project"}:
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
 
     return service
@@ -2021,3 +2021,217 @@ async def test_generate_audio_dispatch_failure_rollback(client, stub_generate_au
 
     # Verify run was actually rolled back to VISUAL_ASSET_REVIEW
     assert run_svc.runs[116].current_stage == "VISUAL_ASSET_REVIEW"
+
+
+
+# ──────────────────────────────────────────────────────────────────────
+# POST /runs/{run_id}/generate-subtitles
+# ──────────────────────────────────────────────────────────────────────
+
+
+class StubSubtitleDispatcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.task_id = "test-subtitle-task-id-xyz"
+
+    def __call__(self, run_id: int, subtitle_model: str, subtitle_format: str) -> str:
+        self.calls.append({
+            "run_id": run_id,
+            "subtitle_model": subtitle_model,
+            "subtitle_format": subtitle_format,
+        })
+        return self.task_id
+
+
+@pytest.fixture
+def stub_generate_subtitles_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubSubtitleDispatcher]:
+    run_svc = StubRunService()
+    dispatcher = StubSubtitleDispatcher()
+
+    for route in runs_router.routes:
+        if route.name == "generate_subtitles_trigger":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "dispatch_generate_subtitles", dispatcher)
+
+    return run_svc, dispatcher
+
+
+def _make_subtitle_run(run_id: int, stage: str = "AUDIO_GENERATING") -> StubPipelineRun:
+    """Helper to create a run in subtitle-relevant stage."""
+    now = datetime.now(timezone.utc)
+    return StubPipelineRun(
+        id=run_id,
+        project_id=1,
+        current_stage=stage,
+        status="running",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=now,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_subtitles_from_audio_generating(client, stub_generate_subtitles_services):
+    run_svc, dispatcher = stub_generate_subtitles_services
+    run_svc.runs[120] = _make_subtitle_run(120, "AUDIO_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/120/generate-subtitles",
+        json={"subtitle_model": "whisper-tiny", "subtitle_format": "srt"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["task_id"] == "test-subtitle-task-id-xyz"
+    assert body["run_id"] == 120
+    assert body["current_stage"] == "SUBTITLE_GENERATING"
+    # CAS was called for AUDIO_GENERATING → SUBTITLE_GENERATING (no restart_from)
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 120
+    assert cas_calls[0]["updates"] == {"current_stage": "SUBTITLE_GENERATING"}
+    assert "AUDIO_GENERATING" in cas_calls[0]["expected_stages"]
+    assert dispatcher.calls == [{
+        "run_id": 120,
+        "subtitle_model": "whisper-tiny",
+        "subtitle_format": "srt",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_generate_subtitles_retry_from_generating(client, stub_generate_subtitles_services):
+    run_svc, dispatcher = stub_generate_subtitles_services
+    run_svc.runs[121] = _make_subtitle_run(121, "SUBTITLE_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/121/generate-subtitles",
+        json={"subtitle_model": "whisper-tiny", "subtitle_format": "srt"},
+    )
+
+    assert response.status_code == 202
+    # CAS was called for SUBTITLE_GENERATING → SUBTITLE_GENERATING with restart_from
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 121
+    assert cas_calls[0]["updates"] == {
+        "current_stage": "SUBTITLE_GENERATING",
+        "restart_from": "SUBTITLE_GENERATING",
+    }
+    assert "SUBTITLE_GENERATING" in cas_calls[0]["expected_stages"]
+    assert len(dispatcher.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_subtitles_default_model(client, stub_generate_subtitles_services):
+    run_svc, dispatcher = stub_generate_subtitles_services
+    run_svc.runs[122] = _make_subtitle_run(122, "AUDIO_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/122/generate-subtitles",
+        json={},
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["subtitle_model"] == "whisper-tiny"
+    assert dispatcher.calls[0]["subtitle_format"] == "srt"
+
+
+@pytest.mark.asyncio
+async def test_generate_subtitles_run_not_found(client, stub_generate_subtitles_services):
+    _, _ = stub_generate_subtitles_services
+    response = await client.post(
+        "/api/creator/runs/999/generate-subtitles",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_subtitles_wrong_stage(client, stub_generate_subtitles_services):
+    run_svc, _ = stub_generate_subtitles_services
+    run_svc.runs[123] = _make_subtitle_run(123, "IDEA_READY")
+
+    response = await client.post(
+        "/api/creator/runs/123/generate-subtitles",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "IDEA_READY" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_subtitles_wrong_stage_visual(client, stub_generate_subtitles_services):
+    run_svc, _ = stub_generate_subtitles_services
+    run_svc.runs[124] = _make_subtitle_run(124, "VISUAL_ASSET_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/124/generate-subtitles",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "VISUAL_ASSET_REVIEW" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_subtitles_cas_conflict(client, stub_generate_subtitles_services):
+    """CAS fails because stage changed between initial check and CAS."""
+    run_svc, dispatcher = stub_generate_subtitles_services
+    run_svc.runs[125] = _make_subtitle_run(125, "AUDIO_GENERATING")
+
+    async def cas_conflict(run_id, updates, expected_stages):
+        return False, {"current_stage": "SUBTITLE_GENERATING", "id": run_id}
+
+    run_svc.storage.conditional_update_run = cas_conflict
+
+    response = await client.post(
+        "/api/creator/runs/125/generate-subtitles",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_subtitles_dispatch_failure_rollback(client, stub_generate_subtitles_services):
+    """Celery dispatch failure triggers rollback to original stage."""
+    run_svc, _ = stub_generate_subtitles_services
+    run_svc.runs[126] = _make_subtitle_run(126, "AUDIO_GENERATING")
+
+    def failing_dispatcher(run_id, subtitle_model, subtitle_format):
+        raise RuntimeError("Celery broker down")
+
+    from shorts_api.main import runs_router as _r
+    for route in _r.routes:
+        if route.name == "generate_subtitles_trigger":
+            route.endpoint.__globals__["dispatch_generate_subtitles"] = failing_dispatcher
+
+    response = await client.post(
+        "/api/creator/runs/126/generate-subtitles",
+        json={},
+    )
+
+    assert response.status_code == 503
+    assert "enqueue" in response.json()["detail"].lower()
+
+    # Rollback: CAS was called twice — first to advance, then to rollback
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 2
+    # Second CAS = rollback to AUDIO_GENERATING
+    rollback = cas_calls[1]
+    assert rollback["updates"]["current_stage"] == "AUDIO_GENERATING"
+    assert rollback["expected_stages"] == frozenset({"SUBTITLE_GENERATING"})
+
+    # Verify run was actually rolled back to AUDIO_GENERATING
+    assert run_svc.runs[126].current_stage == "AUDIO_GENERATING"

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -1486,6 +1486,7 @@ class StubVisualAssetService:
     def __init__(self) -> None:
         self.list_by_run_calls: list[int] = []
         self.list_by_scene_calls: list[dict[str, object]] = []
+        self.select_active_calls: list[dict[str, object]] = []
         self._assets: dict[int, list[StubVisualAsset]] = {}  # run_id -> assets
 
     def add_asset(self, asset: StubVisualAsset) -> None:
@@ -1509,6 +1510,25 @@ class StubVisualAssetService:
             key=lambda a: a.version,
             reverse=True,
         )
+
+    async def select_active(
+        self, run_id: int, scene_id: str, asset_id: int
+    ) -> StubVisualAsset:
+        self.select_active_calls.append({
+            "run_id": run_id,
+            "scene_id": scene_id,
+            "asset_id": asset_id,
+        })
+        assets = self._assets.get(run_id, [])
+        for a in assets:
+            if a.id == asset_id:
+                if a.scene_id != scene_id:
+                    raise ValueError(
+                        f"Asset {asset_id} does not belong to run {run_id} "
+                        f"scene '{scene_id}'"
+                    )
+                return a.model_copy(update={"is_active": True})
+        raise ValueError(f"Asset {asset_id} not found")
 
 
 def _make_asset(
@@ -1692,3 +1712,104 @@ async def test_list_visual_assets_by_scene_includes_fields(client, stub_listing_
     assert asset["provider_type"] == "local-gpu"
     assert asset["is_active"] is True
     assert "created_at" in asset
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Active visual asset selection tests (Issue #54)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def stub_select_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubVisualAssetService]:
+    run_svc = StubRunService()
+    asset_svc = StubVisualAssetService()
+
+    for route in runs_router.routes:
+        if route.name == "select_active_asset":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "visual_asset_service", asset_svc)
+
+    return run_svc, asset_svc
+
+
+@pytest.mark.asyncio
+async def test_select_active_asset_success(client, stub_select_services):
+    run_svc, asset_svc = stub_select_services
+    run_svc.runs[100] = _make_run(100, "VISUAL_ASSET_REVIEW")
+
+    asset_svc.add_asset(_make_asset(40, 100, "scene-0", 1, is_active=False))
+    asset_svc.add_asset(_make_asset(41, 100, "scene-0", 2, is_active=True))
+
+    response = await client.post(
+        "/api/creator/runs/100/visual-assets/scene-0/select/40"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 40
+    assert body["is_active"] is True
+    assert body["scene_id"] == "scene-0"
+    assert asset_svc.select_active_calls == [{"run_id": 100, "scene_id": "scene-0", "asset_id": 40}]
+
+
+@pytest.mark.asyncio
+async def test_select_active_asset_run_not_found(client, stub_select_services):
+    response = await client.post(
+        "/api/creator/runs/999/visual-assets/scene-0/select/1"
+    )
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_select_active_asset_wrong_stage(client, stub_select_services):
+    run_svc, _ = stub_select_services
+    run_svc.runs[101] = _make_run(101, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/101/visual-assets/scene-0/select/1"
+    )
+    assert response.status_code == 400
+    assert "SCRIPT_REVIEW" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_select_active_asset_not_found(client, stub_select_services):
+    run_svc, asset_svc = stub_select_services
+    run_svc.runs[102] = _make_run(102, "VISUAL_ASSET_REVIEW")
+    # No assets added — asset 999 doesn't exist
+
+    response = await client.post(
+        "/api/creator/runs/102/visual-assets/scene-0/select/999"
+    )
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_select_active_asset_wrong_scene(client, stub_select_services):
+    run_svc, asset_svc = stub_select_services
+    run_svc.runs[103] = _make_run(103, "VISUAL_ASSET_REVIEW")
+    # Asset belongs to scene-1, not scene-0
+    asset_svc.add_asset(_make_asset(50, 103, "scene-1", 1))
+
+    response = await client.post(
+        "/api/creator/runs/103/visual-assets/scene-0/select/50"
+    )
+    # Service raises ValueError for wrong scene — mapped to 400
+    assert response.status_code == 400
+    assert "does not belong" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_select_active_asset_during_generating(client, stub_select_services):
+    """Selection is also allowed during VISUAL_ASSET_GENERATING stage."""
+    run_svc, asset_svc = stub_select_services
+    run_svc.runs[104] = _make_run(104, "VISUAL_ASSET_GENERATING")
+    asset_svc.add_asset(_make_asset(60, 104, "scene-0", 1))
+
+    response = await client.post(
+        "/api/creator/runs/104/visual-assets/scene-0/select/60"
+    )
+    assert response.status_code == 200
+    assert response.json()["id"] == 60

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -1462,3 +1462,233 @@ async def test_regenerate_scene_image_dispatch_failure(client, stub_single_scene
 
     assert response.status_code == 503
     assert "enqueue" in response.json()["detail"].lower()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Visual asset listing tests (Issue #53)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class StubVisualAsset(BaseModel):
+    id: int
+    run_id: int
+    scene_id: str
+    version: int = 1
+    asset_path: str
+    prompt_snapshot: str | None = None
+    model_used: str | None = None
+    provider_type: str | None = None
+    is_active: bool = True
+    created_at: datetime
+
+
+class StubVisualAssetService:
+    def __init__(self) -> None:
+        self.list_by_run_calls: list[int] = []
+        self.list_by_scene_calls: list[dict[str, object]] = []
+        self._assets: dict[int, list[StubVisualAsset]] = {}  # run_id -> assets
+
+    def add_asset(self, asset: StubVisualAsset) -> None:
+        self._assets.setdefault(asset.run_id, []).append(asset)
+
+    async def list_by_run(self, run_id: int) -> dict[str, list[StubVisualAsset]]:
+        self.list_by_run_calls.append(run_id)
+        assets = self._assets.get(run_id, [])
+        grouped: dict[str, list[StubVisualAsset]] = {}
+        for a in assets:
+            grouped.setdefault(a.scene_id, []).append(a)
+        return grouped
+
+    async def list_by_scene(
+        self, run_id: int, scene_id: str
+    ) -> list[StubVisualAsset]:
+        self.list_by_scene_calls.append({"run_id": run_id, "scene_id": scene_id})
+        assets = self._assets.get(run_id, [])
+        return sorted(
+            [a for a in assets if a.scene_id == scene_id],
+            key=lambda a: a.version,
+            reverse=True,
+        )
+
+
+def _make_asset(
+    asset_id: int,
+    run_id: int,
+    scene_id: str,
+    version: int = 1,
+    *,
+    is_active: bool = True,
+    prompt_snapshot: str | None = "A beautiful scene",
+    model_used: str | None = "sd15",
+    provider_type: str | None = "local-gpu",
+) -> StubVisualAsset:
+    return StubVisualAsset(
+        id=asset_id,
+        run_id=run_id,
+        scene_id=scene_id,
+        version=version,
+        asset_path=f"data/artifacts/1/{run_id}/{scene_id}_v{version}.png",
+        prompt_snapshot=prompt_snapshot,
+        model_used=model_used,
+        provider_type=provider_type,
+        is_active=is_active,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.fixture
+def stub_listing_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubVisualAssetService]:
+    run_svc = StubRunService()
+    asset_svc = StubVisualAssetService()
+
+    for route in runs_router.routes:
+        if route.name in ("list_visual_assets_by_run", "list_visual_assets_by_scene"):
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "visual_asset_service", asset_svc)
+
+    return run_svc, asset_svc
+
+
+@pytest.mark.asyncio
+async def test_list_visual_assets_by_run_success(client, stub_listing_services):
+    run_svc, asset_svc = stub_listing_services
+    run_svc.runs[90] = _make_run(90, "VISUAL_ASSET_REVIEW")
+
+    asset_svc.add_asset(_make_asset(1, 90, "scene-0", 1, is_active=False))
+    asset_svc.add_asset(_make_asset(2, 90, "scene-0", 2, is_active=True))
+    asset_svc.add_asset(_make_asset(3, 90, "scene-1", 1, is_active=True))
+
+    response = await client.get("/api/creator/runs/90/visual-assets")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 90
+    assert body["total_scenes"] == 2
+    assert body["total_assets"] == 3
+    assert "scene-0" in body["scenes"]
+    assert "scene-1" in body["scenes"]
+    assert len(body["scenes"]["scene-0"]) == 2
+    assert len(body["scenes"]["scene-1"]) == 1
+    assert asset_svc.list_by_run_calls == [90]
+
+
+@pytest.mark.asyncio
+async def test_list_visual_assets_by_run_empty(client, stub_listing_services):
+    run_svc, asset_svc = stub_listing_services
+    run_svc.runs[91] = _make_run(91, "VISUAL_ASSET_REVIEW")
+
+    response = await client.get("/api/creator/runs/91/visual-assets")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 91
+    assert body["total_scenes"] == 0
+    assert body["total_assets"] == 0
+    assert body["scenes"] == {}
+
+
+@pytest.mark.asyncio
+async def test_list_visual_assets_by_run_not_found(client, stub_listing_services):
+    response = await client.get("/api/creator/runs/999/visual-assets")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_list_visual_assets_by_run_includes_fields(client, stub_listing_services):
+    """Verify asset serialization includes prompt_snapshot, model_used, provider_type, timestamps."""
+    run_svc, asset_svc = stub_listing_services
+    run_svc.runs[92] = _make_run(92, "VISUAL_ASSET_REVIEW")
+
+    asset_svc.add_asset(_make_asset(
+        10, 92, "scene-0", 1,
+        prompt_snapshot="A serene landscape",
+        model_used="sd15",
+        provider_type="local-gpu",
+    ))
+
+    response = await client.get("/api/creator/runs/92/visual-assets")
+
+    assert response.status_code == 200
+    body = response.json()
+    asset = body["scenes"]["scene-0"][0]
+    assert asset["prompt_snapshot"] == "A serene landscape"
+    assert asset["model_used"] == "sd15"
+    assert asset["provider_type"] == "local-gpu"
+    assert asset["is_active"] is True
+    assert "created_at" in asset
+
+
+@pytest.mark.asyncio
+async def test_list_visual_assets_by_scene_success(client, stub_listing_services):
+    run_svc, asset_svc = stub_listing_services
+    run_svc.runs[93] = _make_run(93, "VISUAL_ASSET_REVIEW")
+
+    asset_svc.add_asset(_make_asset(20, 93, "scene-sec-0", 1, is_active=False))
+    asset_svc.add_asset(_make_asset(21, 93, "scene-sec-0", 2, is_active=True))
+    asset_svc.add_asset(_make_asset(22, 93, "scene-sec-1", 1, is_active=True))  # different scene
+
+    response = await client.get("/api/creator/runs/93/visual-assets/scene-sec-0")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 93
+    assert body["scene_id"] == "scene-sec-0"
+    assert body["total"] == 2
+    # Newest first (version 2 before version 1)
+    assert body["assets"][0]["version"] == 2
+    assert body["assets"][1]["version"] == 1
+    assert asset_svc.list_by_scene_calls == [{"run_id": 93, "scene_id": "scene-sec-0"}]
+
+
+@pytest.mark.asyncio
+async def test_list_visual_assets_by_scene_empty(client, stub_listing_services):
+    """Empty list is valid — scene may not have any generated assets yet."""
+    run_svc, asset_svc = stub_listing_services
+    run_svc.runs[94] = _make_run(94, "VISUAL_ASSET_REVIEW")
+
+    response = await client.get("/api/creator/runs/94/visual-assets/scene-sec-0")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["assets"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_visual_assets_by_scene_not_found(client, stub_listing_services):
+    response = await client.get("/api/creator/runs/999/visual-assets/scene-sec-0")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_list_visual_assets_by_scene_includes_fields(client, stub_listing_services):
+    """Verify each asset in scene listing includes all expected fields."""
+    run_svc, asset_svc = stub_listing_services
+    run_svc.runs[95] = _make_run(95, "VISUAL_ASSET_REVIEW")
+
+    asset_svc.add_asset(_make_asset(
+        30, 95, "scene-sec-0", 1,
+        prompt_snapshot="A dark forest",
+        model_used="sd15",
+        provider_type="local-gpu",
+        is_active=True,
+    ))
+
+    response = await client.get("/api/creator/runs/95/visual-assets/scene-sec-0")
+
+    assert response.status_code == 200
+    asset = response.json()["assets"][0]
+    assert asset["id"] == 30
+    assert asset["run_id"] == 95
+    assert asset["scene_id"] == "scene-sec-0"
+    assert asset["version"] == 1
+    assert asset["asset_path"] == "data/artifacts/1/95/scene-sec-0_v1.png"
+    assert asset["prompt_snapshot"] == "A dark forest"
+    assert asset["model_used"] == "sd15"
+    assert asset["provider_type"] == "local-gpu"
+    assert asset["is_active"] is True
+    assert "created_at" in asset

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -444,6 +444,122 @@ async def test_approve_script_wrong_stage_generating(client, stub_approve_servic
     assert "conflict" in response.json()["detail"].lower()
 
 
+# ---------------------------------------------------------------------------
+# POST /runs/{run_id}/approve-visual-plan
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_approve_vp_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubStageReviewService]:
+    run_svc = StubRunService()
+    review_svc = StubStageReviewService(run_svc)
+
+    for route in runs_router.routes:
+        if route.name == "approve_visual_plan":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "stage_review_service", review_svc)
+
+    return run_svc, review_svc
+
+
+def _make_vp_run(run_id: int, stage: str = "VISUAL_PLAN_REVIEW") -> StubPipelineRun:
+    now = datetime.now(timezone.utc)
+    return StubPipelineRun(
+        id=run_id,
+        project_id=1,
+        current_stage=stage,
+        status="running",
+        review_stage=stage if stage == "VISUAL_PLAN_REVIEW" else None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=now,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_visual_plan_success(client, stub_approve_vp_services):
+    run_svc, review_svc = stub_approve_vp_services
+    run_svc.runs[50] = _make_vp_run(50, "VISUAL_PLAN_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/50/approve-visual-plan",
+        json={"reviewer": "human", "notes": "Visual plan approved"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 50
+    assert body["current_stage"] == "VISUAL_ASSET_GENERATING"
+    assert review_svc.approve_calls == [
+        {
+            "run_id": 50,
+            "stage_name": "VISUAL_PLAN_REVIEW",
+            "target_stage": "VISUAL_ASSET_GENERATING",
+            "reviewer": "human",
+            "notes": "Visual plan approved",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_approve_visual_plan_default_reviewer(client, stub_approve_vp_services):
+    run_svc, review_svc = stub_approve_vp_services
+    run_svc.runs[51] = _make_vp_run(51, "VISUAL_PLAN_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/51/approve-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 200
+    assert review_svc.approve_calls[0]["reviewer"] == "agent"
+    assert review_svc.approve_calls[0]["notes"] is None
+
+
+@pytest.mark.asyncio
+async def test_approve_visual_plan_run_not_found(client, stub_approve_vp_services):
+    _, _ = stub_approve_vp_services
+    response = await client.post(
+        "/api/creator/runs/999/approve-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_approve_visual_plan_wrong_stage(client, stub_approve_vp_services):
+    run_svc, _ = stub_approve_vp_services
+    run_svc.runs[52] = _make_vp_run(52, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/52/approve-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_approve_visual_plan_wrong_stage_generating(client, stub_approve_vp_services):
+    run_svc, _ = stub_approve_vp_services
+    run_svc.runs[53] = _make_vp_run(53, "VISUAL_PLAN_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/53/approve-visual-plan",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
+
 class StubProject(BaseModel):
     id: int
     title: str | None = None

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -29,6 +29,7 @@ class StubRunService:
         self.create_run_calls: list[dict[str, object]] = []
         self.get_run_calls: list[int] = []
         self.restart_run_calls: list[dict[str, object]] = []
+        self.advance_stage_calls: list[dict[str, object]] = []
         self.runs: dict[int, StubPipelineRun] = {}
         self._next_id = 1
 
@@ -85,6 +86,18 @@ class StubRunService:
         self.runs[run_id] = updated
         return updated
 
+    async def advance_stage(self, run_id: int, target_stage: str) -> StubPipelineRun:
+        self.advance_stage_calls.append({"run_id": run_id, "target_stage": target_stage})
+
+        run = self.runs.get(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        if target_stage not in {"SCRIPT_GENERATING", "VISUAL_PLAN_GENERATING"}:
+            raise ValueError(f"Invalid stage '{target_stage}'")
+
+        updated = run.model_copy(update={"current_stage": target_stage})
+        self.runs[run_id] = updated
+        return updated
 
 class StubStageReviewService:
     def __init__(self) -> None:
@@ -321,7 +334,7 @@ async def test_approve_script_success(client, stub_approve_services):
     assert review_svc.record_approval_calls == [
         {"run_id": 10, "stage_name": "SCRIPT_REVIEW", "reviewer": "human", "notes": "Looks good"}
     ]
-    assert run_svc.restart_run_calls == [{"run_id": 10, "from_stage": "VISUAL_PLAN_GENERATING"}]
+    assert run_svc.advance_stage_calls == [{"run_id": 10, "target_stage": "VISUAL_PLAN_GENERATING"}]
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -5,7 +5,6 @@ from typing import Literal
 
 import pytest
 from pydantic import BaseModel
-
 from shorts_api.main import runs_router
 
 
@@ -87,12 +86,33 @@ class StubRunService:
         return updated
 
 
+class StubStageReviewService:
+    def __init__(self) -> None:
+        self.record_approval_calls: list[dict[str, object]] = []
+
+    async def record_approval(
+        self, run_id: int, stage_name: str, reviewer: str = "agent", notes: str | None = None
+    ) -> dict[str, object]:
+        self.record_approval_calls.append(
+            {"run_id": run_id, "stage_name": stage_name, "reviewer": reviewer, "notes": notes}
+        )
+        return {
+            "id": len(self.record_approval_calls),
+            "run_id": run_id,
+            "stage_name": stage_name,
+            "review_status": "approved",
+            "reviewer": reviewer,
+            "notes": notes,
+            "created_at": datetime.now(timezone.utc),
+        }
+
+
 @pytest.fixture
 def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
     service = StubRunService()
 
     for route in runs_router.routes:
-        if route.name in {"create_run", "get_run_detail", "restart_run"}:
+        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script"}:
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
 
     return service
@@ -250,3 +270,110 @@ async def test_restart_run_not_found(client, stub_run_service: StubRunService):
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Run 4242 not found"}
+
+
+@pytest.fixture
+def stub_approve_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubStageReviewService]:
+    run_svc = StubRunService()
+    review_svc = StubStageReviewService()
+
+    for route in runs_router.routes:
+        if route.name == "approve_script":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "stage_review_service", review_svc)
+
+    return run_svc, review_svc
+
+
+def _make_run(run_id: int, stage: str = "SCRIPT_REVIEW") -> StubPipelineRun:
+    now = datetime.now(timezone.utc)
+    return StubPipelineRun(
+        id=run_id,
+        project_id=1,
+        current_stage=stage,
+        status="running",
+        review_stage=stage if stage == "SCRIPT_REVIEW" else None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=now,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_script_success(client, stub_approve_services):
+    run_svc, review_svc = stub_approve_services
+    run_svc.runs[10] = _make_run(10, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/10/approve-script",
+        json={"reviewer": "human", "notes": "Looks good"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 10
+    assert body["current_stage"] == "VISUAL_PLAN_GENERATING"
+    assert review_svc.record_approval_calls == [
+        {"run_id": 10, "stage_name": "SCRIPT_REVIEW", "reviewer": "human", "notes": "Looks good"}
+    ]
+    assert run_svc.restart_run_calls == [{"run_id": 10, "from_stage": "VISUAL_PLAN_GENERATING"}]
+
+
+@pytest.mark.asyncio
+async def test_approve_script_default_reviewer(client, stub_approve_services):
+    run_svc, review_svc = stub_approve_services
+    run_svc.runs[11] = _make_run(11, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/11/approve-script",
+        json={},
+    )
+
+    assert response.status_code == 200
+    assert review_svc.record_approval_calls[0]["reviewer"] == "agent"
+    assert review_svc.record_approval_calls[0]["notes"] is None
+
+
+@pytest.mark.asyncio
+async def test_approve_script_run_not_found(client, stub_approve_services):
+    _, _ = stub_approve_services
+    response = await client.post(
+        "/api/creator/runs/999/approve-script",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run not found"}
+
+
+@pytest.mark.asyncio
+async def test_approve_script_wrong_stage(client, stub_approve_services):
+    run_svc, _ = stub_approve_services
+    run_svc.runs[12] = _make_run(12, "IDEA_READY")
+
+    response = await client.post(
+        "/api/creator/runs/12/approve-script",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "expected 'SCRIPT_REVIEW'" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_approve_script_wrong_stage_generating(client, stub_approve_services):
+    run_svc, _ = stub_approve_services
+    run_svc.runs[13] = _make_run(13, "SCRIPT_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/13/approve-script",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "SCRIPT_GENERATING" in response.json()["detail"]

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -100,25 +100,40 @@ class StubRunService:
         return updated
 
 class StubStageReviewService:
-    def __init__(self) -> None:
-        self.record_approval_calls: list[dict[str, object]] = []
+    def __init__(self, run_svc: StubRunService) -> None:
+        self.approve_calls: list[dict[str, object]] = []
+        self._run_svc = run_svc
 
-    async def record_approval(
-        self, run_id: int, stage_name: str, reviewer: str = "agent", notes: str | None = None
-    ) -> dict[str, object]:
-        self.record_approval_calls.append(
-            {"run_id": run_id, "stage_name": stage_name, "reviewer": reviewer, "notes": notes}
-        )
-        return {
-            "id": len(self.record_approval_calls),
+    async def approve_and_advance(
+        self,
+        *,
+        run_service: object,
+        run_id: int,
+        stage_name: str,
+        target_stage: str,
+        reviewer: str = "agent",
+        notes: str | None = None,
+    ) -> StubPipelineRun:
+        self.approve_calls.append({
             "run_id": run_id,
             "stage_name": stage_name,
-            "review_status": "approved",
+            "target_stage": target_stage,
             "reviewer": reviewer,
             "notes": notes,
-            "created_at": datetime.now(timezone.utc),
-        }
+        })
 
+        run = self._run_svc.runs.get(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        if run.current_stage != stage_name:
+            raise ValueError(
+                f"Stage conflict: run is now in '{run.current_stage}', "
+                f"expected '{stage_name}'"
+            )
+
+        updated = run.model_copy(update={"current_stage": target_stage})
+        self._run_svc.runs[run_id] = updated
+        return updated
 
 @pytest.fixture
 def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
@@ -288,7 +303,7 @@ async def test_restart_run_not_found(client, stub_run_service: StubRunService):
 @pytest.fixture
 def stub_approve_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubStageReviewService]:
     run_svc = StubRunService()
-    review_svc = StubStageReviewService()
+    review_svc = StubStageReviewService(run_svc)
 
     for route in runs_router.routes:
         if route.name == "approve_script":
@@ -296,7 +311,6 @@ def stub_approve_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunServi
             monkeypatch.setitem(route.endpoint.__globals__, "stage_review_service", review_svc)
 
     return run_svc, review_svc
-
 
 def _make_run(run_id: int, stage: str = "SCRIPT_REVIEW") -> StubPipelineRun:
     now = datetime.now(timezone.utc)
@@ -331,11 +345,15 @@ async def test_approve_script_success(client, stub_approve_services):
     body = response.json()
     assert body["id"] == 10
     assert body["current_stage"] == "VISUAL_PLAN_GENERATING"
-    assert review_svc.record_approval_calls == [
-        {"run_id": 10, "stage_name": "SCRIPT_REVIEW", "reviewer": "human", "notes": "Looks good"}
+    assert review_svc.approve_calls == [
+        {
+            "run_id": 10,
+            "stage_name": "SCRIPT_REVIEW",
+            "target_stage": "VISUAL_PLAN_GENERATING",
+            "reviewer": "human",
+            "notes": "Looks good",
+        }
     ]
-    assert run_svc.advance_stage_calls == [{"run_id": 10, "target_stage": "VISUAL_PLAN_GENERATING"}]
-
 
 @pytest.mark.asyncio
 async def test_approve_script_default_reviewer(client, stub_approve_services):
@@ -348,9 +366,8 @@ async def test_approve_script_default_reviewer(client, stub_approve_services):
     )
 
     assert response.status_code == 200
-    assert review_svc.record_approval_calls[0]["reviewer"] == "agent"
-    assert review_svc.record_approval_calls[0]["notes"] is None
-
+    assert review_svc.approve_calls[0]["reviewer"] == "agent"
+    assert review_svc.approve_calls[0]["notes"] is None
 
 @pytest.mark.asyncio
 async def test_approve_script_run_not_found(client, stub_approve_services):
@@ -361,8 +378,7 @@ async def test_approve_script_run_not_found(client, stub_approve_services):
     )
 
     assert response.status_code == 404
-    assert response.json() == {"detail": "Run not found"}
-
+    assert "not found" in response.json()["detail"].lower()
 
 @pytest.mark.asyncio
 async def test_approve_script_wrong_stage(client, stub_approve_services):
@@ -374,9 +390,8 @@ async def test_approve_script_wrong_stage(client, stub_approve_services):
         json={},
     )
 
-    assert response.status_code == 400
-    assert "expected 'SCRIPT_REVIEW'" in response.json()["detail"]
-
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
 
 @pytest.mark.asyncio
 async def test_approve_script_wrong_stage_generating(client, stub_approve_services):
@@ -388,5 +403,5 @@ async def test_approve_script_wrong_stage_generating(client, stub_approve_servic
         json={},
     )
 
-    assert response.status_code == 400
-    assert "SCRIPT_GENERATING" in response.json()["detail"]
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -248,5 +248,5 @@ async def test_restart_run_not_found(client, stub_run_service: StubRunService):
     _ = stub_run_service
     response = await client.post("/api/creator/runs/4242/restart", json={"stage": "SCRIPT_GENERATING"})
 
-    assert response.status_code == 400
+    assert response.status_code == 404
     assert response.json() == {"detail": "Run 4242 not found"}

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -140,7 +140,7 @@ def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
     service = StubRunService()
 
     for route in runs_router.routes:
-        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script"}:
+        if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger"}:
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
 
     return service
@@ -405,3 +405,189 @@ async def test_approve_script_wrong_stage_generating(client, stub_approve_servic
 
     assert response.status_code == 409
     assert "conflict" in response.json()["detail"].lower()
+
+
+class StubProject(BaseModel):
+    id: int
+    title: str | None = None
+    source_type: str = "idea"
+    idea_brief: str | None = None
+    markdown_source: str | None = None
+    url_source: str | None = None
+    status: str = "draft"
+    created_at: datetime
+    updated_at: datetime
+
+
+class StubProjectService:
+    def __init__(self) -> None:
+        self.projects: dict[int, StubProject] = {}
+
+    async def get_project(self, project_id: int) -> StubProject | None:
+        return self.projects.get(project_id)
+
+
+class StubDispatcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.task_id = "test-task-id-123"
+
+    def __call__(
+        self, run_id: int, idea_brief: str, model_key: str, instructions: str | None
+    ) -> str:
+        self.calls.append({
+            "run_id": run_id,
+            "idea_brief": idea_brief,
+            "model_key": model_key,
+            "instructions": instructions,
+        })
+        return self.task_id
+
+
+@pytest.fixture
+def stub_generate_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubProjectService, StubDispatcher]:
+    run_svc = StubRunService()
+    project_svc = StubProjectService()
+    dispatcher = StubDispatcher()
+
+    for route in runs_router.routes:
+        if route.name == "generate_script_trigger":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "project_service", project_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "dispatch_generate_script", dispatcher)
+
+    return run_svc, project_svc, dispatcher
+
+
+def _make_project(project_id: int, idea_brief: str = "Test idea") -> StubProject:
+    now = datetime.now(timezone.utc)
+    return StubProject(
+        id=project_id,
+        title="Test Project",
+        source_type="idea",
+        idea_brief=idea_brief,
+        status="draft",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_script_from_idea_ready(client, stub_generate_services):
+    run_svc, project_svc, dispatcher = stub_generate_services
+    run_svc.runs[10] = _make_run(10, "IDEA_READY")
+    project_svc.projects[1] = _make_project(1, "Create a cooking tutorial")
+
+    response = await client.post(
+        "/api/creator/runs/10/generate-script",
+        json={"model_key": "qwen3-4b", "instructions": "Focus on pasta"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["task_id"] == "test-task-id-123"
+    assert body["run_id"] == 10
+    assert body["current_stage"] == "SCRIPT_GENERATING"
+    assert run_svc.advance_stage_calls == [{"run_id": 10, "target_stage": "SCRIPT_GENERATING"}]
+    assert len(run_svc.restart_run_calls) == 0
+    assert dispatcher.calls == [{
+        "run_id": 10,
+        "idea_brief": "Create a cooking tutorial",
+        "model_key": "qwen3-4b",
+        "instructions": "Focus on pasta",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_generate_script_from_script_review(client, stub_generate_services):
+    run_svc, project_svc, dispatcher = stub_generate_services
+    run_svc.runs[11] = _make_run(11, "SCRIPT_REVIEW")
+    project_svc.projects[1] = _make_project(1, "Science explainer")
+
+    response = await client.post(
+        "/api/creator/runs/11/generate-script",
+        json={"model_key": "qwen3-4b"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["current_stage"] == "SCRIPT_GENERATING"
+    assert len(run_svc.restart_run_calls) == 1
+    assert run_svc.restart_run_calls[0] == {"run_id": 11, "from_stage": "SCRIPT_GENERATING"}
+    assert len(run_svc.advance_stage_calls) == 0
+    assert dispatcher.calls[0]["idea_brief"] == "Science explainer"
+
+
+@pytest.mark.asyncio
+async def test_generate_script_default_model(client, stub_generate_services):
+    run_svc, project_svc, dispatcher = stub_generate_services
+    run_svc.runs[12] = _make_run(12, "IDEA_READY")
+    project_svc.projects[1] = _make_project(1, "My idea")
+
+    response = await client.post(
+        "/api/creator/runs/12/generate-script",
+        json={},
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["model_key"] == "qwen3-4b"
+    assert dispatcher.calls[0]["instructions"] is None
+
+
+@pytest.mark.asyncio
+async def test_generate_script_run_not_found(client, stub_generate_services):
+    _, _, _ = stub_generate_services
+    response = await client.post(
+        "/api/creator/runs/999/generate-script",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_script_wrong_stage_generating(client, stub_generate_services):
+    run_svc, _, _ = stub_generate_services
+    run_svc.runs[14] = _make_run(14, "SCRIPT_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/14/generate-script",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "SCRIPT_GENERATING" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_script_wrong_stage_visual(client, stub_generate_services):
+    run_svc, _, _ = stub_generate_services
+    run_svc.runs[15] = _make_run(15, "VISUAL_PLAN_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/15/generate-script",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "VISUAL_PLAN_GENERATING" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_script_idea_brief_fallback_to_title(client, stub_generate_services):
+    run_svc, project_svc, dispatcher = stub_generate_services
+    run_svc.runs[16] = _make_run(16, "IDEA_READY")
+    now = datetime.now(timezone.utc)
+    project_svc.projects[1] = StubProject(
+        id=1, title="Fallback Title", idea_brief=None,
+        created_at=now, updated_at=now,
+    )
+
+    response = await client.post(
+        "/api/creator/runs/16/generate-script",
+        json={},
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["idea_brief"] == "Fallback Title"

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -1057,3 +1057,204 @@ async def test_generate_visual_plan_dispatch_failure_rollback(client, stub_gener
 
     # Verify run was actually rolled back to SCRIPT_REVIEW
     assert run_svc.runs[36].current_stage == "SCRIPT_REVIEW"
+
+
+
+
+# -- generate-visual-assets tests -----------------------------------------------
+
+
+
+
+class StubImageDispatcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.task_id = "test-img-task-id-789"
+
+    def __call__(
+        self, run_id: int, model_key: str, scene_id: str | None,
+        prompt_override: str | None, is_active: bool,
+    ) -> str:
+        self.calls.append({
+            "run_id": run_id,
+            "model_key": model_key,
+            "scene_id": scene_id,
+            "prompt_override": prompt_override,
+            "is_active": is_active,
+        })
+        return self.task_id
+
+
+@pytest.fixture
+def stub_generate_visual_assets_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubImageDispatcher]:
+    run_svc = StubRunService()
+    dispatcher = StubImageDispatcher()
+
+    for route in runs_router.routes:
+        if route.name == "generate_visual_assets_trigger":
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "dispatch_generate_scene_image", dispatcher)
+
+    return run_svc, dispatcher
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_assets_from_visual_plan_review(client, stub_generate_visual_assets_services):
+    run_svc, dispatcher = stub_generate_visual_assets_services
+    run_svc.runs[60] = _make_run(60, "VISUAL_PLAN_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/60/generate-visual-assets",
+        json={"model_key": "sd15"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["task_id"] == "test-img-task-id-789"
+    assert body["run_id"] == 60
+    assert body["current_stage"] == "VISUAL_ASSET_GENERATING"
+    # CAS was called for VISUAL_PLAN_REVIEW → VISUAL_ASSET_GENERATING (no restart_from)
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 60
+    assert cas_calls[0]["updates"] == {"current_stage": "VISUAL_ASSET_GENERATING"}
+    assert "VISUAL_PLAN_REVIEW" in cas_calls[0]["expected_stages"]
+    assert dispatcher.calls == [{
+        "run_id": 60,
+        "model_key": "sd15",
+        "scene_id": None,
+        "prompt_override": None,
+        "is_active": True,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_assets_retry_from_generating(client, stub_generate_visual_assets_services):
+    run_svc, dispatcher = stub_generate_visual_assets_services
+    run_svc.runs[61] = _make_run(61, "VISUAL_ASSET_GENERATING")
+
+    response = await client.post(
+        "/api/creator/runs/61/generate-visual-assets",
+        json={"model_key": "sd15"},
+    )
+
+    assert response.status_code == 202
+    # CAS was called for VISUAL_ASSET_GENERATING → VISUAL_ASSET_GENERATING with restart_from
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["run_id"] == 61
+    assert cas_calls[0]["updates"] == {
+        "current_stage": "VISUAL_ASSET_GENERATING",
+        "restart_from": "VISUAL_ASSET_GENERATING",
+    }
+    assert "VISUAL_ASSET_GENERATING" in cas_calls[0]["expected_stages"]
+    assert len(dispatcher.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_assets_default_model(client, stub_generate_visual_assets_services):
+    run_svc, dispatcher = stub_generate_visual_assets_services
+    run_svc.runs[62] = _make_run(62, "VISUAL_PLAN_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/62/generate-visual-assets",
+        json={},
+    )
+
+    assert response.status_code == 202
+    assert dispatcher.calls[0]["model_key"] == "sd15"
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_assets_run_not_found(client, stub_generate_visual_assets_services):
+    _, _ = stub_generate_visual_assets_services
+    response = await client.post(
+        "/api/creator/runs/999/generate-visual-assets",
+        json={},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_assets_wrong_stage(client, stub_generate_visual_assets_services):
+    run_svc, _ = stub_generate_visual_assets_services
+    run_svc.runs[63] = _make_run(63, "IDEA_READY")
+
+    response = await client.post(
+        "/api/creator/runs/63/generate-visual-assets",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "IDEA_READY" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_assets_wrong_stage_script_review(client, stub_generate_visual_assets_services):
+    run_svc, _ = stub_generate_visual_assets_services
+    run_svc.runs[64] = _make_run(64, "SCRIPT_REVIEW")
+
+    response = await client.post(
+        "/api/creator/runs/64/generate-visual-assets",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "SCRIPT_REVIEW" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_assets_cas_conflict(client, stub_generate_visual_assets_services):
+    """CAS fails because stage changed between initial check and CAS."""
+    run_svc, dispatcher = stub_generate_visual_assets_services
+    run_svc.runs[65] = _make_run(65, "VISUAL_PLAN_REVIEW")
+
+    async def cas_conflict(run_id, updates, expected_stages):
+        return False, {"current_stage": "VISUAL_ASSET_GENERATING", "id": run_id}
+
+    run_svc.storage.conditional_update_run = cas_conflict
+
+    response = await client.post(
+        "/api/creator/runs/65/generate-visual-assets",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert "conflict" in response.json()["detail"].lower()
+    assert len(dispatcher.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_visual_assets_dispatch_failure_rollback(client, stub_generate_visual_assets_services):
+    """Celery dispatch failure triggers rollback to original stage."""
+    run_svc, _ = stub_generate_visual_assets_services
+    run_svc.runs[66] = _make_run(66, "VISUAL_PLAN_REVIEW")
+
+    def failing_dispatcher(run_id, model_key, scene_id, prompt_override, is_active):
+        raise RuntimeError("Celery broker down")
+
+    from shorts_api.main import runs_router as _r
+    for route in _r.routes:
+        if route.name == "generate_visual_assets_trigger":
+            route.endpoint.__globals__["dispatch_generate_scene_image"] = failing_dispatcher
+
+    response = await client.post(
+        "/api/creator/runs/66/generate-visual-assets",
+        json={},
+    )
+
+    assert response.status_code == 503
+    assert "enqueue" in response.json()["detail"].lower()
+
+    # Rollback: CAS was called twice — first to advance, then to rollback
+    cas_calls = run_svc.storage.conditional_update_calls
+    assert len(cas_calls) == 2
+    # Second CAS = rollback to VISUAL_PLAN_REVIEW
+    rollback = cas_calls[1]
+    assert rollback["updates"]["current_stage"] == "VISUAL_PLAN_REVIEW"
+    assert rollback["expected_stages"] == frozenset({"VISUAL_ASSET_GENERATING"})
+
+    # Verify run was actually rolled back to VISUAL_PLAN_REVIEW
+    assert run_svc.runs[66].current_stage == "VISUAL_PLAN_REVIEW"

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -692,6 +692,8 @@ async def test_parse_markdown_success(client, stub_parse_markdown_services):
     assert body["version"] == 2  # new draft version saved
     assert len(parse_calls) == 1
     assert parse_calls[0]["markdown"] == "## Hook\n\nGreat opening\n\n## Body\n\nDetails"
+    # Verify source_type is preserved from original draft (pasted_markdown, not edited_manually)
+    assert script_service.save_draft_calls[-1]["source_type"] == "pasted_markdown"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -6,7 +6,7 @@ from typing import Literal
 import pytest
 from pydantic import BaseModel
 
-from shorts_api.main import script_router
+from shorts_api.routes.creator_script import router as script_router, run_script_router
 
 
 class StubProject(BaseModel):
@@ -78,8 +78,22 @@ class StubScriptService:
         self.save_draft_calls: list[dict[str, object]] = []
         self.raise_error_message: str | None = None
         self.next_draft_id = 1
+        self.active_drafts: dict[int, StubScriptDraft] = {}
 
-    async def save_draft(self, run_id: int, source_type: str, markdown_content: str) -> StubScriptDraft:
+    async def get_active_draft(self, run_id: int) -> StubScriptDraft | None:
+        return self.active_drafts.get(run_id)
+
+    async def save_draft(
+        self,
+        run_id: int,
+        source_type: Literal[
+            "generated_by_model",
+            "pasted_markdown",
+            "uploaded_markdown",
+            "edited_manually",
+        ],
+        markdown_content: str,
+    ) -> StubScriptDraft:
         if self.raise_error_message is not None:
             raise ValueError(self.raise_error_message)
 
@@ -90,16 +104,20 @@ class StubScriptService:
                 "markdown_content": markdown_content,
             }
         )
+        current_draft = self.active_drafts.get(run_id)
+        next_version = 1 if current_draft is None else current_draft.version + 1
+
         draft = StubScriptDraft(
             id=self.next_draft_id,
             run_id=run_id,
-            source_type="pasted_markdown",
+            source_type=source_type,
             markdown_content=markdown_content,
             structured_script=None,
-            version=1,
+            version=next_version,
             created_at=datetime.now(timezone.utc),
         )
         self.next_draft_id += 1
+        self.active_drafts[run_id] = draft
         return draft
 
 
@@ -115,6 +133,16 @@ def stub_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubProjectService, 
         monkeypatch.setitem(route.endpoint.__globals__, "script_service", script)
 
     return project, run, script
+
+
+@pytest.fixture
+def stub_run_script_services(monkeypatch: pytest.MonkeyPatch) -> StubScriptService:
+    script = StubScriptService()
+
+    for route in run_script_router.routes:
+        monkeypatch.setitem(route.endpoint.__globals__, "script_service", script)
+
+    return script
 
 
 @pytest.mark.asyncio
@@ -281,4 +309,106 @@ async def test_import_markdown_create_run_failure(client, stub_services):
 
     assert response.status_code == 400
     assert response.json() == {"detail": "Duplicate run not allowed"}
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_get_script_markdown_success(client, stub_run_script_services):
+    script_service = stub_run_script_services
+    await script_service.save_draft(
+        run_id=51,
+        source_type="pasted_markdown",
+        markdown_content="# Current script\n\nLine",
+    )
+
+    response = await client.get("/api/creator/runs/51/script/markdown")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "run_id": 51,
+        "markdown": "# Current script\n\nLine",
+        "version": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_script_markdown_no_draft(client, stub_run_script_services):
+    _script_service = stub_run_script_services
+
+    response = await client.get("/api/creator/runs/999/script/markdown")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No script draft found for this run"}
+
+
+@pytest.mark.asyncio
+async def test_update_script_markdown_success(client, stub_run_script_services):
+    script_service = stub_run_script_services
+    await script_service.save_draft(
+        run_id=42,
+        source_type="pasted_markdown",
+        markdown_content="# V1",
+    )
+
+    response = await client.put(
+        "/api/creator/runs/42/script/markdown",
+        json={"markdown": "# V2\n\nUpdated"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 42
+    assert body["draft"]["source_type"] == "edited_manually"
+    assert body["draft"]["markdown_content"] == "# V2\n\nUpdated"
+    assert body["draft"]["version"] == 2
+    assert script_service.save_draft_calls[-1] == {
+        "run_id": 42,
+        "source_type": "edited_manually",
+        "markdown_content": "# V2\n\nUpdated",
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_script_markdown_without_existing_draft(client, stub_run_script_services):
+    script_service = stub_run_script_services
+
+    response = await client.put(
+        "/api/creator/runs/77/script/markdown",
+        json={"markdown": "# Fresh draft"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 77
+    assert body["draft"]["version"] == 1
+    assert body["draft"]["source_type"] == "edited_manually"
+    assert body["draft"]["markdown_content"] == "# Fresh draft"
+    assert script_service.active_drafts[77].version == 1
+
+
+@pytest.mark.asyncio
+async def test_update_script_markdown_empty(client, stub_run_script_services):
+    script_service = stub_run_script_services
+
+    response = await client.put(
+        "/api/creator/runs/13/script/markdown",
+        json={"markdown": ""},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "markdown content must not be empty"}
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_script_markdown_whitespace_only(client, stub_run_script_services):
+    script_service = stub_run_script_services
+
+    response = await client.put(
+        "/api/creator/runs/13/script/markdown",
+        json={"markdown": "   \n\t  "},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "markdown content must not be empty"}
     assert script_service.save_draft_calls == []

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -1,0 +1,248 @@
+# pyright: reportMissingImports=false
+
+from datetime import datetime, timezone
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from shorts_api.main import script_router
+
+
+class StubProject(BaseModel):
+    id: int
+    title: str = "Test Project"
+
+
+class StubPipelineRun(BaseModel):
+    id: int
+    project_id: int
+
+
+class StubScriptDraft(BaseModel):
+    id: int
+    run_id: int
+    source_type: Literal[
+        "generated_by_model",
+        "pasted_markdown",
+        "uploaded_markdown",
+        "edited_manually",
+    ]
+    markdown_content: str | None = None
+    structured_script: list[dict[str, object]] | None = None
+    version: int = 1
+    created_at: datetime
+
+
+class StubProjectService:
+    def __init__(self) -> None:
+        self.get_project_calls: list[int] = []
+        self.projects: dict[int, StubProject] = {}
+
+    async def get_project(self, project_id: int) -> StubProject | None:
+        self.get_project_calls.append(project_id)
+        return self.projects.get(project_id)
+
+
+class StubRunService:
+    def __init__(self) -> None:
+        self.create_run_calls: list[dict[str, object]] = []
+        self.next_run_id = 1
+
+    async def create_run(
+        self,
+        project_id: int,
+        model_defaults: dict[str, str] | None,
+        style_preset: str,
+        metadata: dict[str, object] | None = None,
+    ) -> StubPipelineRun:
+        self.create_run_calls.append(
+            {
+                "project_id": project_id,
+                "model_defaults": model_defaults,
+                "style_preset": style_preset,
+                "metadata": metadata,
+            }
+        )
+        run = StubPipelineRun(id=self.next_run_id, project_id=project_id)
+        self.next_run_id += 1
+        return run
+
+
+class StubScriptService:
+    def __init__(self) -> None:
+        self.save_draft_calls: list[dict[str, object]] = []
+        self.raise_error_message: str | None = None
+        self.next_draft_id = 1
+
+    async def save_draft(self, run_id: int, source_type: str, markdown_content: str) -> StubScriptDraft:
+        if self.raise_error_message is not None:
+            raise ValueError(self.raise_error_message)
+
+        self.save_draft_calls.append(
+            {
+                "run_id": run_id,
+                "source_type": source_type,
+                "markdown_content": markdown_content,
+            }
+        )
+        draft = StubScriptDraft(
+            id=self.next_draft_id,
+            run_id=run_id,
+            source_type="pasted_markdown",
+            markdown_content=markdown_content,
+            structured_script=None,
+            version=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        self.next_draft_id += 1
+        return draft
+
+
+@pytest.fixture
+def stub_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubProjectService, StubRunService, StubScriptService]:
+    project = StubProjectService()
+    run = StubRunService()
+    script = StubScriptService()
+
+    for route in script_router.routes:
+        monkeypatch.setitem(route.endpoint.__globals__, "project_service", project)
+        monkeypatch.setitem(route.endpoint.__globals__, "run_service", run)
+        monkeypatch.setitem(route.endpoint.__globals__, "script_service", script)
+
+    return project, run, script
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_success(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[11] = StubProject(id=11, title="Project 11")
+
+    response = await client.post(
+        "/api/creator/projects/11/script/import-markdown",
+        json={"markdown": "# My script\n\nHello world"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["project_id"] == 11
+    assert body["run_id"] == 1
+    assert body["draft"]["run_id"] == 1
+    assert body["draft"]["source_type"] == "pasted_markdown"
+    assert body["draft"]["markdown_content"] == "# My script\n\nHello world"
+    assert project_service.get_project_calls == [11]
+    assert run_service.create_run_calls == [
+        {
+            "project_id": 11,
+            "model_defaults": None,
+            "style_preset": "default",
+            "metadata": None,
+        }
+    ]
+    assert script_service.save_draft_calls == [
+        {
+            "run_id": 1,
+            "source_type": "pasted_markdown",
+            "markdown_content": "# My script\n\nHello world",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_project_not_found(client, stub_services):
+    _project_service, run_service, script_service = stub_services
+
+    response = await client.post(
+        "/api/creator/projects/404/script/import-markdown",
+        json={"markdown": "# Missing project"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Project not found"}
+    assert run_service.create_run_calls == []
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_empty_markdown(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[7] = StubProject(id=7, title="Project 7")
+
+    response = await client.post(
+        "/api/creator/projects/7/script/import-markdown",
+        json={"markdown": ""},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "markdown content must not be empty"}
+    assert run_service.create_run_calls == []
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_with_model_defaults(client, stub_services):
+    project_service, run_service, _script_service = stub_services
+    project_service.projects[21] = StubProject(id=21, title="Project 21")
+
+    response = await client.post(
+        "/api/creator/projects/21/script/import-markdown",
+        json={
+            "markdown": "# Styled script",
+            "model_defaults": {
+                "script_model": "manual",
+                "image_model": "sdxl-base",
+                "tts_model": "edge-alloy",
+            },
+            "style_preset": "cinematic",
+        },
+    )
+
+    assert response.status_code == 201
+    assert run_service.create_run_calls == [
+        {
+            "project_id": 21,
+            "model_defaults": {
+                "script_model": "manual",
+                "image_model": "sdxl-base",
+                "tts_model": "edge-alloy",
+            },
+            "style_preset": "cinematic",
+            "metadata": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_missing_markdown_field(client, stub_services):
+    project_service, _run_service, _script_service = stub_services
+    project_service.projects[9] = StubProject(id=9, title="Project 9")
+
+    response = await client.post(
+        "/api/creator/projects/9/script/import-markdown",
+        json={"style_preset": "default"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_service_error(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[15] = StubProject(id=15, title="Project 15")
+    script_service.raise_error_message = "Invalid markdown structure"
+
+    response = await client.post(
+        "/api/creator/projects/15/script/import-markdown",
+        json={"markdown": "# Broken"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid markdown structure"}
+    assert run_service.create_run_calls == [
+        {
+            "project_id": 15,
+            "model_defaults": None,
+            "style_preset": "default",
+            "metadata": None,
+        }
+    ]

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -73,6 +73,15 @@ class StubRunService:
         return run
 
 
+class StubRunServiceRead:
+    """Minimal run service stub for run-scoped endpoints (get_run only)."""
+
+    def __init__(self) -> None:
+        self.runs: dict[int, StubPipelineRun] = {}
+
+    async def get_run(self, run_id: int) -> StubPipelineRun | None:
+        return self.runs.get(run_id)
+
 class StubScriptService:
     def __init__(self) -> None:
         self.save_draft_calls: list[dict[str, object]] = []
@@ -136,14 +145,15 @@ def stub_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubProjectService, 
 
 
 @pytest.fixture
-def stub_run_script_services(monkeypatch: pytest.MonkeyPatch) -> StubScriptService:
+def stub_run_script_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunServiceRead, StubScriptService]:
+    run = StubRunServiceRead()
     script = StubScriptService()
 
     for route in run_script_router.routes:
+        monkeypatch.setitem(route.endpoint.__globals__, "run_service", run)
         monkeypatch.setitem(route.endpoint.__globals__, "script_service", script)
 
-    return script
-
+    return run, script
 
 @pytest.mark.asyncio
 async def test_import_markdown_success(client, stub_services):
@@ -314,7 +324,8 @@ async def test_import_markdown_create_run_failure(client, stub_services):
 
 @pytest.mark.asyncio
 async def test_get_script_markdown_success(client, stub_run_script_services):
-    script_service = stub_run_script_services
+    run_service, script_service = stub_run_script_services
+    run_service.runs[51] = StubPipelineRun(id=51, project_id=1)
     await script_service.save_draft(
         run_id=51,
         source_type="pasted_markdown",
@@ -330,10 +341,10 @@ async def test_get_script_markdown_success(client, stub_run_script_services):
         "version": 1,
     }
 
-
 @pytest.mark.asyncio
 async def test_get_script_markdown_no_draft(client, stub_run_script_services):
-    _script_service = stub_run_script_services
+    run_service, _script_service = stub_run_script_services
+    run_service.runs[999] = StubPipelineRun(id=999, project_id=1)
 
     response = await client.get("/api/creator/runs/999/script/markdown")
 
@@ -342,8 +353,18 @@ async def test_get_script_markdown_no_draft(client, stub_run_script_services):
 
 
 @pytest.mark.asyncio
+async def test_get_script_markdown_run_not_found(client, stub_run_script_services):
+    _run_service, _script_service = stub_run_script_services
+
+    response = await client.get("/api/creator/runs/888/script/markdown")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run 888 not found"}
+
+@pytest.mark.asyncio
 async def test_update_script_markdown_success(client, stub_run_script_services):
-    script_service = stub_run_script_services
+    run_service, script_service = stub_run_script_services
+    run_service.runs[42] = StubPipelineRun(id=42, project_id=1)
     await script_service.save_draft(
         run_id=42,
         source_type="pasted_markdown",
@@ -367,10 +388,25 @@ async def test_update_script_markdown_success(client, stub_run_script_services):
         "markdown_content": "# V2\n\nUpdated",
     }
 
+@pytest.mark.asyncio
+async def test_update_script_markdown_run_not_found(client, stub_run_script_services):
+    _run_service, script_service = stub_run_script_services
+
+    response = await client.put(
+        "/api/creator/runs/77/script/markdown",
+        json={"markdown": "# Fresh draft"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run 77 not found"}
+    assert script_service.save_draft_calls == []
+
 
 @pytest.mark.asyncio
-async def test_update_script_markdown_without_existing_draft(client, stub_run_script_services):
-    script_service = stub_run_script_services
+async def test_update_script_markdown_first_draft(client, stub_run_script_services):
+    """PUT /markdown succeeds when run exists but no prior draft (creates first draft)."""
+    run_service, script_service = stub_run_script_services
+    run_service.runs[77] = StubPipelineRun(id=77, project_id=1)
 
     response = await client.put(
         "/api/creator/runs/77/script/markdown",
@@ -385,10 +421,9 @@ async def test_update_script_markdown_without_existing_draft(client, stub_run_sc
     assert body["draft"]["markdown_content"] == "# Fresh draft"
     assert script_service.active_drafts[77].version == 1
 
-
 @pytest.mark.asyncio
 async def test_update_script_markdown_empty(client, stub_run_script_services):
-    script_service = stub_run_script_services
+    _run_service, script_service = stub_run_script_services
 
     response = await client.put(
         "/api/creator/runs/13/script/markdown",
@@ -399,10 +434,9 @@ async def test_update_script_markdown_empty(client, stub_run_script_services):
     assert response.json() == {"detail": "markdown content must not be empty"}
     assert script_service.save_draft_calls == []
 
-
 @pytest.mark.asyncio
 async def test_update_script_markdown_whitespace_only(client, stub_run_script_services):
-    script_service = stub_run_script_services
+    _run_service, script_service = stub_run_script_services
 
     response = await client.put(
         "/api/creator/runs/13/script/markdown",

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -29,7 +29,7 @@ class StubScriptDraft(BaseModel):
         "edited_manually",
     ]
     markdown_content: str | None = None
-    structured_script: list[dict[str, object]] | None = None
+    structured_script: list[object] | None = None
     version: int = 1
     created_at: datetime
 
@@ -102,17 +102,19 @@ class StubScriptService:
             "edited_manually",
         ],
         markdown_content: str,
+        structured_script: list | None = None,
     ) -> StubScriptDraft:
         if self.raise_error_message is not None:
             raise ValueError(self.raise_error_message)
 
-        self.save_draft_calls.append(
-            {
-                "run_id": run_id,
-                "source_type": source_type,
-                "markdown_content": markdown_content,
-            }
-        )
+        save_call: dict[str, object] = {
+            "run_id": run_id,
+            "source_type": source_type,
+            "markdown_content": markdown_content,
+        }
+        if structured_script is not None:
+            save_call["structured_script"] = structured_script
+        self.save_draft_calls.append(save_call)
         current_draft = self.active_drafts.get(run_id)
         next_version = 1 if current_draft is None else current_draft.version + 1
 
@@ -121,7 +123,7 @@ class StubScriptService:
             run_id=run_id,
             source_type=source_type,
             markdown_content=markdown_content,
-            structured_script=None,
+            structured_script=structured_script,
             version=next_version,
             created_at=datetime.now(timezone.utc),
         )
@@ -446,3 +448,165 @@ async def test_update_script_markdown_whitespace_only(client, stub_run_script_se
     assert response.status_code == 400
     assert response.json() == {"detail": "markdown content must not be empty"}
     assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_get_script_structured_success(client, stub_run_script_services):
+    run_service, script_service = stub_run_script_services
+    run_service.runs[60] = StubPipelineRun(id=60, project_id=1)
+
+    update_response = await client.put(
+        "/api/creator/runs/60/script/structured",
+        json={
+            "sections": [
+                {"section_id": "intro-1", "type": "intro", "text": "Welcome"},
+                {"section_id": "body-1", "type": "body", "text": "Main point"},
+            ]
+        },
+    )
+    assert update_response.status_code == 200
+
+    response = await client.get("/api/creator/runs/60/script/structured")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "run_id": 60,
+        "sections": [
+            {
+                "section_id": "intro-1",
+                "type": "intro",
+                "text": "Welcome",
+                "display_text": None,
+                "speaker": "host",
+                "duration": None,
+                "turn_kind": None,
+                "visual_override": None,
+            },
+            {
+                "section_id": "body-1",
+                "type": "body",
+                "text": "Main point",
+                "display_text": None,
+                "speaker": "host",
+                "duration": None,
+                "turn_kind": None,
+                "visual_override": None,
+            },
+        ],
+        "version": 1,
+    }
+    assert script_service.active_drafts[60].structured_script is not None
+
+
+@pytest.mark.asyncio
+async def test_get_script_structured_no_draft(client, stub_run_script_services):
+    run_service, _script_service = stub_run_script_services
+    run_service.runs[61] = StubPipelineRun(id=61, project_id=1)
+
+    response = await client.get("/api/creator/runs/61/script/structured")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No script draft found for this run"}
+
+
+@pytest.mark.asyncio
+async def test_get_script_structured_run_not_found(client, stub_run_script_services):
+    _run_service, _script_service = stub_run_script_services
+
+    response = await client.get("/api/creator/runs/404/script/structured")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run 404 not found"}
+
+
+@pytest.mark.asyncio
+async def test_get_script_structured_empty_sections(client, stub_run_script_services):
+    run_service, script_service = stub_run_script_services
+    run_service.runs[62] = StubPipelineRun(id=62, project_id=1)
+    await script_service.save_draft(
+        run_id=62,
+        source_type="edited_manually",
+        markdown_content="",
+        structured_script=[],
+    )
+
+    response = await client.get("/api/creator/runs/62/script/structured")
+
+    assert response.status_code == 200
+    assert response.json() == {"run_id": 62, "sections": [], "version": 1}
+
+
+@pytest.mark.asyncio
+async def test_update_script_structured_success(client, stub_run_script_services):
+    run_service, script_service = stub_run_script_services
+    run_service.runs[63] = StubPipelineRun(id=63, project_id=1)
+
+    response = await client.put(
+        "/api/creator/runs/63/script/structured",
+        json={
+            "sections": [
+                {"section_id": "sec-1", "type": "hook", "text": "Start here"},
+                {"section_id": "sec-2", "type": "cta", "text": "Follow for more"},
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 63
+    assert body["draft"]["source_type"] == "edited_manually"
+    assert body["draft"]["markdown_content"] == "## hook\n\nStart here\n\n## cta\n\nFollow for more"
+    assert body["draft"]["structured_script"][0]["section_id"] == "sec-1"
+    assert script_service.save_draft_calls[-1]["source_type"] == "edited_manually"
+    assert script_service.save_draft_calls[-1]["markdown_content"] == "## hook\n\nStart here\n\n## cta\n\nFollow for more"
+
+
+@pytest.mark.asyncio
+async def test_update_script_structured_run_not_found(client, stub_run_script_services):
+    _run_service, script_service = stub_run_script_services
+
+    response = await client.put(
+        "/api/creator/runs/64/script/structured",
+        json={"sections": [{"section_id": "sec-1", "type": "hook", "text": "Start"}]},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run 64 not found"}
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_script_structured_invalid_section(client, stub_run_script_services):
+    run_service, script_service = stub_run_script_services
+    run_service.runs[65] = StubPipelineRun(id=65, project_id=1)
+
+    response = await client.put(
+        "/api/creator/runs/65/script/structured",
+        json={"sections": [{"type": "hook", "text": "Missing id"}]},
+    )
+
+    assert response.status_code == 400
+    assert "detail" in response.json()
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_script_structured_preserves_section_id(client, stub_run_script_services):
+    run_service, script_service = stub_run_script_services
+    run_service.runs[66] = StubPipelineRun(id=66, project_id=1)
+
+    response = await client.put(
+        "/api/creator/runs/66/script/structured",
+        json={
+            "sections": [
+                {"section_id": "original-101", "type": "intro", "text": "Hello"},
+                {"section_id": "original-102", "type": "body", "text": "Details"},
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    saved_sections = script_service.save_draft_calls[-1]["structured_script"]
+    assert saved_sections is not None
+    assert saved_sections[0].section_id == "original-101"
+    assert saved_sections[1].section_id == "original-102"

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -47,6 +47,7 @@ class StubProjectService:
 class StubRunService:
     def __init__(self) -> None:
         self.create_run_calls: list[dict[str, object]] = []
+        self.raise_error_message: str | None = None
         self.next_run_id = 1
 
     async def create_run(
@@ -56,6 +57,9 @@ class StubRunService:
         style_preset: str,
         metadata: dict[str, object] | None = None,
     ) -> StubPipelineRun:
+        if self.raise_error_message is not None:
+            raise ValueError(self.raise_error_message)
+
         self.create_run_calls.append(
             {
                 "project_id": project_id,
@@ -246,3 +250,35 @@ async def test_import_markdown_service_error(client, stub_services):
             "metadata": None,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_whitespace_only(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[7] = StubProject(id=7, title="Project 7")
+
+    response = await client.post(
+        "/api/creator/projects/7/script/import-markdown",
+        json={"markdown": "   \n  \t  "},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "markdown content must not be empty"}
+    assert run_service.create_run_calls == []
+    assert script_service.save_draft_calls == []
+
+
+@pytest.mark.asyncio
+async def test_import_markdown_create_run_failure(client, stub_services):
+    project_service, run_service, script_service = stub_services
+    project_service.projects[20] = StubProject(id=20, title="Project 20")
+    run_service.raise_error_message = "Duplicate run not allowed"
+
+    response = await client.post(
+        "/api/creator/projects/20/script/import-markdown",
+        json={"markdown": "# Valid content"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Duplicate run not allowed"}
+    assert script_service.save_draft_calls == []

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -610,3 +610,190 @@ async def test_update_script_structured_preserves_section_id(client, stub_run_sc
     assert saved_sections is not None
     assert saved_sections[0].section_id == "original-101"
     assert saved_sections[1].section_id == "original-102"
+
+
+# --- parse-markdown endpoint tests ---
+
+
+class StubScriptSection:
+    """Minimal stub matching ScriptSection interface for parse_markdown mock."""
+
+    def __init__(self, section_id: str, type: str, text: str) -> None:
+        self.section_id = section_id
+        self.type = type
+        self.text = text
+        self.display_text = text
+        self.speaker = "host"
+        self.duration = None
+        self.turn_kind = None
+        self.visual_override = None
+
+    def model_dump(self, *, mode: str = "python") -> dict:
+        return {
+            "section_id": self.section_id,
+            "type": self.type,
+            "text": self.text,
+            "display_text": self.display_text,
+            "speaker": self.speaker,
+            "duration": self.duration,
+            "turn_kind": self.turn_kind,
+            "visual_override": self.visual_override,
+        }
+
+
+@pytest.fixture
+def stub_parse_markdown_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunServiceRead, StubScriptService, list]:
+    """Fixture that also patches parse_markdown for run_script_router routes."""
+    run = StubRunServiceRead()
+    script = StubScriptService()
+    parse_calls: list[dict] = []
+
+    def fake_parse_markdown(markdown: str, existing_sections=None):
+        parse_calls.append({"markdown": markdown, "existing_sections": existing_sections})
+        sections = []
+        for line in markdown.split("\n"):
+            if line.startswith("## "):
+                heading = line[3:].strip().lower()
+                sections.append(StubScriptSection(
+                    section_id=f"{heading}-{len(sections)+1}",
+                    type=heading,
+                    text=f"Text for {heading}",
+                ))
+        if not sections:
+            sections.append(StubScriptSection(
+                section_id="body-1", type="body", text=markdown.strip()
+            ))
+        return sections
+
+    for route in run_script_router.routes:
+        monkeypatch.setitem(route.endpoint.__globals__, "run_service", run)
+        monkeypatch.setitem(route.endpoint.__globals__, "script_service", script)
+        monkeypatch.setitem(route.endpoint.__globals__, "parse_markdown", fake_parse_markdown)
+
+    return run, script, parse_calls
+
+
+@pytest.mark.asyncio
+async def test_parse_markdown_success(client, stub_parse_markdown_services):
+    run_service, script_service, parse_calls = stub_parse_markdown_services
+    run_service.runs[70] = StubPipelineRun(id=70, project_id=1)
+    await script_service.save_draft(
+        run_id=70,
+        source_type="pasted_markdown",
+        markdown_content="## Hook\n\nGreat opening\n\n## Body\n\nDetails",
+    )
+
+    response = await client.post("/api/creator/runs/70/script/parse-markdown")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 70
+    assert len(body["sections"]) > 0
+    assert body["version"] == 2  # new draft version saved
+    assert len(parse_calls) == 1
+    assert parse_calls[0]["markdown"] == "## Hook\n\nGreat opening\n\n## Body\n\nDetails"
+
+
+@pytest.mark.asyncio
+async def test_parse_markdown_run_not_found(client, stub_parse_markdown_services):
+    _run_service, script_service, parse_calls = stub_parse_markdown_services
+
+    response = await client.post("/api/creator/runs/999/script/parse-markdown")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run 999 not found"}
+    assert script_service.save_draft_calls == []
+    assert parse_calls == []
+
+
+@pytest.mark.asyncio
+async def test_parse_markdown_no_draft(client, stub_parse_markdown_services):
+    run_service, script_service, parse_calls = stub_parse_markdown_services
+    run_service.runs[71] = StubPipelineRun(id=71, project_id=1)
+
+    response = await client.post("/api/creator/runs/71/script/parse-markdown")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No script draft found for this run"}
+    assert script_service.save_draft_calls == []
+    assert parse_calls == []
+
+
+@pytest.mark.asyncio
+async def test_parse_markdown_empty_content(client, stub_parse_markdown_services):
+    run_service, script_service, parse_calls = stub_parse_markdown_services
+    run_service.runs[72] = StubPipelineRun(id=72, project_id=1)
+    await script_service.save_draft(
+        run_id=72,
+        source_type="pasted_markdown",
+        markdown_content="",
+    )
+
+    response = await client.post("/api/creator/runs/72/script/parse-markdown")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Draft has no markdown content to parse"}
+    assert parse_calls == []
+
+
+@pytest.mark.asyncio
+async def test_parse_markdown_whitespace_only_content(client, stub_parse_markdown_services):
+    run_service, script_service, parse_calls = stub_parse_markdown_services
+    run_service.runs[73] = StubPipelineRun(id=73, project_id=1)
+    await script_service.save_draft(
+        run_id=73,
+        source_type="pasted_markdown",
+        markdown_content="   \n  \t  ",
+    )
+
+    response = await client.post("/api/creator/runs/73/script/parse-markdown")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Draft has no markdown content to parse"}
+    assert parse_calls == []
+
+
+@pytest.mark.asyncio
+async def test_parse_markdown_preserves_existing_sections(client, stub_parse_markdown_services):
+    """Parse passes existing structured_script to parse_markdown for stable IDs."""
+    run_service, script_service, parse_calls = stub_parse_markdown_services
+    run_service.runs[74] = StubPipelineRun(id=74, project_id=1)
+
+    existing_sections = [
+        StubScriptSection(section_id="existing-1", type="hook", text="Old hook"),
+    ]
+    await script_service.save_draft(
+        run_id=74,
+        source_type="edited_manually",
+        markdown_content="## Hook\n\nOld hook",
+        structured_script=existing_sections,
+    )
+
+    response = await client.post("/api/creator/runs/74/script/parse-markdown")
+
+    assert response.status_code == 200
+    assert len(parse_calls) == 1
+    # Verify existing_sections was passed to parse_markdown
+    assert parse_calls[0]["existing_sections"] is not None
+    assert parse_calls[0]["existing_sections"][0].section_id == "existing-1"
+
+
+@pytest.mark.asyncio
+async def test_parse_markdown_none_content(client, stub_parse_markdown_services):
+    """Draft with markdown_content=None should return 400."""
+    run_service, script_service, parse_calls = stub_parse_markdown_services
+    run_service.runs[75] = StubPipelineRun(id=75, project_id=1)
+    script_service.active_drafts[75] = StubScriptDraft(
+        id=100,
+        run_id=75,
+        source_type="edited_manually",
+        markdown_content=None,
+        version=1,
+        created_at=datetime.now(timezone.utc),
+    )
+
+    response = await client.post("/api/creator/runs/75/script/parse-markdown")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Draft has no markdown content to parse"}
+    assert parse_calls == []

--- a/apps/api/tests/test_creator_visual_plan.py
+++ b/apps/api/tests/test_creator_visual_plan.py
@@ -1,0 +1,299 @@
+# pyright: reportMissingImports=false
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+import pytest
+from models.visual_plan import VisualScene
+from pydantic import BaseModel
+from shorts_api.main import visual_plan_router
+
+
+class StubPipelineRun(BaseModel):
+    id: int
+    project_id: int
+    current_stage: str | None = None
+    status: Literal["pending", "running", "paused", "completed", "failed", "cancelled"] = "pending"
+    review_stage: str | None = None
+    restart_from: str | None = None
+    model_defaults: dict[str, str] | None = None
+    metadata: dict[str, object] | None = None
+    style_preset: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class StubRunService:
+    def __init__(self) -> None:
+        self.runs: dict[int, StubPipelineRun] = {}
+
+    async def get_run(self, run_id: int) -> StubPipelineRun | None:
+        return self.runs.get(run_id)
+
+
+class StubVisualPlan(BaseModel):
+    id: int
+    run_id: int
+    version: int
+    scenes: list[VisualScene]
+    created_at: datetime
+
+
+class StubVisualPlanService:
+    def __init__(self) -> None:
+        self.plans: dict[int, list[StubVisualPlan]] = {}
+        self._next_id = 1
+        self.save_calls: list[dict[str, Any]] = []
+
+    async def get_active_plan(self, run_id: int) -> StubVisualPlan | None:
+        versions = self.plans.get(run_id, [])
+        if not versions:
+            return None
+        return max(versions, key=lambda p: p.version)
+
+    async def save_plan(self, run_id: int, scenes: list[Any]) -> StubVisualPlan:
+        self.save_calls.append({"run_id": run_id, "scenes": scenes})
+        versions = self.plans.setdefault(run_id, [])
+        next_version = max((p.version for p in versions), default=0) + 1
+        plan = StubVisualPlan(
+            id=self._next_id,
+            run_id=run_id,
+            version=next_version,
+            scenes=[VisualScene.model_validate(s) for s in scenes],
+            created_at=datetime.now(timezone.utc),
+        )
+        self._next_id += 1
+        versions.append(plan)
+        return plan
+
+
+def _make_run(run_id: int, stage: str = "VISUAL_PLAN_REVIEW") -> StubPipelineRun:
+    now = datetime.now(timezone.utc)
+    return StubPipelineRun(
+        id=run_id,
+        project_id=1,
+        current_stage=stage,
+        status="running",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_scene(scene_id: str = "scene-1", index: int = 0) -> dict[str, Any]:
+    return {
+        "scene_id": scene_id,
+        "section_id": "sec-1",
+        "scene_index": index,
+        "section_type": "narration",
+        "original_text": "Sample narration text",
+        "prompt": "A person explaining something",
+        "prompt_edited": False,
+        "prompt_source": "auto_generated",
+        "style_tags": ["cinematic"],
+        "mood": "neutral",
+        "composition": "medium-shot",
+        "generation_status": "pending",
+        "latest_asset_id": None,
+    }
+
+
+@pytest.fixture
+def stub_visual_plan_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubVisualPlanService]:
+    run_svc = StubRunService()
+    vp_svc = StubVisualPlanService()
+
+    for route in visual_plan_router.routes:
+        if route.name in {"get_visual_plan", "replace_visual_plan"}:
+            monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
+            monkeypatch.setitem(route.endpoint.__globals__, "visual_plan_service", vp_svc)
+
+    return run_svc, vp_svc
+
+
+# ---------------------------------------------------------------------------
+# GET /runs/{run_id}/visual-plan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_visual_plan_success(client, stub_visual_plan_services):
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[10] = _make_run(10)
+    scene = _make_scene()
+    vp_svc.plans[10] = [
+        StubVisualPlan(
+            id=1,
+            run_id=10,
+            version=1,
+            scenes=[scene],
+            created_at=datetime.now(timezone.utc),
+        )
+    ]
+
+    response = await client.get("/api/creator/runs/10/visual-plan")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 10
+    assert body["version"] == 1
+    assert len(body["scenes"]) == 1
+    assert body["scenes"][0]["scene_id"] == "scene-1"
+    assert body["scenes"][0]["prompt"] == "A person explaining something"
+
+
+@pytest.mark.asyncio
+async def test_get_visual_plan_run_not_found(client, stub_visual_plan_services):
+    _, _ = stub_visual_plan_services
+    response = await client.get("/api/creator/runs/999/visual-plan")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_get_visual_plan_no_plan(client, stub_visual_plan_services):
+    run_svc, _ = stub_visual_plan_services
+    run_svc.runs[11] = _make_run(11)
+
+    response = await client.get("/api/creator/runs/11/visual-plan")
+
+    assert response.status_code == 404
+    assert "no visual plan" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_get_visual_plan_latest_version(client, stub_visual_plan_services):
+    """When multiple versions exist, GET returns the latest."""
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[12] = _make_run(12)
+    scene_v1 = _make_scene("scene-v1")
+    scene_v2 = _make_scene("scene-v2")
+    now = datetime.now(timezone.utc)
+    vp_svc.plans[12] = [
+        StubVisualPlan(id=1, run_id=12, version=1, scenes=[scene_v1], created_at=now),
+        StubVisualPlan(id=2, run_id=12, version=2, scenes=[scene_v2], created_at=now),
+    ]
+
+    response = await client.get("/api/creator/runs/12/visual-plan")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == 2
+    assert body["scenes"][0]["scene_id"] == "scene-v2"
+
+
+# ---------------------------------------------------------------------------
+# PUT /runs/{run_id}/visual-plan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replace_visual_plan_success(client, stub_visual_plan_services):
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[20] = _make_run(20)
+
+    scene = _make_scene("scene-new")
+    response = await client.put(
+        "/api/creator/runs/20/visual-plan",
+        json={"scenes": [scene]},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 20
+    assert body["version"] == 1
+    assert len(body["scenes"]) == 1
+    assert body["scenes"][0]["scene_id"] == "scene-new"
+    assert len(vp_svc.save_calls) == 1
+    assert vp_svc.save_calls[0]["run_id"] == 20
+
+
+@pytest.mark.asyncio
+async def test_replace_visual_plan_version_increment(client, stub_visual_plan_services):
+    """Second PUT creates version 2."""
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[21] = _make_run(21)
+
+    scene1 = _make_scene("scene-a")
+    scene2 = _make_scene("scene-b")
+
+    await client.put(
+        "/api/creator/runs/21/visual-plan",
+        json={"scenes": [scene1]},
+    )
+
+    response = await client.put(
+        "/api/creator/runs/21/visual-plan",
+        json={"scenes": [scene2]},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == 2
+    assert body["scenes"][0]["scene_id"] == "scene-b"
+    assert len(vp_svc.save_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_replace_visual_plan_run_not_found(client, stub_visual_plan_services):
+    _, _ = stub_visual_plan_services
+    scene = _make_scene()
+    response = await client.put(
+        "/api/creator/runs/999/visual-plan",
+        json={"scenes": [scene]},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_replace_visual_plan_invalid_scene(client, stub_visual_plan_services):
+    """Invalid scene data returns 400."""
+    run_svc, _ = stub_visual_plan_services
+    run_svc.runs[22] = _make_run(22)
+
+    response = await client.put(
+        "/api/creator/runs/22/visual-plan",
+        json={"scenes": [{"invalid": "data"}]},
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_replace_visual_plan_empty_scenes(client, stub_visual_plan_services):
+    """Empty scenes list is valid — clears the plan."""
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[23] = _make_run(23)
+
+    response = await client.put(
+        "/api/creator/runs/23/visual-plan",
+        json={"scenes": []},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scenes"] == []
+    assert body["version"] == 1
+    assert len(vp_svc.save_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_replace_visual_plan_multiple_scenes(client, stub_visual_plan_services):
+    """PUT with multiple scenes preserves order."""
+    run_svc, _ = stub_visual_plan_services
+    run_svc.runs[24] = _make_run(24)
+
+    scenes = [_make_scene(f"scene-{i}", i) for i in range(3)]
+    response = await client.put(
+        "/api/creator/runs/24/visual-plan",
+        json={"scenes": scenes},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["scenes"]) == 3
+    assert [s["scene_id"] for s in body["scenes"]] == ["scene-0", "scene-1", "scene-2"]

--- a/apps/api/tests/test_creator_visual_plan.py
+++ b/apps/api/tests/test_creator_visual_plan.py
@@ -68,6 +68,42 @@ class StubVisualPlanService:
         versions.append(plan)
         return plan
 
+    async def patch_scene(
+        self,
+        run_id: int,
+        scene_id: str,
+        updates: dict[str, Any],
+        *,
+        expected_version: int | None = None,
+    ) -> StubVisualPlan:
+        """Stub patch_scene: load active plan, apply updates, save new version."""
+        active = await self.get_active_plan(run_id)
+        if active is None:
+            raise ValueError(f"No active visual plan for run {run_id}")
+
+        if expected_version is not None and active.version != expected_version:
+            from visual_plan_service import VersionConflictError
+            raise VersionConflictError(run_id, expected_version, active.version)
+
+        _patchable = {"prompt", "prompt_edited", "prompt_source", "style_tags", "mood", "composition"}
+        unknown = set(updates.keys()) - _patchable
+        if unknown:
+            raise ValueError(f"Cannot patch immutable/unknown fields: {sorted(unknown)}")
+
+        patched = False
+        new_scenes: list[VisualScene] = []
+        for scene in active.scenes:
+            d = scene.model_dump()
+            if d["scene_id"] == scene_id:
+                d.update(updates)
+                patched = True
+            new_scenes.append(VisualScene.model_validate(d))
+
+        if not patched:
+            raise ValueError(f"Scene '{scene_id}' not found in visual plan for run {run_id}")
+
+        return await self.save_plan(run_id, new_scenes)
+
 
 def _make_run(run_id: int, stage: str = "VISUAL_PLAN_REVIEW") -> StubPipelineRun:
     now = datetime.now(timezone.utc)
@@ -105,7 +141,7 @@ def stub_visual_plan_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunS
     vp_svc = StubVisualPlanService()
 
     for route in visual_plan_router.routes:
-        if route.name in {"get_visual_plan", "replace_visual_plan"}:
+        if route.name in {"get_visual_plan", "replace_visual_plan", "patch_scene"}:
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
             monkeypatch.setitem(route.endpoint.__globals__, "visual_plan_service", vp_svc)
 
@@ -297,3 +333,234 @@ async def test_replace_visual_plan_multiple_scenes(client, stub_visual_plan_serv
     body = response.json()
     assert len(body["scenes"]) == 3
     assert [s["scene_id"] for s in body["scenes"]] == ["scene-0", "scene-1", "scene-2"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH /runs/{run_id}/visual-plan/scenes/{scene_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_success(client, stub_visual_plan_services):
+    """PATCH updates a single field and returns updated plan."""
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[30] = _make_run(30)
+    scene = _make_scene("scene-1")
+    vp_svc.plans[30] = [
+        StubVisualPlan(
+            id=1,
+            run_id=30,
+            version=1,
+            scenes=[scene],
+            created_at=datetime.now(timezone.utc),
+        )
+    ]
+
+    response = await client.patch(
+        "/api/creator/runs/30/visual-plan/scenes/scene-1",
+        json={"prompt": "Updated prompt text"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == 30
+    assert body["version"] == 2
+    assert body["scenes"][0]["prompt"] == "Updated prompt text"
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_multiple_fields(client, stub_visual_plan_services):
+    """PATCH can update multiple patchable fields at once."""
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[31] = _make_run(31)
+    scene = _make_scene("scene-1")
+    vp_svc.plans[31] = [
+        StubVisualPlan(
+            id=1,
+            run_id=31,
+            version=1,
+            scenes=[scene],
+            created_at=datetime.now(timezone.utc),
+        )
+    ]
+
+    response = await client.patch(
+        "/api/creator/runs/31/visual-plan/scenes/scene-1",
+        json={
+            "prompt": "New prompt",
+            "mood": "dramatic",
+            "style_tags": ["noir", "high-contrast"],
+            "composition": "close-up",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    s = body["scenes"][0]
+    assert s["prompt"] == "New prompt"
+    assert s["mood"] == "dramatic"
+    assert s["style_tags"] == ["noir", "high-contrast"]
+    assert s["composition"] == "close-up"
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_preserves_non_patched_fields(client, stub_visual_plan_services):
+    """Fields not in the PATCH body remain unchanged."""
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[32] = _make_run(32)
+    scene = _make_scene("scene-1")
+    vp_svc.plans[32] = [
+        StubVisualPlan(
+            id=1,
+            run_id=32,
+            version=1,
+            scenes=[scene],
+            created_at=datetime.now(timezone.utc),
+        )
+    ]
+
+    response = await client.patch(
+        "/api/creator/runs/32/visual-plan/scenes/scene-1",
+        json={"mood": "tense"},
+    )
+
+    assert response.status_code == 200
+    s = response.json()["scenes"][0]
+    assert s["prompt"] == "A person explaining something"
+    assert s["style_tags"] == ["cinematic"]
+    assert s["composition"] == "medium-shot"
+    assert s["mood"] == "tense"
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_run_not_found(client, stub_visual_plan_services):
+    """PATCH returns 404 when run doesn't exist."""
+    _, _ = stub_visual_plan_services
+    response = await client.patch(
+        "/api/creator/runs/999/visual-plan/scenes/scene-1",
+        json={"prompt": "x"},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_no_plan(client, stub_visual_plan_services):
+    """PATCH returns 404 when run has no visual plan."""
+    run_svc, _ = stub_visual_plan_services
+    run_svc.runs[33] = _make_run(33)
+
+    response = await client.patch(
+        "/api/creator/runs/33/visual-plan/scenes/scene-1",
+        json={"prompt": "x"},
+    )
+
+    assert response.status_code == 404
+    assert "no active" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_not_found(client, stub_visual_plan_services):
+    """PATCH returns 404 when scene_id doesn't exist in the plan."""
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[34] = _make_run(34)
+    scene = _make_scene("scene-1")
+    vp_svc.plans[34] = [
+        StubVisualPlan(
+            id=1,
+            run_id=34,
+            version=1,
+            scenes=[scene],
+            created_at=datetime.now(timezone.utc),
+        )
+    ]
+
+    response = await client.patch(
+        "/api/creator/runs/34/visual-plan/scenes/nonexistent",
+        json={"prompt": "x"},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_version_conflict(client, stub_visual_plan_services):
+    """PATCH returns 409 when expected_version doesn't match."""
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[35] = _make_run(35)
+    scene = _make_scene("scene-1")
+    vp_svc.plans[35] = [
+        StubVisualPlan(
+            id=1,
+            run_id=35,
+            version=3,
+            scenes=[scene],
+            created_at=datetime.now(timezone.utc),
+        )
+    ]
+
+    response = await client.patch(
+        "/api/creator/runs/35/visual-plan/scenes/scene-1",
+        json={"prompt": "x", "expected_version": 1},
+    )
+
+    assert response.status_code == 409
+    assert "version conflict" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_empty_updates(client, stub_visual_plan_services):
+    """PATCH returns 400 when no patchable fields provided."""
+    run_svc, _ = stub_visual_plan_services
+    run_svc.runs[36] = _make_run(36)
+
+    response = await client.patch(
+        "/api/creator/runs/36/visual-plan/scenes/scene-1",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert "no patchable" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_unknown_fields(client, stub_visual_plan_services):
+    """PATCH returns 422 when unknown fields are sent (extra=forbid)."""
+    run_svc, _ = stub_visual_plan_services
+    run_svc.runs[37] = _make_run(37)
+
+    response = await client.patch(
+        "/api/creator/runs/37/visual-plan/scenes/scene-1",
+        json={"scene_id": "hacked", "prompt": "valid"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_scene_with_expected_version_match(client, stub_visual_plan_services):
+    """PATCH succeeds when expected_version matches active version."""
+    run_svc, vp_svc = stub_visual_plan_services
+    run_svc.runs[38] = _make_run(38)
+    scene = _make_scene("scene-1")
+    vp_svc.plans[38] = [
+        StubVisualPlan(
+            id=1,
+            run_id=38,
+            version=2,
+            scenes=[scene],
+            created_at=datetime.now(timezone.utc),
+        )
+    ]
+
+    response = await client.patch(
+        "/api/creator/runs/38/visual-plan/scenes/scene-1",
+        json={"prompt": "Updated", "expected_version": 2},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == 3
+    assert body["scenes"][0]["prompt"] == "Updated"

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -1,0 +1,10 @@
+"""Tests for health endpoint."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_health_returns_ok(client):
+    """Test that /health endpoint returns 200 with ok status."""
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/apps/studio-web/.eslintrc.cjs
+++ b/apps/studio-web/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react', 'react-hooks', '@typescript-eslint'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+  },
+};

--- a/apps/studio-web/.prettierrc
+++ b/apps/studio-web/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/apps/studio-web/package-lock.json
+++ b/apps/studio-web/package-lock.json
@@ -1,0 +1,7225 @@
+{
+  "name": "studio-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "studio-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.1"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.1.0",
+        "@testing-library/react": "^14.0.0",
+        "@types/react": "^18.3.5",
+        "@types/react-dom": "^18.3.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "@vitejs/plugin-react": "^4.2.0",
+        "eslint": "^8.0.0",
+        "eslint-plugin-react": "^7.33.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "jsdom": "^23.0.0",
+        "prettier": "^3.0.0",
+        "typescript": "^5.5.4",
+        "vite": "^5.4.2",
+        "vitest": "^1.0.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+      "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001782",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
+      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
+      "integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.1",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^2.0.1",
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/apps/studio-web/package.json
+++ b/apps/studio-web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write src",
-    "test": "echo \"No tests yet\""
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -19,7 +19,12 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.4",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "jsdom": "^23.0.0",
     "eslint": "^8.0.0",
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/apps/studio-web/package.json
+++ b/apps/studio-web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx",
+    "format": "prettier --write src",
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
@@ -19,5 +20,12 @@
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.4",
     "vite": "^5.4.2"
+    "eslint": "^8.0.0",
+    "eslint-plugin-react": "^7.33.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "prettier": "^3.0.0"
   }
+
 }

--- a/apps/studio-web/src/__tests__/App.test.tsx
+++ b/apps/studio-web/src/__tests__/App.test.tsx
@@ -1,17 +1,27 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import CreatePage from '../pages/CreatePage';
 
 describe('App', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        script_models: [], image_models: [], tts_models: [], stt_models: [],
+      }),
+    } as Response);
+  });
+
   it('renders CreatePage without crashing', () => {
     render(
       <MemoryRouter>
         <CreatePage />
       </MemoryRouter>
     );
-    // Verify CreatePage renders
-    expect(screen.getByText('CreatePage')).toBeTruthy();
+    // Verify CreatePage renders the heading
+    expect(screen.getByText('Create New Project')).toBeTruthy();
   });
 
   it('App module exports default function', async () => {

--- a/apps/studio-web/src/__tests__/App.test.tsx
+++ b/apps/studio-web/src/__tests__/App.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import CreatePage from '../pages/CreatePage';
+
+describe('App', () => {
+  it('renders CreatePage without crashing', () => {
+    render(
+      <MemoryRouter>
+        <CreatePage />
+      </MemoryRouter>
+    );
+    // Verify CreatePage renders
+    expect(screen.getByText('CreatePage')).toBeTruthy();
+  });
+
+  it('App module exports default function', async () => {
+    const mod = await import('../App');
+    expect(typeof mod.default).toBe('function');
+  });
+});

--- a/apps/studio-web/src/__tests__/CreatePage.test.tsx
+++ b/apps/studio-web/src/__tests__/CreatePage.test.tsx
@@ -14,11 +14,39 @@ const MOCK_MODELS = {
   stt_models: [],
 };
 
+const MOCK_PROJECT = { id: 42, title: "Test", source_type: "idea", idea_brief: "Brief" };
+const MOCK_RUN = { id: 7, project_id: 42, current_stage: "IDEA_READY" };
+
+// Track navigate calls
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
 function mockFetchSuccess() {
   vi.spyOn(globalThis, "fetch").mockResolvedValue({
     ok: true,
     json: () => Promise.resolve(MOCK_MODELS),
   } as Response);
+}
+
+/** Mock fetch that handles models, project creation, and run creation */
+function mockFetchFullFlow() {
+  vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+
+    if (url.includes("/models")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_MODELS) } as Response);
+    }
+    if (url.includes("/projects") && url.includes("/runs")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_RUN) } as Response);
+    }
+    if (url.includes("/projects")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_PROJECT) } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  });
 }
 
 function renderCreatePage() {
@@ -33,6 +61,7 @@ describe("CreatePage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     mockFetchSuccess();
+    mockNavigate.mockReset();
   });
 
   it("renders the page heading", () => {
@@ -127,17 +156,6 @@ describe("CreatePage", () => {
     expect(screen.getByRole("button", { name: "Create Project" })).toBeTruthy();
   });
 
-  it("submit logs form state to console", () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    renderCreatePage();
-
-    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "CreatePage submit (stub):",
-      expect.objectContaining({ tab: "idea" }),
-    );
-  });
-
   it("renders ModelSelector with script and image categories", async () => {
     renderCreatePage();
 
@@ -195,5 +213,146 @@ describe("CreatePage", () => {
     const select = screen.getByLabelText(/Style Preset/) as HTMLSelectElement;
     const options = Array.from(select.options).map((o) => o.value);
     expect(options).toEqual(["default", "cinematic", "dynamic", "minimal"]);
+  });
+
+  // --- New tests for Issue #33: API submission flow ---
+
+  it("submits idea form and navigates to project page", async () => {
+    mockFetchFullFlow();
+    renderCreatePage();
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "My Video" } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "A cooking tutorial" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/projects/42");
+    });
+
+    // Verify project creation API was called
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const projectCall = calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/projects") && !c[0].includes("/runs") && !c[0].includes("/models"),
+    );
+    expect(projectCall).toBeTruthy();
+    const projectBody = JSON.parse((projectCall![1] as RequestInit).body as string);
+    expect(projectBody.title).toBe("My Video");
+    expect(projectBody.source_type).toBe("idea");
+    expect(projectBody.idea_brief).toBe("A cooking tutorial");
+  });
+
+  it("creates a run with model defaults and metadata", async () => {
+    mockFetchFullFlow();
+    renderCreatePage();
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "My Video" } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "Brief" } });
+    fireEvent.change(screen.getByLabelText(/Content Goal/), { target: { value: "educational" } });
+    fireEvent.change(screen.getByLabelText(/Target Duration/), { target: { value: "90" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/projects/42");
+    });
+
+    // Verify run creation API was called with metadata
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const runCall = calls.find((c: unknown[]) => typeof c[0] === "string" && c[0].includes("/runs"));
+    expect(runCall).toBeTruthy();
+    const runBody = JSON.parse((runCall![1] as RequestInit).body as string);
+    expect(runBody.metadata.content_goal).toBe("educational");
+    expect(runBody.metadata.target_duration).toBe(90);
+    expect(runBody.style_preset).toBe("default");
+  });
+
+  it("shows error when project creation fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/models")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_MODELS) } as Response);
+      }
+      // Project creation fails
+      return Promise.resolve({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ detail: "Title is required" }),
+      } as Response);
+    });
+
+    renderCreatePage();
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "T" } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "B" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("idea-form-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("idea-form-error").textContent).toBe("Title is required");
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("shows error when run creation fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/models")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_MODELS) } as Response);
+      }
+      if (url.includes("/projects") && !url.includes("/runs")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_PROJECT) } as Response);
+      }
+      // Run creation fails
+      return Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ detail: "Internal error" }),
+      } as Response);
+    });
+
+    renderCreatePage();
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "T" } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "B" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("idea-form-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("idea-form-error").textContent).toBe("Internal error");
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("shows 'Creating…' on submit button while submitting", async () => {
+    // Make fetch hang so we can observe the loading state
+    let resolveProject!: (value: Response) => void;
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/models")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_MODELS) } as Response);
+      }
+      return new Promise((resolve) => { resolveProject = resolve; });
+    });
+
+    renderCreatePage();
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "T" } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "B" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Creating…" })).toBeTruthy();
+    });
+
+    // Resolve to clean up
+    resolveProject({ ok: true, json: () => Promise.resolve(MOCK_PROJECT) } as Response);
+  });
+
+  it("renders IdeaForm inside the idea tab panel", () => {
+    renderCreatePage();
+    const panel = screen.getByRole("tabpanel");
+    const form = screen.getByTestId("idea-form");
+    expect(panel.contains(form)).toBe(true);
   });
 });

--- a/apps/studio-web/src/__tests__/CreatePage.test.tsx
+++ b/apps/studio-web/src/__tests__/CreatePage.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import CreatePage from "../pages/CreatePage";
+
+const MOCK_MODELS = {
+  script_models: [
+    { key: "qwen3-4b", label: "Qwen3 4B", provider_type: "ollama", is_local: true, requires_gpu: true, status: "available" as const },
+  ],
+  image_models: [
+    { key: "sd15", label: "SD 1.5", provider_type: "sd", is_local: true, requires_gpu: true, status: "available" as const },
+  ],
+  tts_models: [],
+  stt_models: [],
+};
+
+function mockFetchSuccess() {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(MOCK_MODELS),
+  } as Response);
+}
+
+function renderCreatePage() {
+  return render(
+    <MemoryRouter>
+      <CreatePage />
+    </MemoryRouter>,
+  );
+}
+
+describe("CreatePage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockFetchSuccess();
+  });
+
+  it("renders the page heading", () => {
+    renderCreatePage();
+    expect(screen.getByText("Create New Project")).toBeTruthy();
+  });
+
+  it("has 'Start from Idea' tab selected by default", () => {
+    renderCreatePage();
+    const ideaTab = screen.getByRole("tab", { name: "Start from Idea" });
+    expect(ideaTab).toHaveAttribute("aria-selected", "true");
+
+    const mdTab = screen.getByRole("tab", { name: "Start from Markdown" });
+    expect(mdTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("shows idea form fields on the default tab", () => {
+    renderCreatePage();
+    expect(screen.getByLabelText(/Title/)).toBeTruthy();
+    expect(screen.getByLabelText(/Idea Brief/)).toBeTruthy();
+    expect(screen.getByLabelText(/Target Duration/)).toBeTruthy();
+    expect(screen.getByLabelText(/Content Goal/)).toBeTruthy();
+  });
+
+  it("switches to markdown tab when clicked", () => {
+    renderCreatePage();
+    const mdTab = screen.getByRole("tab", { name: "Start from Markdown" });
+    fireEvent.click(mdTab);
+
+    expect(mdTab).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Start from Idea" })).toHaveAttribute("aria-selected", "false");
+
+    // Markdown tab content should be visible
+    expect(screen.getByLabelText(/Markdown Content/)).toBeTruthy();
+    expect(screen.getByLabelText(/Or upload a file/)).toBeTruthy();
+  });
+
+  it("allows typing in idea form fields", () => {
+    renderCreatePage();
+
+    const titleInput = screen.getByLabelText(/^Title/) as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: "My Video" } });
+    expect(titleInput.value).toBe("My Video");
+
+    const briefInput = screen.getByLabelText(/Idea Brief/) as HTMLTextAreaElement;
+    fireEvent.change(briefInput, { target: { value: "A cooking tutorial" } });
+    expect(briefInput.value).toBe("A cooking tutorial");
+
+    const durationInput = screen.getByLabelText(/Target Duration/) as HTMLInputElement;
+    fireEvent.change(durationInput, { target: { value: "90" } });
+    expect(durationInput.value).toBe("90");
+
+    const goalInput = screen.getByLabelText(/Content Goal/) as HTMLInputElement;
+    fireEvent.change(goalInput, { target: { value: "educational" } });
+    expect(goalInput.value).toBe("educational");
+  });
+
+  it("allows typing in markdown form fields", () => {
+    renderCreatePage();
+    fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
+
+    const titleInput = screen.getByLabelText(/^Title/) as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: "MD Project" } });
+    expect(titleInput.value).toBe("MD Project");
+
+    const mdTextarea = screen.getByLabelText(/Markdown Content/) as HTMLTextAreaElement;
+    fireEvent.change(mdTextarea, { target: { value: "# Scene 1\nHello" } });
+    expect(mdTextarea.value).toBe("# Scene 1\nHello");
+  });
+
+  it("style preset select works", () => {
+    renderCreatePage();
+    const select = screen.getByLabelText(/Style Preset/) as HTMLSelectElement;
+    expect(select.value).toBe("default");
+
+    fireEvent.change(select, { target: { value: "cinematic" } });
+    expect(select.value).toBe("cinematic");
+  });
+
+  it("has submit button", () => {
+    renderCreatePage();
+    expect(screen.getByRole("button", { name: "Create Project" })).toBeTruthy();
+  });
+
+  it("submit button is present on both tabs", () => {
+    renderCreatePage();
+    // Idea tab
+    expect(screen.getByRole("button", { name: "Create Project" })).toBeTruthy();
+
+    // Markdown tab
+    fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
+    expect(screen.getByRole("button", { name: "Create Project" })).toBeTruthy();
+  });
+
+  it("submit logs form state to console", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    renderCreatePage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "CreatePage submit (stub):",
+      expect.objectContaining({ tab: "idea" }),
+    );
+  });
+
+  it("renders ModelSelector with script and image categories", async () => {
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Should show Script Model and Image Model
+    expect(screen.getByText("Script Model")).toBeTruthy();
+    expect(screen.getByText("Image Model")).toBeTruthy();
+    // Should NOT show TTS or STT
+    expect(screen.queryByText("TTS Model")).toBeNull();
+    expect(screen.queryByText("STT Model")).toBeNull();
+  });
+
+  it("has proper tablist and tabpanel roles", () => {
+    renderCreatePage();
+    expect(screen.getByRole("tablist")).toBeTruthy();
+    expect(screen.getByRole("tabpanel")).toBeTruthy();
+  });
+
+  it("markdown file upload input is present on markdown tab", () => {
+    renderCreatePage();
+    fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
+    const fileInput = screen.getByLabelText(/Or upload a file/) as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+    expect(fileInput.type).toBe("file");
+    expect(fileInput.accept).toBe(".md,.txt");
+  });
+
+  it("file upload populates markdown textarea", async () => {
+    renderCreatePage();
+    fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
+
+    const fileInput = screen.getByLabelText(/Or upload a file/) as HTMLInputElement;
+    const fileContent = "# Test Script\nScene one content";
+    const file = new File([fileContent], "script.md", { type: "text/markdown" });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      const textarea = screen.getByLabelText(/Markdown Content/) as HTMLTextAreaElement;
+      expect(textarea.value).toBe(fileContent);
+    });
+  });
+
+  it("target duration defaults to 60", () => {
+    renderCreatePage();
+    const durationInput = screen.getByLabelText(/Target Duration/) as HTMLInputElement;
+    expect(durationInput.value).toBe("60");
+  });
+
+  it("has all style preset options", () => {
+    renderCreatePage();
+    const select = screen.getByLabelText(/Style Preset/) as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toEqual(["default", "cinematic", "dynamic", "minimal"]);
+  });
+});

--- a/apps/studio-web/src/__tests__/CreatePage.test.tsx
+++ b/apps/studio-web/src/__tests__/CreatePage.test.tsx
@@ -355,4 +355,134 @@ describe("CreatePage", () => {
     const form = screen.getByTestId("idea-form");
     expect(panel.contains(form)).toBe(true);
   });
+
+  // --- Markdown submission flow tests ---
+
+  it("submits markdown form and navigates to project page", async () => {
+    const MOCK_IMPORT = { project_id: 42, run_id: 7, draft: {} };
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/models")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_MODELS) } as Response);
+      }
+      if (url.includes("/import-markdown")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_IMPORT) } as Response);
+      }
+      if (url.includes("/projects")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_PROJECT) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+    });
+
+    renderCreatePage();
+    fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "MD Project" } });
+    fireEvent.change(screen.getByLabelText(/Markdown Content/), { target: { value: "# Scene 1\nHello world" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/projects/42");
+    });
+
+    // Verify project creation was called with source_type=markdown
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const projectCall = calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/projects") && !c[0].includes("/script") && !c[0].includes("/models"),
+    );
+    expect(projectCall).toBeTruthy();
+    const projectBody = JSON.parse((projectCall![1] as RequestInit).body as string);
+    expect(projectBody.source_type).toBe("markdown");
+    expect(projectBody.markdown_source).toBe("# Scene 1\nHello world");
+
+    // Verify import-markdown was called
+    const importCall = calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/import-markdown"),
+    );
+    expect(importCall).toBeTruthy();
+    const importBody = JSON.parse((importCall![1] as RequestInit).body as string);
+    expect(importBody.markdown).toBe("# Scene 1\nHello world");
+  });
+
+  it("does not submit markdown when content is empty", async () => {
+    mockFetchFullFlow();
+    renderCreatePage();
+    fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
+
+    // Leave markdown content empty, just set title
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "My Project" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    // Should NOT navigate since markdown is empty
+    await new Promise((r) => setTimeout(r, 100));
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("shows error when import-markdown fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/models")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_MODELS) } as Response);
+      }
+      if (url.includes("/import-markdown")) {
+        return Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ detail: "markdown content must not be empty" }),
+        } as Response);
+      }
+      if (url.includes("/projects")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_PROJECT) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+    });
+
+    renderCreatePage();
+    fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
+
+    fireEvent.change(screen.getByLabelText(/Markdown Content/), { target: { value: "# Test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-form-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("markdown-form-error").textContent).toBe("markdown content must not be empty");
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("uses 'Untitled' when markdown title is empty", async () => {
+    const MOCK_IMPORT = { project_id: 42, run_id: 7, draft: {} };
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/models")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_MODELS) } as Response);
+      }
+      if (url.includes("/import-markdown")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_IMPORT) } as Response);
+      }
+      if (url.includes("/projects")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_PROJECT) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+    });
+
+    renderCreatePage();
+    fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
+
+    // No title, just markdown content
+    fireEvent.change(screen.getByLabelText(/Markdown Content/), { target: { value: "# Scene" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled();
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const projectCall = calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/projects") && !c[0].includes("/script") && !c[0].includes("/models"),
+    );
+    const projectBody = JSON.parse((projectCall![1] as RequestInit).body as string);
+    expect(projectBody.title).toBe("Untitled");
+  });
 });

--- a/apps/studio-web/src/__tests__/IdeaForm.test.tsx
+++ b/apps/studio-web/src/__tests__/IdeaForm.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import IdeaForm from "../components/creator/IdeaForm";
+
+function renderIdeaForm(props: Partial<Parameters<typeof IdeaForm>[0]> = {}) {
+  const onSubmit = props.onSubmit ?? vi.fn();
+  return {
+    onSubmit,
+    ...render(<IdeaForm onSubmit={onSubmit} submitting={props.submitting} error={props.error} />),
+  };
+}
+
+describe("IdeaForm", () => {
+  it("renders all form fields", () => {
+    renderIdeaForm();
+    expect(screen.getByLabelText(/Title/)).toBeTruthy();
+    expect(screen.getByLabelText(/Idea Brief/)).toBeTruthy();
+    expect(screen.getByLabelText(/Target Duration/)).toBeTruthy();
+    expect(screen.getByLabelText(/Content Goal/)).toBeTruthy();
+  });
+
+  it("has data-testid on form element", () => {
+    renderIdeaForm();
+    expect(screen.getByTestId("idea-form")).toBeTruthy();
+  });
+
+  it("target duration defaults to 60", () => {
+    renderIdeaForm();
+    const input = screen.getByLabelText(/Target Duration/) as HTMLInputElement;
+    expect(input.value).toBe("60");
+  });
+
+  it("allows typing in all fields", () => {
+    renderIdeaForm();
+
+    const titleInput = screen.getByLabelText(/^Title/) as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: "My Video" } });
+    expect(titleInput.value).toBe("My Video");
+
+    const briefInput = screen.getByLabelText(/Idea Brief/) as HTMLTextAreaElement;
+    fireEvent.change(briefInput, { target: { value: "A cooking tutorial" } });
+    expect(briefInput.value).toBe("A cooking tutorial");
+
+    const durationInput = screen.getByLabelText(/Target Duration/) as HTMLInputElement;
+    fireEvent.change(durationInput, { target: { value: "90" } });
+    expect(durationInput.value).toBe("90");
+
+    const goalInput = screen.getByLabelText(/Content Goal/) as HTMLInputElement;
+    fireEvent.change(goalInput, { target: { value: "educational" } });
+    expect(goalInput.value).toBe("educational");
+  });
+
+  it("calls onSubmit with form data when submitted", () => {
+    const { onSubmit } = renderIdeaForm();
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "Test Title" } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "Test brief" } });
+    fireEvent.change(screen.getByLabelText(/Content Goal/), { target: { value: "entertainment" } });
+
+    fireEvent.submit(screen.getByTestId("idea-form"));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "Test Title",
+      ideaBrief: "Test brief",
+      targetDuration: 60,
+      contentGoal: "entertainment",
+    });
+  });
+
+  it("trims whitespace from text fields on submit", () => {
+    const { onSubmit } = renderIdeaForm();
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "  Spaced Title  " } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "  brief  " } });
+    fireEvent.change(screen.getByLabelText(/Content Goal/), { target: { value: "  fun  " } });
+
+    fireEvent.submit(screen.getByTestId("idea-form"));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "Spaced Title",
+      ideaBrief: "brief",
+      targetDuration: 60,
+      contentGoal: "fun",
+    });
+  });
+
+  it("does not submit when title is empty", () => {
+    const { onSubmit } = renderIdeaForm();
+
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "Has brief" } });
+    fireEvent.submit(screen.getByTestId("idea-form"));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when ideaBrief is empty", () => {
+    const { onSubmit } = renderIdeaForm();
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "Has title" } });
+    fireEvent.submit(screen.getByTestId("idea-form"));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when title is whitespace-only", () => {
+    const { onSubmit } = renderIdeaForm();
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "   " } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "Brief" } });
+    fireEvent.submit(screen.getByTestId("idea-form"));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when submitting is true", () => {
+    const { onSubmit } = renderIdeaForm({ submitting: true });
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "Title" } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "Brief" } });
+    fireEvent.submit(screen.getByTestId("idea-form"));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("disables inputs when submitting", () => {
+    renderIdeaForm({ submitting: true });
+
+    expect(screen.getByLabelText(/^Title/)).toBeDisabled();
+    expect(screen.getByLabelText(/Idea Brief/)).toBeDisabled();
+    expect(screen.getByLabelText(/Target Duration/)).toBeDisabled();
+    expect(screen.getByLabelText(/Content Goal/)).toBeDisabled();
+  });
+
+  it("does not show error when error is null", () => {
+    renderIdeaForm();
+    expect(screen.queryByTestId("idea-form-error")).toBeNull();
+  });
+
+  it("shows error message when error is provided", () => {
+    renderIdeaForm({ error: "Something went wrong" });
+    const errorEl = screen.getByTestId("idea-form-error");
+    expect(errorEl).toBeTruthy();
+    expect(errorEl.textContent).toBe("Something went wrong");
+    expect(errorEl).toHaveAttribute("role", "alert");
+  });
+
+  it("marks title and idea brief as required", () => {
+    renderIdeaForm();
+    expect(screen.getByLabelText(/^Title/)).toHaveAttribute("required");
+    expect(screen.getByLabelText(/Idea Brief/)).toHaveAttribute("required");
+  });
+
+  it("has duration constraints min=10 max=180", () => {
+    renderIdeaForm();
+    const input = screen.getByLabelText(/Target Duration/) as HTMLInputElement;
+    expect(input.min).toBe("10");
+    expect(input.max).toBe("180");
+  });
+});

--- a/apps/studio-web/src/__tests__/MarkdownScriptEditor.test.tsx
+++ b/apps/studio-web/src/__tests__/MarkdownScriptEditor.test.tsx
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import MarkdownScriptEditor from "../components/creator/MarkdownScriptEditor";
+
+// --------------- fetch mock helpers ---------------
+
+function mockFetchSuccess(responses: Record<string, { status?: number; body: unknown }>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    const key = `${method} ${url}`;
+
+    for (const [pattern, resp] of Object.entries(responses)) {
+      if (key.includes(pattern) || url.includes(pattern)) {
+        return {
+          ok: (resp.status ?? 200) < 400,
+          status: resp.status ?? 200,
+          json: async () => resp.body,
+        };
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({ detail: "Not found" }) };
+  }) as unknown as typeof fetch;
+}
+
+// --------------- constants ---------------
+
+const API = "/api/creator";
+const RUN_ID = 42;
+const LOAD_URL = `/runs/${RUN_ID}/script/markdown`;
+
+const LOADED_DATA = {
+  run_id: RUN_ID,
+  markdown: "# Hello\n\nWorld",
+  version: 1,
+};
+
+// --------------- tests ---------------
+
+describe("MarkdownScriptEditor", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    globalThis.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof fetch;
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} />);
+    expect(screen.getByTestId("markdown-loading")).toHaveTextContent("Loading script");
+  });
+
+  it("loads and displays markdown content", async () => {
+    globalThis.fetch = mockFetchSuccess({ [LOAD_URL]: { body: LOADED_DATA } });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toHaveValue("# Hello\n\nWorld");
+    });
+    expect(screen.getByTestId("markdown-version")).toHaveTextContent("v1");
+  });
+
+  it("shows error when load fails", async () => {
+    const onError = vi.fn();
+    globalThis.fetch = mockFetchSuccess({
+      [LOAD_URL]: { status: 404, body: { detail: "No script draft found for this run" } },
+    });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-error")).toHaveTextContent("No script draft found");
+    });
+    expect(onError).toHaveBeenCalledWith("load", "No script draft found for this run");
+  });
+
+  it("shows 'Unsaved changes' when content is modified", async () => {
+    globalThis.fetch = mockFetchSuccess({ [LOAD_URL]: { body: LOADED_DATA } });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toHaveValue("# Hello\n\nWorld");
+    });
+
+    expect(screen.queryByTestId("markdown-dirty")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("markdown-textarea"), {
+      target: { value: "# Modified" },
+    });
+
+    expect(screen.getByTestId("markdown-dirty")).toHaveTextContent("Unsaved changes");
+  });
+
+  it("enables save button only when dirty", async () => {
+    globalThis.fetch = mockFetchSuccess({ [LOAD_URL]: { body: LOADED_DATA } });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("markdown-save-btn")).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("markdown-textarea"), {
+      target: { value: "New content" },
+    });
+
+    expect(screen.getByTestId("markdown-save-btn")).not.toBeDisabled();
+  });
+
+  it("saves markdown and updates version", async () => {
+    const onSuccess = vi.fn();
+    const savedData = { run_id: RUN_ID, draft: { version: 2 } };
+    globalThis.fetch = mockFetchSuccess({
+      [`GET ${API}/runs/${RUN_ID}/script/markdown`]: { body: LOADED_DATA },
+      [`PUT ${API}/runs/${RUN_ID}/script/markdown`]: { body: savedData },
+    });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} onSuccess={onSuccess} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toHaveValue("# Hello\n\nWorld");
+    });
+
+    fireEvent.change(screen.getByTestId("markdown-textarea"), {
+      target: { value: "# Updated" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("markdown-save-btn"));
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith("save", savedData);
+    });
+    expect(screen.getByTestId("markdown-version")).toHaveTextContent("v2");
+    // Dirty indicator should be gone after save
+    expect(screen.queryByTestId("markdown-dirty")).not.toBeInTheDocument();
+  });
+
+  it("shows error when save fails", async () => {
+    const onError = vi.fn();
+    globalThis.fetch = mockFetchSuccess({
+      [`GET ${API}/runs/${RUN_ID}/script/markdown`]: { body: LOADED_DATA },
+      [`PUT ${API}/runs/${RUN_ID}/script/markdown`]: { status: 400, body: { detail: "Bad request" } },
+    });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("markdown-textarea"), {
+      target: { value: "Modified" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("markdown-save-btn"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-error")).toHaveTextContent("Bad request");
+    });
+    expect(onError).toHaveBeenCalledWith("save", "Bad request");
+  });
+
+  it("parses markdown and calls onSuccess", async () => {
+    const onSuccess = vi.fn();
+    const parseResult = {
+      run_id: RUN_ID,
+      sections: [{ type: "narration", text: "Hello" }],
+      version: 2,
+    };
+    globalThis.fetch = mockFetchSuccess({
+      [`GET ${API}/runs/${RUN_ID}/script/markdown`]: { body: LOADED_DATA },
+      [`POST ${API}/runs/${RUN_ID}/script/parse-markdown`]: { body: parseResult },
+    });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} onSuccess={onSuccess} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("markdown-parse-btn"));
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith("parse", parseResult);
+    });
+  });
+
+  it("disables parse button when content is dirty", async () => {
+    globalThis.fetch = mockFetchSuccess({ [LOAD_URL]: { body: LOADED_DATA } });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toBeInTheDocument();
+    });
+
+    // Parse should be enabled when not dirty
+    expect(screen.getByTestId("markdown-parse-btn")).not.toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("markdown-textarea"), {
+      target: { value: "Dirty content" },
+    });
+
+    // Parse should be disabled when dirty (save first)
+    expect(screen.getByTestId("markdown-parse-btn")).toBeDisabled();
+  });
+
+  it("shows error when parse fails", async () => {
+    const onError = vi.fn();
+    globalThis.fetch = mockFetchSuccess({
+      [`GET ${API}/runs/${RUN_ID}/script/markdown`]: { body: LOADED_DATA },
+      [`POST ${API}/runs/${RUN_ID}/script/parse-markdown`]: {
+        status: 400,
+        body: { detail: "Draft has no markdown content to parse" },
+      },
+    });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("markdown-parse-btn"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-error")).toHaveTextContent(
+        "Draft has no markdown content to parse",
+      );
+    });
+    expect(onError).toHaveBeenCalledWith("parse", "Draft has no markdown content to parse");
+  });
+
+  it("does not show save/parse buttons in readOnly mode", async () => {
+    globalThis.fetch = mockFetchSuccess({ [LOAD_URL]: { body: LOADED_DATA } });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} readOnly />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("markdown-save-btn")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("markdown-parse-btn")).not.toBeInTheDocument();
+    expect(screen.getByTestId("markdown-textarea")).toHaveAttribute("readonly");
+  });
+
+  it("disables textarea while saving", async () => {
+    let resolveSave: (value: unknown) => void;
+    globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        return new Promise((resolve) => {
+          resolveSave = () =>
+            resolve({
+              ok: true,
+              status: 200,
+              json: async () => ({ run_id: RUN_ID, draft: { version: 2 } }),
+            });
+        });
+      }
+      return { ok: true, status: 200, json: async () => LOADED_DATA };
+    }) as unknown as typeof fetch;
+
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toHaveValue("# Hello\n\nWorld");
+    });
+
+    fireEvent.change(screen.getByTestId("markdown-textarea"), {
+      target: { value: "Modified" },
+    });
+
+    // Start save — don't resolve yet
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("markdown-save-btn"));
+    });
+
+    expect(screen.getByTestId("markdown-textarea")).toBeDisabled();
+    expect(screen.getByTestId("markdown-save-btn")).toHaveTextContent("Saving…");
+
+    // Resolve save
+    await act(async () => {
+      resolveSave!(undefined);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).not.toBeDisabled();
+    });
+  });
+
+  it("does not save when markdown is empty/whitespace", async () => {
+    globalThis.fetch = mockFetchSuccess({ [LOAD_URL]: { body: LOADED_DATA } });
+    render(<MarkdownScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-textarea")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("markdown-textarea"), {
+      target: { value: "   " },
+    });
+
+    // Button should be disabled (dirty but whitespace-only)
+    expect(screen.getByTestId("markdown-save-btn")).toBeDisabled();
+  });
+});

--- a/apps/studio-web/src/__tests__/ModelSelector.test.tsx
+++ b/apps/studio-web/src/__tests__/ModelSelector.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import ModelSelector from "../components/creator/ModelSelector";
@@ -153,7 +154,7 @@ describe("ModelSelector", () => {
     expect(screen.getByText("unknown")).toBeTruthy();
   });
 
-  it("keyboard navigation works via native radio inputs", async () => {
+  it("radio click fires onSelectionChange with correct category and key", async () => {
     mockFetchSuccess();
     const onChange = vi.fn();
     render(<ModelSelector onSelectionChange={onChange} />);
@@ -164,10 +165,8 @@ describe("ModelSelector", () => {
 
     onChange.mockClear();
 
-    // Native radios support keyboard by default; simulate click on radio
     const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
     fireEvent.click(gptRadio);
-    // The onChange handler fires through the radio onChange
     expect(onChange).toHaveBeenCalledWith("script", "gpt-4o-mini");
   });
 
@@ -256,5 +255,35 @@ describe("ModelSelector", () => {
     // The manually selected gpt-4o-mini should still be checked, not overwritten by default
     const gptRadioAfter = screen.getByRole("radio", { name: /GPT-4o Mini/ });
     expect(gptRadioAfter).toBeChecked();
+  });
+
+  it("default callbacks fire exactly once under StrictMode", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(
+      <React.StrictMode>
+        <ModelSelector onSelectionChange={onChange} />
+      </React.StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Each category default should fire exactly once, not doubled by StrictMode
+    const scriptCalls = onChange.mock.calls.filter(
+      ([cat, key]: [string, string]) => cat === "script" && key === "qwen3-4b",
+    );
+    expect(scriptCalls.length).toBe(1);
+
+    const imageCalls = onChange.mock.calls.filter(
+      ([cat, key]: [string, string]) => cat === "image" && key === "sd15",
+    );
+    expect(imageCalls.length).toBe(1);
+
+    const ttsCalls = onChange.mock.calls.filter(
+      ([cat, key]: [string, string]) => cat === "tts" && key === "qwen-tts",
+    );
+    expect(ttsCalls.length).toBe(1);
   });
 });

--- a/apps/studio-web/src/__tests__/ModelSelector.test.tsx
+++ b/apps/studio-web/src/__tests__/ModelSelector.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ModelSelector from "../components/creator/ModelSelector";
+
+const MOCK_RESPONSE = {
+  script_models: [
+    { key: "qwen3-4b", label: "Qwen3 4B (Local)", provider_type: "ollama", is_local: true, requires_gpu: true, status: "available" as const },
+    { key: "gpt-4o-mini", label: "GPT-4o Mini (Remote)", provider_type: "openai", is_local: false, requires_gpu: false, status: "unavailable" as const },
+  ],
+  image_models: [
+    { key: "sd15", label: "Stable Diffusion 1.5 (Local)", provider_type: "stable-diffusion", is_local: true, requires_gpu: true, status: "available" as const },
+  ],
+  tts_models: [
+    { key: "qwen-tts", label: "Qwen TTS (Local)", provider_type: "qwen-tts", is_local: true, requires_gpu: true, status: "unknown" as const },
+  ],
+  stt_models: [],
+};
+
+function mockFetchSuccess() {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(MOCK_RESPONSE),
+  } as Response);
+}
+
+function mockFetchError() {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: () => Promise.resolve({}),
+  } as Response);
+}
+
+describe("ModelSelector", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders loading state initially", () => {
+    // Never resolve fetch
+    vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise(() => {}));
+    render(<ModelSelector />);
+    expect(screen.getByTestId("model-selector-loading")).toBeTruthy();
+  });
+
+  it("renders model lists after fetch", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Qwen3 4B (Local)")).toBeTruthy();
+    expect(screen.getByText("GPT-4o Mini (Remote)")).toBeTruthy();
+    expect(screen.getByText("Stable Diffusion 1.5 (Local)")).toBeTruthy();
+    expect(screen.getByText("Qwen TTS (Local)")).toBeTruthy();
+  });
+
+  it("calls onSelectionChange when model clicked", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(<ModelSelector onSelectionChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("GPT-4o Mini (Remote)"));
+    expect(onChange).toHaveBeenCalledWith("script", "gpt-4o-mini");
+  });
+
+  it("handles fetch error gracefully", async () => {
+    mockFetchError();
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector-error")).toBeTruthy();
+    });
+
+    expect(screen.getByText(/Failed to fetch models: 500/)).toBeTruthy();
+  });
+
+  it("default selection mode selects first available model", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(<ModelSelector onSelectionChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // qwen3-4b should be auto-selected (first available in script)
+    const qwenItem = screen.getByText("Qwen3 4B (Local)").closest("li");
+    expect(qwenItem?.getAttribute("aria-selected")).toBe("true");
+
+    // gpt-4o-mini should NOT be selected
+    const gptItem = screen.getByText("GPT-4o Mini (Remote)").closest("li");
+    expect(gptItem?.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("respects override mode with selectedModels prop", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector selectedModels={{ script: "gpt-4o-mini" }} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // In override mode, gpt-4o-mini should be selected
+    const gptItem = screen.getByText("GPT-4o Mini (Remote)").closest("li");
+    expect(gptItem?.getAttribute("aria-selected")).toBe("true");
+
+    const qwenItem = screen.getByText("Qwen3 4B (Local)").closest("li");
+    expect(qwenItem?.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("shows only specified categories", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector categories={["script"]} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Script Model")).toBeTruthy();
+    expect(screen.queryByText("Image Model")).toBeNull();
+    expect(screen.queryByText("TTS Model")).toBeNull();
+  });
+
+  it("shows status badges for each model", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Check status badges exist
+    const availableBadges = screen.getAllByText("available");
+    expect(availableBadges.length).toBe(2); // qwen3-4b + sd15
+
+    expect(screen.getByText("unavailable")).toBeTruthy();
+    expect(screen.getByText("unknown")).toBeTruthy();
+  });
+});

--- a/apps/studio-web/src/__tests__/ModelSelector.test.tsx
+++ b/apps/studio-web/src/__tests__/ModelSelector.test.tsx
@@ -57,7 +57,7 @@ describe("ModelSelector", () => {
     expect(screen.getByText("Qwen TTS (Local)")).toBeTruthy();
   });
 
-  it("calls onSelectionChange when model clicked", async () => {
+  it("calls onSelectionChange when model selected via radio", async () => {
     mockFetchSuccess();
     const onChange = vi.fn();
     render(<ModelSelector onSelectionChange={onChange} />);
@@ -66,7 +66,11 @@ describe("ModelSelector", () => {
       expect(screen.getByTestId("model-selector")).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByText("GPT-4o Mini (Remote)"));
+    // Clear default-notification calls
+    onChange.mockClear();
+
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    fireEvent.click(gptRadio);
     expect(onChange).toHaveBeenCalledWith("script", "gpt-4o-mini");
   });
 
@@ -81,7 +85,7 @@ describe("ModelSelector", () => {
     expect(screen.getByText(/Failed to fetch models: 500/)).toBeTruthy();
   });
 
-  it("default selection mode selects first available model", async () => {
+  it("default selection mode selects first available model and notifies parent", async () => {
     mockFetchSuccess();
     const onChange = vi.fn();
     render(<ModelSelector onSelectionChange={onChange} />);
@@ -90,16 +94,21 @@ describe("ModelSelector", () => {
       expect(screen.getByTestId("model-selector")).toBeTruthy();
     });
 
-    // qwen3-4b should be auto-selected (first available in script)
-    const qwenItem = screen.getByText("Qwen3 4B (Local)").closest("li");
-    expect(qwenItem?.getAttribute("aria-selected")).toBe("true");
+    // qwen3-4b radio should be checked (first available in script)
+    const qwenRadio = screen.getByRole("radio", { name: /Qwen3 4B/ });
+    expect(qwenRadio).toBeChecked();
 
-    // gpt-4o-mini should NOT be selected
-    const gptItem = screen.getByText("GPT-4o Mini (Remote)").closest("li");
-    expect(gptItem?.getAttribute("aria-selected")).toBe("false");
+    // gpt-4o-mini radio should NOT be checked
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    expect(gptRadio).not.toBeChecked();
+
+    // Parent should have been notified of default selections
+    expect(onChange).toHaveBeenCalledWith("script", "qwen3-4b");
+    expect(onChange).toHaveBeenCalledWith("image", "sd15");
+    expect(onChange).toHaveBeenCalledWith("tts", "qwen-tts");
   });
 
-  it("respects override mode with selectedModels prop", async () => {
+  it("respects controlled mode with selectedModels prop", async () => {
     mockFetchSuccess();
     render(<ModelSelector selectedModels={{ script: "gpt-4o-mini" }} />);
 
@@ -107,12 +116,12 @@ describe("ModelSelector", () => {
       expect(screen.getByTestId("model-selector")).toBeTruthy();
     });
 
-    // In override mode, gpt-4o-mini should be selected
-    const gptItem = screen.getByText("GPT-4o Mini (Remote)").closest("li");
-    expect(gptItem?.getAttribute("aria-selected")).toBe("true");
+    // In controlled mode, gpt-4o-mini should be checked
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    expect(gptRadio).toBeChecked();
 
-    const qwenItem = screen.getByText("Qwen3 4B (Local)").closest("li");
-    expect(qwenItem?.getAttribute("aria-selected")).toBe("false");
+    const qwenRadio = screen.getByRole("radio", { name: /Qwen3 4B/ });
+    expect(qwenRadio).not.toBeChecked();
   });
 
   it("shows only specified categories", async () => {
@@ -142,5 +151,50 @@ describe("ModelSelector", () => {
 
     expect(screen.getByText("unavailable")).toBeTruthy();
     expect(screen.getByText("unknown")).toBeTruthy();
+  });
+
+  it("keyboard navigation works via native radio inputs", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(<ModelSelector onSelectionChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    onChange.mockClear();
+
+    // Native radios support keyboard by default; simulate click on radio
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    fireEvent.click(gptRadio);
+    // The onChange handler fires through the radio onChange
+    expect(onChange).toHaveBeenCalledWith("script", "gpt-4o-mini");
+  });
+
+  it("uses radiogroup role with proper aria-label per category", async () => {
+    mockFetchSuccess();
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Each category should have a radiogroup
+    expect(screen.getByRole("radiogroup", { name: "Script Model" })).toBeTruthy();
+    expect(screen.getByRole("radiogroup", { name: "Image Model" })).toBeTruthy();
+    expect(screen.getByRole("radiogroup", { name: "TTS Model" })).toBeTruthy();
+  });
+
+  it("does not notify parent of defaults in controlled mode", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    render(<ModelSelector selectedModels={{ script: "qwen3-4b" }} onSelectionChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // In controlled mode, onSelectionChange should NOT be called with defaults
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/studio-web/src/__tests__/ModelSelector.test.tsx
+++ b/apps/studio-web/src/__tests__/ModelSelector.test.tsx
@@ -197,4 +197,64 @@ describe("ModelSelector", () => {
     // In controlled mode, onSelectionChange should NOT be called with defaults
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("does not fire duplicate default callbacks when categories array identity changes", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <ModelSelector categories={["script", "image"]} onSelectionChange={onChange} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Initial defaults should have fired for script + image
+    expect(onChange).toHaveBeenCalledWith("script", "qwen3-4b");
+    expect(onChange).toHaveBeenCalledWith("image", "sd15");
+    const initialCallCount = onChange.mock.calls.length;
+    onChange.mockClear();
+
+    // Rerender with a NEW array reference but same content
+    rerender(
+      <ModelSelector categories={["script", "image"]} onSelectionChange={onChange} />,
+    );
+
+    // Allow any effects to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    // No duplicate callbacks should have fired — selections already exist
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("manual uncontrolled selection survives parent rerender", async () => {
+    mockFetchSuccess();
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <ModelSelector onSelectionChange={onChange} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    // Manually select gpt-4o-mini (overriding the default qwen3-4b)
+    const gptRadio = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    fireEvent.click(gptRadio);
+    expect(gptRadio).toBeChecked();
+
+    onChange.mockClear();
+
+    // Rerender with new categories array identity (same content)
+    rerender(
+      <ModelSelector categories={["script", "image", "tts", "stt"]} onSelectionChange={onChange} />,
+    );
+
+    // Allow effects to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The manually selected gpt-4o-mini should still be checked, not overwritten by default
+    const gptRadioAfter = screen.getByRole("radio", { name: /GPT-4o Mini/ });
+    expect(gptRadioAfter).toBeChecked();
+  });
 });

--- a/apps/studio-web/src/__tests__/PipelineStepper.test.tsx
+++ b/apps/studio-web/src/__tests__/PipelineStepper.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PipelineStepper, {
+  PIPELINE_STEPS,
+  STAGE_TO_STEP,
+} from "../components/creator/PipelineStepper";
+
+describe("PipelineStepper", () => {
+  it("renders all 6 pipeline steps", () => {
+    render(<PipelineStepper currentStage="IDEA_READY" />);
+    const stepper = screen.getByTestId("pipeline-stepper");
+    expect(stepper).toBeInTheDocument();
+    for (const step of PIPELINE_STEPS) {
+      expect(screen.getByTestId(`step-${step.key}`)).toBeInTheDocument();
+    }
+  });
+
+  it("marks the first step as current for IDEA_READY", () => {
+    render(<PipelineStepper currentStage="IDEA_READY" />);
+    const ideaStep = screen.getByTestId("step-idea");
+    expect(ideaStep).toHaveAttribute("data-status", "current");
+  });
+
+  it("marks idea as completed and script as current for SCRIPT_GENERATING", () => {
+    render(<PipelineStepper currentStage="SCRIPT_GENERATING" />);
+    expect(screen.getByTestId("step-idea")).toHaveAttribute("data-status", "completed");
+    expect(screen.getByTestId("step-script")).toHaveAttribute("data-status", "current");
+  });
+
+  it("marks idea as completed and script as current for SCRIPT_REVIEW", () => {
+    render(<PipelineStepper currentStage="SCRIPT_REVIEW" />);
+    expect(screen.getByTestId("step-idea")).toHaveAttribute("data-status", "completed");
+    expect(screen.getByTestId("step-script")).toHaveAttribute("data-status", "current");
+  });
+
+  it("marks visual_plan as current for VISUAL_PLAN_GENERATING", () => {
+    render(<PipelineStepper currentStage="VISUAL_PLAN_GENERATING" />);
+    expect(screen.getByTestId("step-idea")).toHaveAttribute("data-status", "completed");
+    expect(screen.getByTestId("step-script")).toHaveAttribute("data-status", "completed");
+    expect(screen.getByTestId("step-visual_plan")).toHaveAttribute("data-status", "current");
+  });
+
+  it("marks assets as current for VISUAL_ASSET_GENERATING", () => {
+    render(<PipelineStepper currentStage="VISUAL_ASSET_GENERATING" />);
+    expect(screen.getByTestId("step-visual_plan")).toHaveAttribute("data-status", "completed");
+    expect(screen.getByTestId("step-assets")).toHaveAttribute("data-status", "current");
+  });
+
+  it("marks audio_subtitles as current for AUDIO_GENERATING", () => {
+    render(<PipelineStepper currentStage="AUDIO_GENERATING" />);
+    expect(screen.getByTestId("step-assets")).toHaveAttribute("data-status", "completed");
+    expect(screen.getByTestId("step-audio_subtitles")).toHaveAttribute("data-status", "current");
+  });
+
+  it("marks audio_subtitles as current for SUBTITLE_GENERATING", () => {
+    render(<PipelineStepper currentStage="SUBTITLE_GENERATING" />);
+    expect(screen.getByTestId("step-audio_subtitles")).toHaveAttribute("data-status", "current");
+  });
+
+  it("marks render as current for RENDER_GENERATING", () => {
+    render(<PipelineStepper currentStage="RENDER_GENERATING" />);
+    expect(screen.getByTestId("step-audio_subtitles")).toHaveAttribute("data-status", "completed");
+    expect(screen.getByTestId("step-render")).toHaveAttribute("data-status", "current");
+  });
+
+  it("marks render as current for FINAL_REVIEW", () => {
+    render(<PipelineStepper currentStage="FINAL_REVIEW" />);
+    expect(screen.getByTestId("step-render")).toHaveAttribute("data-status", "current");
+  });
+
+  it("marks all steps as completed for PUBLISHED", () => {
+    render(<PipelineStepper currentStage="PUBLISHED" />);
+    for (const step of PIPELINE_STEPS) {
+      expect(screen.getByTestId(`step-${step.key}`)).toHaveAttribute("data-status", "completed");
+    }
+  });
+
+  it("marks current step as failed when failed prop is true", () => {
+    render(<PipelineStepper currentStage="SCRIPT_GENERATING" failed={true} />);
+    expect(screen.getByTestId("step-idea")).toHaveAttribute("data-status", "completed");
+    expect(screen.getByTestId("step-script")).toHaveAttribute("data-status", "failed");
+    expect(screen.getByTestId("step-visual_plan")).toHaveAttribute("data-status", "pending");
+  });
+
+  it("renders pending steps after current", () => {
+    render(<PipelineStepper currentStage="SCRIPT_REVIEW" />);
+    expect(screen.getByTestId("step-visual_plan")).toHaveAttribute("data-status", "pending");
+    expect(screen.getByTestId("step-assets")).toHaveAttribute("data-status", "pending");
+    expect(screen.getByTestId("step-audio_subtitles")).toHaveAttribute("data-status", "pending");
+    expect(screen.getByTestId("step-render")).toHaveAttribute("data-status", "pending");
+  });
+
+  it("displays step labels", () => {
+    render(<PipelineStepper currentStage="IDEA_READY" />);
+    expect(screen.getByText("Idea")).toBeInTheDocument();
+    expect(screen.getByText("Script")).toBeInTheDocument();
+    expect(screen.getByText("Visual Plan")).toBeInTheDocument();
+    expect(screen.getByText("Assets")).toBeInTheDocument();
+    expect(screen.getByText("Audio / Subs")).toBeInTheDocument();
+    expect(screen.getByText("Render")).toBeInTheDocument();
+  });
+
+  it("shows checkmark for completed steps", () => {
+    render(<PipelineStepper currentStage="VISUAL_PLAN_GENERATING" />);
+    // Idea and Script are completed — should show ✓
+    const ideaStep = screen.getByTestId("step-idea");
+    expect(ideaStep.textContent).toContain("✓");
+    const scriptStep = screen.getByTestId("step-script");
+    expect(scriptStep.textContent).toContain("✓");
+  });
+
+  it("shows ✕ for failed step", () => {
+    render(<PipelineStepper currentStage="AUDIO_GENERATING" failed={true} />);
+    const audioStep = screen.getByTestId("step-audio_subtitles");
+    expect(audioStep.textContent).toContain("✕");
+  });
+
+  it("renders as a nav with proper aria-label", () => {
+    render(<PipelineStepper currentStage="IDEA_READY" />);
+    const nav = screen.getByRole("navigation", { name: "Pipeline progress" });
+    expect(nav).toBeInTheDocument();
+  });
+
+  it("sets aria-current=step on the current step circle", () => {
+    render(<PipelineStepper currentStage="SCRIPT_REVIEW" />);
+    const currentCircle = screen.getByTestId("step-script").querySelector("[aria-current='step']");
+    expect(currentCircle).toBeInTheDocument();
+  });
+
+  it("STAGE_TO_STEP covers all documented stages", () => {
+    const expectedStages = [
+      "IDEA_READY",
+      "SCRIPT_GENERATING",
+      "SCRIPT_REVIEW",
+      "VISUAL_PLAN_GENERATING",
+      "VISUAL_PLAN_REVIEW",
+      "VISUAL_ASSET_GENERATING",
+      "VISUAL_ASSET_REVIEW",
+      "AUDIO_GENERATING",
+      "SUBTITLE_GENERATING",
+      "RENDER_GENERATING",
+      "FINAL_REVIEW",
+      "PUBLISHED",
+    ];
+    for (const stage of expectedStages) {
+      expect(STAGE_TO_STEP).toHaveProperty(stage);
+    }
+  });
+
+  it("PIPELINE_STEPS has exactly 6 entries", () => {
+    expect(PIPELINE_STEPS).toHaveLength(6);
+  });
+
+  it("handles unknown stage gracefully (all pending)", () => {
+    render(<PipelineStepper currentStage="UNKNOWN_STAGE" />);
+    // With activeIdx = -1, all steps should be pending (no step matches idx -1)
+    for (const step of PIPELINE_STEPS) {
+      expect(screen.getByTestId(`step-${step.key}`)).toHaveAttribute("data-status", "pending");
+    }
+  });
+});

--- a/apps/studio-web/src/__tests__/ProgressDialog.test.tsx
+++ b/apps/studio-web/src/__tests__/ProgressDialog.test.tsx
@@ -1,0 +1,456 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import ProgressDialog from "../components/creator/ProgressDialog";
+
+// --------------- helpers ---------------
+
+const API = "/api/creator";
+const RUN_ID = 70;
+
+function mockFetch(responses: Record<string, { status?: number; body: unknown }>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    const key = `${method} ${url}`;
+    for (const [pattern, resp] of Object.entries(responses)) {
+      if (key.includes(pattern) || url.includes(pattern)) {
+        return {
+          ok: (resp.status ?? 200) < 400,
+          status: resp.status ?? 200,
+          json: async () => resp.body,
+        };
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({ detail: "Not found" }) };
+  }) as unknown as typeof fetch;
+}
+
+// --------------- tests ---------------
+
+describe("ProgressDialog", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not render when open=false", () => {
+    globalThis.fetch = mockFetch({});
+    render(
+      <ProgressDialog
+        open={false}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+      />,
+    );
+    expect(screen.queryByTestId("progress-dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders overlay and dialog when open=true", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}`]: {
+        body: { current_stage: "SCRIPT_GENERATING", status: "running" },
+      },
+    });
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+      />,
+    );
+
+    // Initial render should show dialog immediately
+    expect(screen.getByTestId("progress-dialog-overlay")).toBeInTheDocument();
+    expect(screen.getByTestId("progress-dialog")).toBeInTheDocument();
+
+    // Wait for first poll to resolve
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId("progress-stage")).toBeInTheDocument();
+    expect(screen.getByTestId("progress-status")).toHaveTextContent("Status: running");
+  });
+
+  it("shows friendly stage label for known stages", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}`]: {
+        body: { current_stage: "VISUAL_ASSET_GENERATING", status: "running" },
+      },
+    });
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="VISUAL_ASSET_GENERATING"
+        apiBase={API}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId("progress-stage")).toHaveTextContent(
+      "Generating visual assets…",
+    );
+  });
+
+  it("shows spinner while running", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}`]: {
+        body: { current_stage: "SCRIPT_GENERATING", status: "running" },
+      },
+    });
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId("progress-spinner")).toBeInTheDocument();
+  });
+
+  it("calls onComplete when stage transitions past expected", async () => {
+    const onComplete = vi.fn();
+    let callNum = 0;
+
+    globalThis.fetch = vi.fn(async () => {
+      callNum++;
+      const stage = callNum <= 1 ? "SCRIPT_GENERATING" : "SCRIPT_REVIEW";
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ current_stage: stage, status: "running" }),
+      };
+    }) as unknown as typeof fetch;
+
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+        pollInterval={1000}
+        onComplete={onComplete}
+      />,
+    );
+
+    // First poll — still generating
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // Second poll — moved to SCRIPT_REVIEW
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith("SCRIPT_REVIEW", "running");
+    expect(screen.getByTestId("progress-completed")).toHaveTextContent(
+      "Generation complete",
+    );
+    // Spinner should be gone
+    expect(screen.queryByTestId("progress-spinner")).not.toBeInTheDocument();
+  });
+
+  it("calls onFailed when run status becomes failed", async () => {
+    const onFailed = vi.fn();
+    let callNum = 0;
+
+    globalThis.fetch = vi.fn(async () => {
+      callNum++;
+      const status = callNum <= 1 ? "running" : "failed";
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ current_stage: "SCRIPT_GENERATING", status }),
+      };
+    }) as unknown as typeof fetch;
+
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+        pollInterval={1000}
+        onFailed={onFailed}
+      />,
+    );
+
+    // First poll — running
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(onFailed).not.toHaveBeenCalled();
+
+    // Second poll — failed
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(onFailed).toHaveBeenCalledWith("SCRIPT_GENERATING", "failed");
+    expect(screen.getByTestId("progress-failed")).toHaveTextContent("Generation failed");
+  });
+
+  it("shows error when poll request fails", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}`]: {
+        status: 500,
+        body: { detail: "Internal server error" },
+      },
+    });
+
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId("progress-error")).toHaveTextContent(
+      "Internal server error",
+    );
+  });
+
+  it("increments poll count on each successful poll", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}`]: {
+        body: { current_stage: "SCRIPT_GENERATING", status: "running" },
+      },
+    });
+
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+        pollInterval={1000}
+      />,
+    );
+
+    // First poll
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByTestId("progress-poll-count")).toHaveTextContent("1 poll");
+
+    // Second poll
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(screen.getByTestId("progress-poll-count")).toHaveTextContent("2 polls");
+  });
+
+  it("calls onClose when dismiss/close button is clicked", async () => {
+    const onClose = vi.fn();
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}`]: {
+        body: { current_stage: "SCRIPT_GENERATING", status: "running" },
+      },
+    });
+
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+        onClose={onClose}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    fireEvent.click(screen.getByTestId("progress-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("button says 'Dismiss' when running, 'Close' when terminal", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}`]: {
+        body: { current_stage: "SCRIPT_GENERATING", status: "running" },
+      },
+    });
+
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId("progress-close")).toHaveTextContent("Dismiss");
+  });
+
+  it("resets state when closed and reopened", async () => {
+    const onComplete = vi.fn();
+    let callNum = 0;
+
+    globalThis.fetch = vi.fn(async () => {
+      callNum++;
+      // First 2 calls: still generating. Call 3+: review stage.
+      const stage = callNum <= 2 ? "SCRIPT_GENERATING" : "SCRIPT_REVIEW";
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ current_stage: stage, status: "running" }),
+      };
+    }) as unknown as typeof fetch;
+
+    const { rerender } = render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+        pollInterval={1000}
+        onComplete={onComplete}
+      />,
+    );
+
+    // First poll — still generating
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByTestId("progress-poll-count")).toHaveTextContent("1 poll");
+
+    // Second poll — still generating
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(screen.getByTestId("progress-poll-count")).toHaveTextContent("2 polls");
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // Close dialog
+    await act(async () => {
+      rerender(
+        <ProgressDialog
+          open={false}
+          runId={RUN_ID}
+          expectedStage="SCRIPT_GENERATING"
+          apiBase={API}
+          pollInterval={1000}
+          onComplete={onComplete}
+        />,
+      );
+    });
+    expect(screen.queryByTestId("progress-dialog")).not.toBeInTheDocument();
+
+    // Reopen — callNum=3 will return SCRIPT_REVIEW
+    await act(async () => {
+      rerender(
+        <ProgressDialog
+          open={true}
+          runId={RUN_ID}
+          expectedStage="SCRIPT_GENERATING"
+          apiBase={API}
+          pollInterval={1000}
+          onComplete={onComplete}
+        />,
+      );
+      // Allow the useEffect to schedule and the immediate poll to fire
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // callNum=3 → SCRIPT_REVIEW → should trigger onComplete
+    expect(onComplete).toHaveBeenCalledWith("SCRIPT_REVIEW", "running");
+    // Poll count should have reset to 1 (not continuing from 2)
+    expect(screen.getByTestId("progress-poll-count")).toHaveTextContent("1 poll");
+  });
+
+  it("stops polling after completion", async () => {
+    let callNum = 0;
+    globalThis.fetch = vi.fn(async () => {
+      callNum++;
+      const stage = callNum <= 1 ? "SCRIPT_GENERATING" : "SCRIPT_REVIEW";
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ current_stage: stage, status: "running" }),
+      };
+    }) as unknown as typeof fetch;
+
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+        pollInterval={1000}
+      />,
+    );
+
+    // First poll — generating
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Second poll — complete
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(screen.getByTestId("progress-completed")).toBeInTheDocument();
+
+    const fetchCountAfterComplete = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // Advance time — no more polls should fire
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      fetchCountAfterComplete,
+    );
+  });
+
+  it("handles network error gracefully", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("Network failure");
+    }) as unknown as typeof fetch;
+
+    render(
+      <ProgressDialog
+        open={true}
+        runId={RUN_ID}
+        expectedStage="SCRIPT_GENERATING"
+        apiBase={API}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId("progress-error")).toHaveTextContent("Network failure");
+  });
+});

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -1,0 +1,369 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ProjectPage from "../pages/ProjectPage";
+
+// ---- mock data ----
+
+const MOCK_PROJECT = {
+  id: 7,
+  title: "My Short",
+  source_type: "idea",
+  status: "active",
+  created_at: "2025-03-15T10:00:00Z",
+  updated_at: "2025-03-15T12:00:00Z",
+};
+
+const MOCK_RUN_IDEA = {
+  id: 1,
+  project_id: 7,
+  current_stage: "IDEA_READY",
+  status: "pending",
+  restart_from: null,
+};
+
+const MOCK_RUN_REVIEW = {
+  id: 1,
+  project_id: 7,
+  current_stage: "SCRIPT_REVIEW",
+  status: "running",
+  restart_from: null,
+};
+
+const MOCK_RUN_GENERATING = {
+  id: 1,
+  project_id: 7,
+  current_stage: "SCRIPT_GENERATING",
+  status: "running",
+  restart_from: null,
+};
+
+// ---- helpers ----
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderPage(projectId = "7") {
+  return render(
+    <MemoryRouter initialEntries={[`/projects/${projectId}`]}>
+      <Routes>
+        <Route path="/projects/:projectId" element={<ProjectPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+type MockRun = typeof MOCK_RUN_IDEA;
+
+function mockFetchProjectAndRuns(
+  project: typeof MOCK_PROJECT | null,
+  runs: MockRun[] = [],
+) {
+  vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+
+    // GET /projects/:id/runs
+    if (url.includes("/projects/") && url.includes("/runs")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ runs, total: runs.length }),
+      } as Response);
+    }
+    // GET /projects/:id
+    if (url.includes("/projects/")) {
+      if (!project) {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          json: () => Promise.resolve({ detail: "Project not found" }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(project),
+      } as Response);
+    }
+    // GET /runs/:id (for refreshRun)
+    if (url.includes("/runs/")) {
+      const latestRun = runs[0];
+      if (latestRun) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(latestRun),
+        } as Response);
+      }
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockNavigate.mockReset();
+});
+
+describe("ProjectPage", () => {
+  // ---- Loading ----
+  it("shows loading state initially", () => {
+    vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise(() => {}));
+    renderPage();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading project");
+  });
+
+  // ---- Error ----
+  it("shows error when project not found", async () => {
+    mockFetchProjectAndRuns(null);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("Project not found");
+  });
+
+  it("shows back link on error", async () => {
+    mockFetchProjectAndRuns(null);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Back to projects")).toBeInTheDocument();
+    });
+  });
+
+  // ---- Invalid project ID ----
+  it("shows invalid ID message for non-numeric id", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects/abc"]}>
+        <Routes>
+          <Route path="/projects/:projectId" element={<ProjectPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Invalid project ID.")).toBeInTheDocument();
+  });
+
+  // ---- Project loaded, no runs ----
+  it("shows project title and no-run state", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, []);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("My Short")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("no-run")).toBeInTheDocument();
+    expect(screen.getByText("No runs yet")).toBeInTheDocument();
+  });
+
+  it("shows source and status metadata", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, []);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Source: idea/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Status: active/)).toBeInTheDocument();
+  });
+
+  // ---- Project with run in IDEA_READY ----
+  it("shows stepper and Generate Script button for IDEA_READY", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_IDEA]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("My Short")).toBeInTheDocument();
+    });
+    // Stepper should be present (PipelineStepper renders step labels)
+    expect(screen.getByText("Idea")).toBeInTheDocument();
+    expect(screen.getByText("Script")).toBeInTheDocument();
+    // Generate button visible
+    expect(screen.getByRole("button", { name: "Generate Script" })).toBeInTheDocument();
+    // Approve and Regenerate should not be visible
+    expect(screen.queryByRole("button", { name: "Approve Script" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Regenerate" })).not.toBeInTheDocument();
+  });
+
+  // ---- Project with run in SCRIPT_REVIEW ----
+  it("shows editor tabs and action buttons for SCRIPT_REVIEW", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("My Short")).toBeInTheDocument();
+    });
+    // Editor tabs
+    expect(screen.getByRole("tab", { name: "Markdown" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Structured" })).toBeInTheDocument();
+    // Approve + Regenerate visible
+    expect(screen.getByRole("button", { name: "Approve Script" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Regenerate" })).toBeInTheDocument();
+    // Generate should not be visible
+    expect(screen.queryByRole("button", { name: "Generate Script" })).not.toBeInTheDocument();
+  });
+
+  it("switches between markdown and structured tabs", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Markdown" })).toBeInTheDocument();
+    });
+
+    // Default: Markdown tab selected
+    const mdTab = screen.getByRole("tab", { name: "Markdown" });
+    expect(mdTab.getAttribute("aria-selected")).toBe("true");
+
+    // Switch to structured
+    fireEvent.click(screen.getByRole("tab", { name: "Structured" }));
+
+    const stTab = screen.getByRole("tab", { name: "Structured" });
+    expect(stTab.getAttribute("aria-selected")).toBe("true");
+    expect(mdTab.getAttribute("aria-selected")).toBe("false");
+  });
+
+  // ---- SCRIPT_GENERATING state ----
+  it("shows generating indicator for SCRIPT_GENERATING", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_GENERATING]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("generating-indicator")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Generating Script…")).toBeInTheDocument();
+    // Editor tabs should NOT be visible during generation
+    expect(screen.queryByRole("tab", { name: "Markdown" })).not.toBeInTheDocument();
+  });
+
+  // ---- Approve action ----
+  it("calls approve endpoint and shows status", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Approve Script" })).toBeInTheDocument();
+    });
+
+    // Override fetch for the approve call
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve Script" }));
+
+    await waitFor(() => {
+      // Verify approve endpoint was called
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/approve-script"))).toBe(true);
+    });
+  });
+
+  // ---- Generate action ----
+  it("calls generate endpoint on button click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_IDEA]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Generate Script" })).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    fireEvent.click(screen.getByRole("button", { name: "Generate Script" }));
+
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/generate-script"))).toBe(true);
+    });
+  });
+
+  // ---- Restart action ----
+  it("calls restart endpoint on Regenerate click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Regenerate" })).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
+
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/restart"))).toBe(true);
+    });
+  });
+
+  // ---- API calls ----
+  it("fetches project and runs on mount", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/runs")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ runs: [], total: 0 }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(MOCK_PROJECT),
+      } as Response);
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      const calls = spy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/projects/7") && !u.includes("/runs"))).toBe(true);
+      expect(calls.some((u) => u.includes("/projects/7/runs"))).toBe(true);
+    });
+  });
+
+  // ---- Untitled project ----
+  it("shows 'Untitled Project' for null title", async () => {
+    mockFetchProjectAndRuns({ ...MOCK_PROJECT, title: null }, []);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Untitled Project")).toBeInTheDocument();
+    });
+  });
+
+  // ---- Back link ----
+  it("renders back link to projects", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_IDEA]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("← Projects")).toBeInTheDocument();
+    });
+  });
+
+  // ---- Action error display ----
+  it("shows error status when approve fails", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Approve Script" })).toBeInTheDocument();
+    });
+
+    // Override fetch to fail on approve
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/approve-script")) {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: () => Promise.resolve({ detail: "Stage conflict" }),
+        } as Response);
+      }
+      // Fallback for other calls
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(MOCK_RUN_REVIEW),
+      } as Response);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve Script" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Stage conflict")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -38,6 +38,22 @@ const MOCK_RUN_GENERATING = {
   restart_from: null,
 };
 
+const MOCK_RUN_VP_GENERATING = {
+  id: 1,
+  project_id: 7,
+  current_stage: "VISUAL_PLAN_GENERATING",
+  status: "running",
+  restart_from: null,
+};
+
+const MOCK_RUN_VP_REVIEW = {
+  id: 1,
+  project_id: 7,
+  current_stage: "VISUAL_PLAN_REVIEW",
+  status: "running",
+  restart_from: null,
+};
+
 // ---- helpers ----
 
 const mockNavigate = vi.fn();
@@ -177,7 +193,7 @@ describe("ProjectPage", () => {
     expect(screen.getByRole("button", { name: "Generate Script" })).toBeInTheDocument();
     // Approve and Regenerate should not be visible
     expect(screen.queryByRole("button", { name: "Approve Script" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Regenerate" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Regenerate Script" })).not.toBeInTheDocument();
   });
 
   // ---- Project with run in SCRIPT_REVIEW ----
@@ -190,11 +206,10 @@ describe("ProjectPage", () => {
     // Editor tabs
     expect(screen.getByRole("tab", { name: "Markdown" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Structured" })).toBeInTheDocument();
-    // Approve + Regenerate visible
+    // Approve + Regenerate Script + Generate Visual Plan visible
     expect(screen.getByRole("button", { name: "Approve Script" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Regenerate" })).toBeInTheDocument();
-    // Generate should not be visible
-    expect(screen.queryByRole("button", { name: "Generate Script" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Regenerate Script" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Generate Visual Plan" })).toBeInTheDocument();
   });
 
   it("switches between markdown and structured tabs", async () => {
@@ -275,12 +290,12 @@ describe("ProjectPage", () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Regenerate" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Regenerate Script" })).toBeInTheDocument();
     });
 
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate Script" }));
 
     await waitFor(() => {
       const calls = fetchSpy.mock.calls.map(([url]) =>
@@ -364,6 +379,101 @@ describe("ProjectPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Stage conflict")).toBeInTheDocument();
+    });
+  });
+  // ---- Visual Plan stages ----
+
+  it("shows VP generating indicator for VISUAL_PLAN_GENERATING", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_GENERATING]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("vp-generating-indicator")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Generating Visual Plan\u2026")).toBeInTheDocument();
+    // Script editor tabs should NOT be visible
+    expect(screen.queryByRole("tab", { name: "Markdown" })).not.toBeInTheDocument();
+  });
+
+  it("shows VisualPlanEditor and action buttons for VISUAL_PLAN_REVIEW", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("visual-plan-editor")).toBeInTheDocument();
+    });
+    // Approve and Regenerate Plan visible
+    expect(screen.getByRole("button", { name: "Approve Visual Plan" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Regenerate Plan" })).toBeInTheDocument();
+    // Script actions should not be visible
+    expect(screen.queryByRole("button", { name: "Approve Script" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Generate Script" })).not.toBeInTheDocument();
+  });
+
+  it("calls approve-visual-plan endpoint on Approve Visual Plan click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Approve Visual Plan" })).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve Visual Plan" }));
+
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/approve-visual-plan"))).toBe(true);
+    });
+  });
+
+  it("shows Generate Visual Plan button in SCRIPT_REVIEW", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Generate Visual Plan" })).toBeInTheDocument();
+    });
+  });
+
+  it("calls generate-visual-plan endpoint from SCRIPT_REVIEW", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Generate Visual Plan" })).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    fireEvent.click(screen.getByRole("button", { name: "Generate Visual Plan" }));
+
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/generate-visual-plan"))).toBe(true);
+    });
+  });
+
+  it("calls restart with VISUAL_PLAN_GENERATING stage on Regenerate Plan click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Regenerate Plan" })).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate Plan" }));
+
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls;
+      const restartCall = calls.find(([url]) => {
+        const u = typeof url === "string" ? url : (url as Request).url;
+        return u.includes("/restart");
+      });
+      expect(restartCall).toBeDefined();
+      const body = JSON.parse(restartCall![1]!.body as string);
+      expect(body.stage).toBe("VISUAL_PLAN_GENERATING");
     });
   });
 });

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -103,6 +103,22 @@ function mockFetchProjectAndRuns(
       } as Response);
     }
     // GET /runs/:id (for refreshRun)
+    // GET /runs/:id/visual-assets
+    if (url.includes("/visual-assets")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ run_id: 1, scenes: {}, total_scenes: 0, total_assets: 0 }),
+      } as Response);
+    }
+    // GET /api/creator/models
+    if (url.includes("/models")) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ script_models: [], image_models: [], tts_models: [], stt_models: [] }),
+      } as Response);
+    }
+    // GET /runs/:id (for refreshRun)
     if (url.includes("/runs/")) {
       const latestRun = runs[0];
       if (latestRun) {
@@ -474,6 +490,157 @@ describe("ProjectPage", () => {
       expect(restartCall).toBeDefined();
       const body = JSON.parse(restartCall![1]!.body as string);
       expect(body.stage).toBe("VISUAL_PLAN_GENERATING");
+    });
+  });
+
+  // ---- Visual Asset Stages ----
+
+  const MOCK_RUN_VA_GENERATING = {
+    id: 1,
+    project_id: 7,
+    current_stage: "VISUAL_ASSET_GENERATING",
+    status: "running",
+    restart_from: null,
+  };
+
+  const MOCK_RUN_VA_REVIEW = {
+    id: 1,
+    project_id: 7,
+    current_stage: "VISUAL_ASSET_REVIEW",
+    status: "running",
+    restart_from: null,
+  };
+
+  it("shows VA generating indicator for VISUAL_ASSET_GENERATING", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_GENERATING]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("va-generating-indicator")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Generating Visual Assets…")).toBeInTheDocument();
+  });
+
+  it("shows visual-asset-section for VISUAL_ASSET_REVIEW", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("visual-asset-section")).toBeInTheDocument();
+    });
+  });
+
+  it("shows scene regen controls in VISUAL_ASSET_REVIEW", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-regen-controls")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("scene-id-input")).toBeInTheDocument();
+    expect(screen.getByTestId("regen-scene-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("generate-scene-btn")).toBeInTheDocument();
+  });
+
+  it("hides scene regen controls during VISUAL_ASSET_GENERATING", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_GENERATING]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("visual-asset-section")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("scene-regen-controls")).not.toBeInTheDocument();
+  });
+
+  it("shows Approve Assets button in VISUAL_ASSET_REVIEW", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Approve Assets" })).toBeInTheDocument();
+    });
+  });
+
+  it("calls approve-visual-assets endpoint on Approve Assets click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Approve Assets" })).toBeInTheDocument();
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fireEvent.click(screen.getByRole("button", { name: "Approve Assets" }));
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/approve-visual-assets"))).toBe(true);
+    });
+  });
+
+  it("calls generate-visual-assets endpoint on Regenerate All click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Regenerate All" })).toBeInTheDocument();
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate All" }));
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/generate-visual-assets"))).toBe(true);
+    });
+  });
+
+  it("calls restart with VISUAL_ASSET_GENERATING stage on Restart Assets click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Restart Assets" })).toBeInTheDocument();
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fireEvent.click(screen.getByRole("button", { name: "Restart Assets" }));
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls;
+      const restartCall = calls.find(([url]) => {
+        const u = typeof url === "string" ? url : (url as Request).url;
+        return u.includes("/restart");
+      });
+      expect(restartCall).toBeDefined();
+      const body = JSON.parse(restartCall![1]!.body as string);
+      expect(body.stage).toBe("VISUAL_ASSET_GENERATING");
+    });
+  });
+
+  it("calls regenerate-image endpoint when scene regen button clicked", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-regen-controls")).toBeInTheDocument();
+    });
+    const input = screen.getByTestId("scene-id-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "scene-0" } });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fireEvent.click(screen.getByTestId("regen-scene-btn"));
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/scenes/scene-0/regenerate-image"))).toBe(true);
+    });
+  });
+
+  it("calls generate-image endpoint when generate-scene button clicked", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-regen-controls")).toBeInTheDocument();
+    });
+    const input = screen.getByTestId("scene-id-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "scene-1" } });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fireEvent.click(screen.getByTestId("generate-scene-btn"));
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/scenes/scene-1/generate-image"))).toBe(true);
     });
   });
 });

--- a/apps/studio-web/src/__tests__/ReviewPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ReviewPage.test.tsx
@@ -1,0 +1,254 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ReviewPage from "../pages/ReviewPage";
+
+// ---- mock data ----
+
+const MOCK_RUN_FINAL_REVIEW = {
+  id: 10,
+  project_id: 5,
+  current_stage: "FINAL_REVIEW",
+  status: "running",
+  restart_from: null,
+};
+
+const MOCK_RUN_IDEA_READY = {
+  id: 11,
+  project_id: 5,
+  current_stage: "IDEA_READY",
+  status: "pending",
+  restart_from: null,
+};
+
+const MOCK_SCRIPT = {
+  script: "# Scene 1\nA calm morning in Tokyo.",
+  structured_script: null,
+};
+
+const MOCK_SCENES = {
+  scenes: [
+    { scene_id: "scene-0", description: "Tokyo skyline", image_prompt: "panoramic tokyo" },
+    { scene_id: "scene-1", description: "Cherry blossoms", image_prompt: "sakura trees" },
+  ],
+};
+
+const MOCK_ASSETS = {
+  "scene-0": [
+    { asset_path: "data/artifacts/10/visual/scene-0.png", model_used: "sd15", is_active: true },
+  ],
+  "scene-1": [
+    { asset_path: "data/artifacts/10/visual/scene-1.png", model_used: "sd15", is_active: true },
+  ],
+};
+
+const MOCK_PREVIEW = {
+  run_id: 10,
+  current_stage: "FINAL_REVIEW",
+  video: {
+    id: 1,
+    path: "data/artifacts/10/render/output.mp4",
+    render_profile: "shorts_default",
+    created_at: "2026-03-31T10:00:00Z",
+  },
+  audio: {
+    id: 2,
+    path: "data/artifacts/10/audio/audio.wav",
+    model_used: "piper",
+    created_at: "2026-03-31T09:00:00Z",
+  },
+  subtitle: {
+    id: 3,
+    path: "data/artifacts/10/subtitles/subtitles.srt",
+    format: "srt",
+    created_at: "2026-03-31T09:30:00Z",
+  },
+};
+
+// ---- helpers ----
+
+function renderPage(runId = "10") {
+  return render(
+    <MemoryRouter initialEntries={[`/review/${runId}`]}>
+      <Routes>
+        <Route path="/review/:runId" element={<ReviewPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function mockFetchAll(
+  run: typeof MOCK_RUN_FINAL_REVIEW | null,
+  opts: {
+    script?: typeof MOCK_SCRIPT | null;
+    scenes?: typeof MOCK_SCENES | null;
+    assets?: typeof MOCK_ASSETS | null;
+    preview?: typeof MOCK_PREVIEW | null;
+  } = {},
+) {
+  vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+
+    // GET /runs/:id/preview
+    if (url.includes("/preview")) {
+      if (!opts.preview) return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) } as Response);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.preview) } as Response);
+    }
+    // GET /runs/:id/visual-assets
+    if (url.includes("/visual-assets")) {
+      if (!opts.assets) return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.assets) } as Response);
+    }
+    // GET /runs/:id/visual-plan
+    if (url.includes("/visual-plan")) {
+      if (!opts.scenes) return Promise.resolve({ ok: true, json: () => Promise.resolve({ scenes: [] }) } as Response);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.scenes) } as Response);
+    }
+    // GET /runs/:id/script
+    if (url.includes("/script")) {
+      if (!opts.script) return Promise.resolve({ ok: true, json: () => Promise.resolve({ script: null, structured_script: null }) } as Response);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.script) } as Response);
+    }
+    // GET /runs/:id
+    if (url.match(/\/runs\/\d+$/)) {
+      if (!run) return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({ detail: "Run not found" }) } as Response);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(run) } as Response);
+    }
+
+    return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) } as Response);
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---- tests ----
+
+describe("ReviewPage", () => {
+  it("shows loading state initially", () => {
+    mockFetchAll(MOCK_RUN_FINAL_REVIEW);
+    renderPage();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading review");
+  });
+
+  it("shows error for invalid run ID", () => {
+    mockFetchAll(null);
+    renderPage("abc");
+    expect(screen.getByText("Invalid run ID.")).toBeTruthy();
+  });
+
+  it("shows run not found error", async () => {
+    mockFetchAll(null);
+    renderPage("999");
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Run not found");
+    });
+  });
+
+  it("renders full review at FINAL_REVIEW with all artifacts", async () => {
+    mockFetchAll(MOCK_RUN_FINAL_REVIEW, {
+      script: MOCK_SCRIPT,
+      scenes: MOCK_SCENES,
+      assets: MOCK_ASSETS,
+      preview: MOCK_PREVIEW,
+    });
+    renderPage();
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByTestId("review-script-section")).toBeTruthy();
+    });
+
+    // Script section
+    expect(screen.getByText(/calm morning in Tokyo/)).toBeTruthy();
+
+    // Visual plan section
+    expect(screen.getByTestId("review-visual-plan-section")).toBeTruthy();
+    expect(screen.getAllByText("scene-0").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("scene-1").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Tokyo skyline")).toBeTruthy();
+
+    // Visual assets section
+    expect(screen.getByTestId("review-assets-section")).toBeTruthy();
+    expect(screen.getByText(/scene-0\.png/)).toBeTruthy();
+
+    // Audio section
+    expect(screen.getByTestId("review-audio-section")).toBeTruthy();
+    expect(screen.getByText("piper")).toBeTruthy();
+
+    // Subtitle section
+    expect(screen.getByTestId("review-subtitle-section")).toBeTruthy();
+    expect(screen.getByText("srt")).toBeTruthy();
+
+    // Video section
+    expect(screen.getByTestId("review-video-section")).toBeTruthy();
+    expect(screen.getByText(/output\.mp4/)).toBeTruthy();
+    expect(screen.getByText("shorts_default")).toBeTruthy();
+  });
+
+  it("shows empty state at IDEA_READY", async () => {
+    mockFetchAll(MOCK_RUN_IDEA_READY);
+    renderPage("11");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("review-empty")).toBeTruthy();
+    });
+    expect(screen.getByText("No outputs yet")).toBeTruthy();
+    expect(screen.getByText(/Go to editor/)).toBeTruthy();
+  });
+
+  it("shows edit links pointing to project page", async () => {
+    mockFetchAll(MOCK_RUN_FINAL_REVIEW, {
+      script: MOCK_SCRIPT,
+      scenes: MOCK_SCENES,
+      assets: MOCK_ASSETS,
+      preview: MOCK_PREVIEW,
+    });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("review-script-section")).toBeTruthy();
+    });
+
+    // Multiple "Edit in Project" links
+    const editLinks = screen.getAllByText(/Edit in Project/);
+    expect(editLinks.length).toBeGreaterThanOrEqual(1);
+    // All should link to /projects/5
+    editLinks.forEach((link) => {
+      expect(link.closest("a")?.getAttribute("href")).toBe("/projects/5");
+    });
+  });
+
+  it("renders Back to Editor button", async () => {
+    mockFetchAll(MOCK_RUN_FINAL_REVIEW, { script: MOCK_SCRIPT });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("review-script-section")).toBeTruthy();
+    });
+
+    const backBtn = screen.getByText("Back to Editor");
+    expect(backBtn).toBeTruthy();
+    expect(backBtn.closest("a")?.getAttribute("href")).toBe("/projects/5");
+  });
+
+  it("displays pipeline stepper with current stage", async () => {
+    mockFetchAll(MOCK_RUN_FINAL_REVIEW, { script: MOCK_SCRIPT });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/FINAL_REVIEW/)).toBeTruthy();
+    });
+  });
+
+  it("shows model metadata in audio section", async () => {
+    mockFetchAll(MOCK_RUN_FINAL_REVIEW, { preview: MOCK_PREVIEW });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("review-audio-section")).toBeTruthy();
+    });
+    expect(screen.getByText("piper")).toBeTruthy();
+  });
+});

--- a/apps/studio-web/src/__tests__/RunsPage.test.tsx
+++ b/apps/studio-web/src/__tests__/RunsPage.test.tsx
@@ -1,0 +1,297 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import RunsPage from "../pages/RunsPage";
+
+const MOCK_PROJECTS = [
+  {
+    id: 1,
+    title: "Morning Routine",
+    source_type: "idea",
+    status: "active",
+    created_at: "2025-03-15T10:00:00Z",
+    updated_at: "2025-03-15T12:00:00Z",
+  },
+  {
+    id: 2,
+    title: "Cooking Tips",
+    source_type: "markdown",
+    status: "draft",
+    created_at: "2025-03-14T08:00:00Z",
+    updated_at: "2025-03-14T09:00:00Z",
+  },
+  {
+    id: 3,
+    title: null,
+    source_type: "url",
+    status: "completed",
+    created_at: "2025-03-13T06:00:00Z",
+    updated_at: "2025-03-13T07:00:00Z",
+  },
+];
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/runs"]}>
+      <RunsPage />
+    </MemoryRouter>,
+  );
+}
+
+function mockFetchOk(projects: typeof MOCK_PROJECTS, total?: number) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ projects, total: total ?? projects.length }),
+  } as Response);
+}
+
+function mockFetchError(status = 500, detail = "Internal error") {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ detail }),
+  } as Response);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockNavigate.mockReset();
+});
+
+describe("RunsPage", () => {
+  // --- Loading ---
+  it("shows loading state initially", () => {
+    // fetch that never resolves
+    vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise(() => {}));
+    renderPage();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading projects");
+  });
+
+  // --- Empty ---
+  it("shows empty state when no projects", async () => {
+    mockFetchOk([]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No projects yet")).toBeInTheDocument();
+  });
+
+  it("empty state has a create project button", async () => {
+    mockFetchOk([]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+    });
+    const btn = screen.getByRole("button", { name: "Create Project" });
+    fireEvent.click(btn);
+    expect(mockNavigate).toHaveBeenCalledWith("/create");
+  });
+
+  // --- Error ---
+  it("shows error message on fetch failure", async () => {
+    mockFetchError(500, "Internal error");
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("Internal error");
+  });
+
+  it("retry button re-fetches projects", async () => {
+    mockFetchError(500, "Server down");
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    // Now fix the mock
+    vi.restoreAllMocks();
+    mockFetchOk(MOCK_PROJECTS);
+
+    const retryBtn = screen.getByRole("button", { name: "Retry" });
+    fireEvent.click(retryBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+  });
+
+  it("shows generic error when fetch throws", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network error"));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("Network error");
+  });
+
+  // --- Data rendering ---
+  it("renders project list with titles", async () => {
+    mockFetchOk(MOCK_PROJECTS);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Cooking Tips")).toBeInTheDocument();
+  });
+
+  it("shows 'Untitled' for null titles", async () => {
+    mockFetchOk(MOCK_PROJECTS);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Untitled")).toBeInTheDocument();
+    });
+  });
+
+  it("renders source type labels", async () => {
+    mockFetchOk(MOCK_PROJECTS);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Idea")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Markdown")).toBeInTheDocument();
+    expect(screen.getByText("URL")).toBeInTheDocument();
+  });
+
+  it("renders status badges", async () => {
+    mockFetchOk(MOCK_PROJECTS);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("active")).toBeInTheDocument();
+    });
+    expect(screen.getByText("draft")).toBeInTheDocument();
+    expect(screen.getByText("completed")).toBeInTheDocument();
+  });
+
+  it("renders formatted dates", async () => {
+    mockFetchOk(MOCK_PROJECTS);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Mar 15, 2025")).toBeInTheDocument();
+    });
+  });
+
+  // --- Navigation ---
+  it("clicking a row navigates to project page", async () => {
+    mockFetchOk(MOCK_PROJECTS);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+    const row = screen.getByText("Morning Routine").closest("tr")!;
+    fireEvent.click(row);
+    expect(mockNavigate).toHaveBeenCalledWith("/projects/1");
+  });
+
+  it("pressing Enter on a row navigates to project page", async () => {
+    mockFetchOk(MOCK_PROJECTS);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Cooking Tips")).toBeInTheDocument();
+    });
+    const row = screen.getByText("Cooking Tips").closest("tr")!;
+    fireEvent.keyDown(row, { key: "Enter" });
+    expect(mockNavigate).toHaveBeenCalledWith("/projects/2");
+  });
+
+  it("+ New Project button navigates to /create", async () => {
+    mockFetchOk(MOCK_PROJECTS);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("+ New Project"));
+    expect(mockNavigate).toHaveBeenCalledWith("/create");
+  });
+
+  // --- Pagination ---
+  it("does not show pagination when total <= PAGE_SIZE", async () => {
+    mockFetchOk(MOCK_PROJECTS, 3);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Next page")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Previous page")).not.toBeInTheDocument();
+  });
+
+  it("shows pagination when total > PAGE_SIZE", async () => {
+    mockFetchOk(MOCK_PROJECTS, 25);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Next page")).toBeInTheDocument();
+    expect(screen.getByLabelText("Previous page")).toBeInTheDocument();
+    expect(screen.getByText(/Showing 1–20 of 25/)).toBeInTheDocument();
+  });
+
+  it("Previous button is disabled on first page", async () => {
+    mockFetchOk(MOCK_PROJECTS, 25);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Previous page")).toBeDisabled();
+  });
+
+  it("Next button fetches next page", async () => {
+    mockFetchOk(MOCK_PROJECTS, 25);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    fireEvent.click(screen.getByLabelText("Next page"));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("offset=20"),
+      );
+    });
+  });
+
+  // --- API call ---
+  it("calls fetch with correct URL on mount", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ projects: [], total: 0 }),
+    } as Response);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith("/api/creator/projects?limit=20&offset=0");
+    });
+  });
+
+  // --- Header ---
+  it("renders page heading", async () => {
+    mockFetchOk([]);
+    renderPage();
+    expect(screen.getByRole("heading", { name: "Projects" })).toBeInTheDocument();
+  });
+
+  // --- Fallback error when json parse fails ---
+  it("shows fallback error when json parse fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: () => Promise.reject(new Error("parse error")),
+    } as Response);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("Failed to load projects (502)");
+  });
+});

--- a/apps/studio-web/src/__tests__/StageActionBar.test.tsx
+++ b/apps/studio-web/src/__tests__/StageActionBar.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import StageActionBar from "../components/creator/StageActionBar";
+
+describe("StageActionBar", () => {
+  it("renders nothing when no actions or status message provided", () => {
+    const { container } = render(<StageActionBar />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when all actions are hidden", () => {
+    const { container } = render(
+      <StageActionBar
+        save={{ visible: false }}
+        approve={{ visible: false }}
+        generate={{ visible: false }}
+        restart={{ visible: false }}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders the bar when at least one action is visible", () => {
+    render(<StageActionBar save={{}} />);
+    expect(screen.getByTestId("stage-action-bar")).toBeInTheDocument();
+  });
+
+  it("renders save button with default label", () => {
+    render(<StageActionBar save={{}} />);
+    const btn = screen.getByTestId("action-save");
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent("Save");
+  });
+
+  it("renders approve button with default label", () => {
+    render(<StageActionBar approve={{}} />);
+    expect(screen.getByTestId("action-approve")).toHaveTextContent("Approve");
+  });
+
+  it("renders generate button with default label", () => {
+    render(<StageActionBar generate={{}} />);
+    expect(screen.getByTestId("action-generate")).toHaveTextContent("Generate");
+  });
+
+  it("renders restart button with default label", () => {
+    render(<StageActionBar restart={{}} />);
+    expect(screen.getByTestId("action-restart")).toHaveTextContent("Restart");
+  });
+
+  it("renders custom labels when provided", () => {
+    render(
+      <StageActionBar
+        save={{ label: "Save Draft" }}
+        approve={{ label: "Approve & Continue" }}
+      />,
+    );
+    expect(screen.getByTestId("action-save")).toHaveTextContent("Save Draft");
+    expect(screen.getByTestId("action-approve")).toHaveTextContent("Approve & Continue");
+  });
+
+  it("calls onClick when button is clicked", () => {
+    const handleSave = vi.fn();
+    const handleApprove = vi.fn();
+    render(
+      <StageActionBar
+        save={{ onClick: handleSave }}
+        approve={{ onClick: handleApprove }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("action-save"));
+    expect(handleSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("action-approve"));
+    expect(handleApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables button when disabled=true", () => {
+    render(<StageActionBar save={{ disabled: true }} />);
+    const btn = screen.getByTestId("action-save");
+    expect(btn).toBeDisabled();
+  });
+
+  it("does not fire onClick when disabled", () => {
+    const handler = vi.fn();
+    render(<StageActionBar save={{ disabled: true, onClick: handler }} />);
+    fireEvent.click(screen.getByTestId("action-save"));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("shows loading state with ellipsis and disables button", () => {
+    render(<StageActionBar generate={{ loading: true }} />);
+    const btn = screen.getByTestId("action-generate");
+    expect(btn).toHaveTextContent("Generate…");
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("shows loading with custom label", () => {
+    render(<StageActionBar save={{ loading: true, label: "Saving" }} />);
+    expect(screen.getByTestId("action-save")).toHaveTextContent("Saving…");
+  });
+
+  it("renders status message", () => {
+    render(<StageActionBar statusMessage="Draft saved 2m ago" save={{}} />);
+    expect(screen.getByTestId("action-status")).toHaveTextContent("Draft saved 2m ago");
+  });
+
+  it("renders bar with only status message and no buttons", () => {
+    render(<StageActionBar statusMessage="Processing..." />);
+    expect(screen.getByTestId("stage-action-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("action-status")).toHaveTextContent("Processing...");
+    expect(screen.queryByTestId("action-save")).not.toBeInTheDocument();
+  });
+
+  it("renders all four buttons simultaneously", () => {
+    render(
+      <StageActionBar
+        save={{}}
+        approve={{}}
+        generate={{}}
+        restart={{}}
+      />,
+    );
+    expect(screen.getByTestId("action-save")).toBeInTheDocument();
+    expect(screen.getByTestId("action-approve")).toBeInTheDocument();
+    expect(screen.getByTestId("action-generate")).toBeInTheDocument();
+    expect(screen.getByTestId("action-restart")).toBeInTheDocument();
+  });
+
+  it("only renders visible buttons", () => {
+    render(
+      <StageActionBar
+        save={{}}
+        approve={{ visible: false }}
+        generate={{}}
+        restart={{ visible: false }}
+      />,
+    );
+    expect(screen.getByTestId("action-save")).toBeInTheDocument();
+    expect(screen.queryByTestId("action-approve")).not.toBeInTheDocument();
+    expect(screen.getByTestId("action-generate")).toBeInTheDocument();
+    expect(screen.queryByTestId("action-restart")).not.toBeInTheDocument();
+  });
+
+  it("has proper toolbar role and aria-label", () => {
+    render(<StageActionBar save={{}} />);
+    const toolbar = screen.getByRole("toolbar", { name: "Stage actions" });
+    expect(toolbar).toBeInTheDocument();
+  });
+
+  it("supports mixed enabled/disabled/loading states", () => {
+    render(
+      <StageActionBar
+        save={{ disabled: false }}
+        approve={{ disabled: true }}
+        generate={{ loading: true }}
+        restart={{}}
+      />,
+    );
+    expect(screen.getByTestId("action-save")).not.toBeDisabled();
+    expect(screen.getByTestId("action-approve")).toBeDisabled();
+    expect(screen.getByTestId("action-generate")).toBeDisabled();
+    expect(screen.getByTestId("action-restart")).not.toBeDisabled();
+  });
+});

--- a/apps/studio-web/src/__tests__/StructuredScriptEditor.test.tsx
+++ b/apps/studio-web/src/__tests__/StructuredScriptEditor.test.tsx
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import StructuredScriptEditor from "../components/creator/StructuredScriptEditor";
+import type { SectionData } from "../components/creator/StructuredScriptEditor";
+
+// --------------- helpers ---------------
+
+const API = "/api/creator";
+const RUN_ID = 42;
+
+function makeSections(n: number): SectionData[] {
+  return Array.from({ length: n }, (_, i) => ({
+    section_id: `sec-${i + 1}`,
+    type: "narration",
+    text: `Text for section ${i + 1}`,
+    display_text: null,
+    speaker: "host",
+    duration: 5,
+    visual_override: null,
+  }));
+}
+
+const LOADED_DATA = {
+  run_id: RUN_ID,
+  sections: makeSections(3),
+  version: 1,
+};
+
+function mockFetch(responses: Record<string, { status?: number; body: unknown }>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    const key = `${method} ${url}`;
+    for (const [pattern, resp] of Object.entries(responses)) {
+      if (key.includes(pattern) || url.includes(pattern)) {
+        return {
+          ok: (resp.status ?? 200) < 400,
+          status: resp.status ?? 200,
+          json: async () => resp.body,
+        };
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({ detail: "Not found" }) };
+  }) as unknown as typeof fetch;
+}
+
+// --------------- tests ---------------
+
+describe("StructuredScriptEditor", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("shows loading state initially", () => {
+    globalThis.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof fetch;
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+    expect(screen.getByTestId("structured-loading")).toHaveTextContent("Loading sections");
+  });
+
+  it("loads and renders section cards", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-sections")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("section-card-0")).toBeInTheDocument();
+    expect(screen.getByTestId("section-card-1")).toBeInTheDocument();
+    expect(screen.getByTestId("section-card-2")).toBeInTheDocument();
+    expect(screen.getByTestId("structured-version")).toHaveTextContent("v1");
+  });
+
+  it("shows empty state when no sections", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: {
+        body: { run_id: RUN_ID, sections: [], version: 1 },
+      },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-empty")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when load fails", async () => {
+    const onError = vi.fn();
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: {
+        status: 404,
+        body: { detail: "No script draft found for this run" },
+      },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-error")).toHaveTextContent("No script draft found");
+    });
+    expect(onError).toHaveBeenCalledWith("load", "No script draft found for this run");
+  });
+
+  it("shows dirty indicator when section text is edited", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-card-0")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("structured-dirty")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("section-0-text"), {
+      target: { value: "Modified text" },
+    });
+
+    expect(screen.getByTestId("structured-dirty")).toHaveTextContent("Unsaved changes");
+  });
+
+  it("enables save button only when dirty", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-save-btn")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("structured-save-btn")).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("section-0-text"), {
+      target: { value: "Changed" },
+    });
+
+    expect(screen.getByTestId("structured-save-btn")).not.toBeDisabled();
+  });
+
+  it("reorders sections up", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-card-1")).toBeInTheDocument();
+    });
+
+    // Section 1 (index 1) should be moveable up
+    fireEvent.click(screen.getByTestId("section-1-move-up"));
+
+    // After move, section-card-0 should now contain "Text for section 2"
+    const firstCardText = screen.getByTestId("section-0-text") as HTMLTextAreaElement;
+    expect(firstCardText.value).toBe("Text for section 2");
+  });
+
+  it("reorders sections down", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-card-0")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("section-0-move-down"));
+
+    const secondCardText = screen.getByTestId("section-1-text") as HTMLTextAreaElement;
+    expect(secondCardText.value).toBe("Text for section 1");
+  });
+
+  it("disables move-up for first section and move-down for last", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-card-0")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("section-0-move-up")).toBeDisabled();
+    expect(screen.getByTestId("section-2-move-down")).toBeDisabled();
+  });
+
+  it("saves sections and calls onSuccess", async () => {
+    const onSuccess = vi.fn();
+    const savedData = { run_id: RUN_ID, draft: { version: 2 } };
+    globalThis.fetch = mockFetch({
+      [`GET ${API}/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+      [`PUT ${API}/runs/${RUN_ID}/script/structured`]: { body: savedData },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} onSuccess={onSuccess} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-card-0")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("section-0-text"), {
+      target: { value: "Updated text" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("structured-save-btn"));
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(savedData);
+    });
+    expect(screen.getByTestId("structured-version")).toHaveTextContent("v2");
+    expect(screen.queryByTestId("structured-dirty")).not.toBeInTheDocument();
+  });
+
+  it("shows error when save fails", async () => {
+    const onError = vi.fn();
+    globalThis.fetch = mockFetch({
+      [`GET ${API}/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+      [`PUT ${API}/runs/${RUN_ID}/script/structured`]: { status: 400, body: { detail: "Invalid sections" } },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-card-0")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("section-0-text"), {
+      target: { value: "Changed" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("structured-save-btn"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("structured-error")).toHaveTextContent("Invalid sections");
+    });
+    expect(onError).toHaveBeenCalledWith("save", "Invalid sections");
+  });
+
+  it("hides buttons in readOnly mode", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} readOnly />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-card-0")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("structured-save-btn")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("section-0-move-up")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("section-0-move-down")).not.toBeInTheDocument();
+  });
+
+  it("renders section fields: type, speaker, text, display_text, duration", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-card-0")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("section-0-type")).toHaveValue("narration");
+    expect(screen.getByTestId("section-0-speaker")).toHaveValue("host");
+    expect(screen.getByTestId("section-0-text")).toHaveValue("Text for section 1");
+    expect(screen.getByTestId("section-0-duration")).toHaveValue(5);
+  });
+
+  it("editing type field marks dirty", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/script/structured`]: { body: LOADED_DATA },
+    });
+    render(<StructuredScriptEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-card-0")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("section-0-type"), {
+      target: { value: "dialog" },
+    });
+
+    expect(screen.getByTestId("structured-dirty")).toBeInTheDocument();
+  });
+});

--- a/apps/studio-web/src/__tests__/VisualAssetGrid.test.tsx
+++ b/apps/studio-web/src/__tests__/VisualAssetGrid.test.tsx
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import VisualAssetGrid from "../components/creator/VisualAssetGrid";
+import type { AssetData } from "../components/creator/VisualAssetGrid";
+
+// --------------- helpers ---------------
+
+const API = "/api/creator";
+const RUN_ID = 50;
+
+function makeAsset(
+  id: number,
+  sceneId: string,
+  version: number,
+  overrides: Partial<AssetData> = {},
+): AssetData {
+  return {
+    id,
+    run_id: RUN_ID,
+    scene_id: sceneId,
+    version,
+    asset_path: `data/artifacts/1/${RUN_ID}/${sceneId}_v${version}.png`,
+    prompt_snapshot: `Prompt for ${sceneId} v${version}`,
+    model_used: "sd15",
+    provider_type: "local-gpu",
+    is_active: version === 1,
+    created_at: "2026-01-15T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function mockFetch(responses: Record<string, { status?: number; body: unknown }>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    const key = `${method} ${url}`;
+    for (const [pattern, resp] of Object.entries(responses)) {
+      if (key.includes(pattern) || url.includes(pattern)) {
+        return {
+          ok: (resp.status ?? 200) < 400,
+          status: resp.status ?? 200,
+          json: async () => resp.body,
+        };
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({ detail: "Not found" }) };
+  }) as unknown as typeof fetch;
+}
+
+// --------------- tests ---------------
+
+describe("VisualAssetGrid", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("shows loading state initially", () => {
+    globalThis.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof fetch;
+    render(<VisualAssetGrid runId={RUN_ID} apiBase={API} />);
+    expect(screen.getByTestId("asset-grid-loading")).toHaveTextContent("Loading visual assets");
+  });
+
+  it("loads and renders scene groups", async () => {
+    const response = {
+      run_id: RUN_ID,
+      scenes: {
+        "scene-0": [
+          makeAsset(1, "scene-0", 2, { is_active: true }),
+          makeAsset(2, "scene-0", 1, { is_active: false }),
+        ],
+        "scene-1": [makeAsset(3, "scene-1", 1, { is_active: true })],
+      },
+      total_scenes: 2,
+      total_assets: 3,
+    };
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-assets`]: { body: response },
+    });
+    render(<VisualAssetGrid runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("asset-grid")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("scene-group-scene-0")).toBeInTheDocument();
+    expect(screen.getByTestId("scene-group-scene-1")).toBeInTheDocument();
+    expect(screen.getByTestId("asset-1")).toBeInTheDocument();
+    expect(screen.getByTestId("asset-2")).toBeInTheDocument();
+    expect(screen.getByTestId("asset-3")).toBeInTheDocument();
+    expect(screen.getByText("2 scenes · 3 assets")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no assets", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-assets`]: {
+        body: { run_id: RUN_ID, scenes: {}, total_scenes: 0, total_assets: 0 },
+      },
+    });
+    render(<VisualAssetGrid runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("asset-grid-empty")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No visual assets yet")).toBeInTheDocument();
+  });
+
+  it("shows error when load fails", async () => {
+    const onError = vi.fn();
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-assets`]: {
+        status: 404,
+        body: { detail: "Run not found" },
+      },
+    });
+    render(<VisualAssetGrid runId={RUN_ID} apiBase={API} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("asset-grid-error")).toHaveTextContent("Run not found");
+    });
+    expect(onError).toHaveBeenCalledWith("load", "Run not found");
+  });
+
+  it("marks active asset visually", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-assets`]: {
+        body: {
+          run_id: RUN_ID,
+          scenes: {
+            "scene-0": [
+              makeAsset(10, "scene-0", 2, { is_active: true }),
+              makeAsset(11, "scene-0", 1, { is_active: false }),
+            ],
+          },
+          total_scenes: 1,
+          total_assets: 2,
+        },
+      },
+    });
+    render(<VisualAssetGrid runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("asset-grid")).toBeInTheDocument();
+    });
+
+    // Active asset has badge
+    expect(screen.getByTestId("asset-10-active")).toHaveTextContent("Active");
+    // Inactive asset has select button, no badge
+    expect(screen.queryByTestId("asset-11-active")).not.toBeInTheDocument();
+    expect(screen.getByTestId("asset-11-select")).toHaveTextContent("Set Active");
+  });
+
+  it("displays asset metadata", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-assets`]: {
+        body: {
+          run_id: RUN_ID,
+          scenes: {
+            "scene-0": [makeAsset(20, "scene-0", 1, {
+              is_active: true,
+              prompt_snapshot: "A serene landscape",
+              model_used: "sd15",
+            })],
+          },
+          total_scenes: 1,
+          total_assets: 1,
+        },
+      },
+    });
+    render(<VisualAssetGrid runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("asset-grid")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("asset-20-prompt")).toHaveTextContent("A serene landscape");
+    expect(screen.getByTestId("asset-20-model")).toHaveTextContent("Model: sd15");
+    expect(screen.getByTestId("asset-20-time")).toBeInTheDocument();
+  });
+
+  it("readOnly mode hides select buttons", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-assets`]: {
+        body: {
+          run_id: RUN_ID,
+          scenes: {
+            "scene-0": [
+              makeAsset(30, "scene-0", 2, { is_active: true }),
+              makeAsset(31, "scene-0", 1, { is_active: false }),
+            ],
+          },
+          total_scenes: 1,
+          total_assets: 2,
+        },
+      },
+    });
+    render(<VisualAssetGrid runId={RUN_ID} apiBase={API} readOnly />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("asset-grid")).toBeInTheDocument();
+    });
+
+    // No select button for inactive asset in readOnly mode
+    expect(screen.queryByTestId("asset-31-select")).not.toBeInTheDocument();
+  });
+
+  it("select button triggers API call and refreshes", async () => {
+    const onSelect = vi.fn();
+    const initialData = {
+      run_id: RUN_ID,
+      scenes: {
+        "scene-0": [
+          makeAsset(40, "scene-0", 2, { is_active: true }),
+          makeAsset(41, "scene-0", 1, { is_active: false }),
+        ],
+      },
+      total_scenes: 1,
+      total_assets: 2,
+    };
+    const updatedData = {
+      ...initialData,
+      scenes: {
+        "scene-0": [
+          makeAsset(40, "scene-0", 2, { is_active: false }),
+          makeAsset(41, "scene-0", 1, { is_active: true }),
+        ],
+      },
+    };
+    const selectedAsset = makeAsset(41, "scene-0", 1, { is_active: true });
+
+    let callCount = 0;
+    globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (method === "POST" && (url as string).includes("/select/41")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => selectedAsset,
+        };
+      }
+      if ((url as string).includes("/visual-assets") && method === "GET") {
+        callCount++;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => (callCount <= 1 ? initialData : updatedData),
+        };
+      }
+      return { ok: false, status: 404, json: async () => ({ detail: "Not found" }) };
+    }) as unknown as typeof fetch;
+
+    render(<VisualAssetGrid runId={RUN_ID} apiBase={API} onSelect={onSelect} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("asset-grid")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("asset-41-select"));
+    });
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith(selectedAsset);
+    });
+
+    // Verify POST was called
+    const postCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([, init]: [string, RequestInit | undefined]) => init?.method === "POST",
+    );
+    expect(postCall).toBeDefined();
+    expect(postCall![0]).toContain("/select/41");
+  });
+
+  it("shows error when select fails", async () => {
+    const onError = vi.fn();
+    globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (method === "POST") {
+        return {
+          ok: false,
+          status: 400,
+          json: async () => ({ detail: "Asset does not belong to scene" }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          run_id: RUN_ID,
+          scenes: {
+            "scene-0": [
+              makeAsset(50, "scene-0", 2, { is_active: true }),
+              makeAsset(51, "scene-0", 1, { is_active: false }),
+            ],
+          },
+          total_scenes: 1,
+          total_assets: 2,
+        }),
+      };
+    }) as unknown as typeof fetch;
+
+    render(<VisualAssetGrid runId={RUN_ID} apiBase={API} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("asset-grid")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("asset-51-select"));
+    });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith("select", "Asset does not belong to scene");
+    });
+  });
+});

--- a/apps/studio-web/src/__tests__/VisualPlanEditor.test.tsx
+++ b/apps/studio-web/src/__tests__/VisualPlanEditor.test.tsx
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import VisualPlanEditor from "../components/creator/VisualPlanEditor";
+import type { SceneData } from "../components/creator/VisualPlanEditor";
+
+// --------------- helpers ---------------
+
+const API = "/api/creator";
+const RUN_ID = 42;
+
+function makeScenes(n: number): SceneData[] {
+  return Array.from({ length: n }, (_, i) => ({
+    scene_id: `scene-${i + 1}`,
+    section_id: `sec-${i + 1}`,
+    scene_index: i,
+    section_type: "narration",
+    original_text: `Original text for scene ${i + 1}`,
+    prompt: `A cinematic shot of scene ${i + 1}`,
+    prompt_edited: false,
+    prompt_source: "auto_generated" as const,
+    style_tags: ["cinematic", "dramatic"],
+    mood: "intense",
+    composition: "wide shot",
+    generation_status: "pending" as const,
+    latest_asset_id: null,
+  }));
+}
+
+const LOADED_DATA = {
+  run_id: RUN_ID,
+  scenes: makeScenes(3),
+  version: 1,
+};
+
+function mockFetch(responses: Record<string, { status?: number; body: unknown }>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    const key = `${method} ${url}`;
+    for (const [pattern, resp] of Object.entries(responses)) {
+      if (key.includes(pattern) || url.includes(pattern)) {
+        return {
+          ok: (resp.status ?? 200) < 400,
+          status: resp.status ?? 200,
+          json: async () => resp.body,
+        };
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({ detail: "Not found" }) };
+  }) as unknown as typeof fetch;
+}
+
+// --------------- tests ---------------
+
+describe("VisualPlanEditor", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("shows loading state initially", () => {
+    globalThis.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof fetch;
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} />);
+    expect(screen.getByTestId("visual-plan-loading")).toHaveTextContent("Loading visual plan");
+  });
+
+  it("loads and renders scene cards", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("visual-plan-scenes")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("scene-scene-1")).toBeInTheDocument();
+    expect(screen.getByTestId("scene-scene-2")).toBeInTheDocument();
+    expect(screen.getByTestId("scene-scene-3")).toBeInTheDocument();
+    expect(screen.getByTestId("visual-plan-version")).toHaveTextContent("v1");
+  });
+
+  it("shows empty state when no scenes", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: {
+        body: { run_id: RUN_ID, scenes: [], version: 1 },
+      },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("visual-plan-empty")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when load fails", async () => {
+    const onError = vi.fn();
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: {
+        status: 404,
+        body: { detail: "No active visual plan for run 42" },
+      },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("visual-plan-error")).toHaveTextContent(
+        "No active visual plan for run 42",
+      );
+    });
+    expect(onError).toHaveBeenCalledWith("load", "No active visual plan for run 42");
+  });
+
+  it("editing prompt marks scene dirty", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-scene-1")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("scene-scene-1-dirty")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("scene-scene-1-prompt"), {
+      target: { value: "A modified prompt" },
+    });
+
+    expect(screen.getByTestId("scene-scene-1-dirty")).toHaveTextContent("Unsaved changes");
+  });
+
+  it("save button disabled when scene is clean", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-scene-1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("scene-scene-1-save")).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("scene-scene-1-prompt"), {
+      target: { value: "Changed prompt" },
+    });
+
+    expect(screen.getByTestId("scene-scene-1-save")).not.toBeDisabled();
+  });
+
+  it("saves scene via PATCH with diff and calls onSuccess", async () => {
+    const onSuccess = vi.fn();
+    const updatedScenes = makeScenes(3);
+    updatedScenes[0] = {
+      ...updatedScenes[0],
+      prompt: "Updated prompt",
+      prompt_edited: true,
+      prompt_source: "user_edited",
+    };
+    const savedData = { run_id: RUN_ID, version: 2, scenes: updatedScenes };
+
+    globalThis.fetch = mockFetch({
+      [`GET ${API}/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+      [`PATCH ${API}/runs/${RUN_ID}/visual-plan/scenes/scene-1`]: { body: savedData },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} onSuccess={onSuccess} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-scene-1")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("scene-scene-1-prompt"), {
+      target: { value: "Updated prompt" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("scene-scene-1-save"));
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(savedData);
+    });
+
+    // Verify PATCH was called with expected payload
+    const patchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([url, init]: [string, RequestInit | undefined]) =>
+        url.includes("scenes/scene-1") && init?.method === "PATCH",
+    );
+    expect(patchCall).toBeDefined();
+    const body = JSON.parse(patchCall![1].body as string);
+    expect(body.prompt).toBe("Updated prompt");
+    expect(body.prompt_edited).toBe(true);
+    expect(body.prompt_source).toBe("user_edited");
+    expect(body.expected_version).toBe(1);
+
+    // Version updated and dirty cleared
+    expect(screen.getByTestId("visual-plan-version")).toHaveTextContent("v2");
+    expect(screen.queryByTestId("scene-scene-1-dirty")).not.toBeInTheDocument();
+  });
+
+  it("shows error when save fails", async () => {
+    const onError = vi.fn();
+    globalThis.fetch = mockFetch({
+      [`GET ${API}/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+      [`PATCH ${API}/runs/${RUN_ID}/visual-plan/scenes/scene-1`]: {
+        status: 409,
+        body: { detail: "Version conflict" },
+      },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-scene-1")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("scene-scene-1-prompt"), {
+      target: { value: "Changed" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("scene-scene-1-save"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("visual-plan-error")).toHaveTextContent("Version conflict");
+    });
+    expect(onError).toHaveBeenCalledWith("save", "Version conflict");
+  });
+
+  it("readOnly mode hides save buttons and disables editing", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} readOnly />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-scene-1")).toBeInTheDocument();
+    });
+
+    // Save button not rendered in readOnly
+    expect(screen.queryByTestId("scene-scene-1-save")).not.toBeInTheDocument();
+
+    // Prompt textarea is readOnly
+    const promptInput = screen.getByTestId("scene-scene-1-prompt") as HTMLTextAreaElement;
+    expect(promptInput.readOnly).toBe(true);
+
+    // Mood input is readOnly
+    const moodInput = screen.getByTestId("scene-scene-1-mood") as HTMLInputElement;
+    expect(moodInput.readOnly).toBe(true);
+  });
+
+  it("regenerate button is disabled (Phase 4)", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-scene-1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("scene-scene-1-regenerate")).toBeDisabled();
+  });
+
+  it("renders scene fields: original_text, status, mood, composition, style_tags", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-scene-1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("scene-scene-1-original-text")).toHaveTextContent(
+      "Original text for scene 1",
+    );
+    expect(screen.getByTestId("scene-scene-1-status")).toHaveTextContent("pending");
+
+    const promptInput = screen.getByTestId("scene-scene-1-prompt") as HTMLTextAreaElement;
+    expect(promptInput.value).toBe("A cinematic shot of scene 1");
+
+    const moodInput = screen.getByTestId("scene-scene-1-mood") as HTMLInputElement;
+    expect(moodInput.value).toBe("intense");
+
+    const compInput = screen.getByTestId("scene-scene-1-composition") as HTMLInputElement;
+    expect(compInput.value).toBe("wide shot");
+
+    const tagsInput = screen.getByTestId("scene-scene-1-style-tags") as HTMLInputElement;
+    expect(tagsInput.value).toBe("cinematic, dramatic");
+  });
+
+  it("editing mood marks scene dirty", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-scene-1")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("scene-scene-1-mood"), {
+      target: { value: "calm" },
+    });
+
+    expect(screen.getByTestId("scene-scene-1-dirty")).toBeInTheDocument();
+  });
+
+  it("displays scene count", async () => {
+    globalThis.fetch = mockFetch({
+      [`/runs/${RUN_ID}/visual-plan`]: { body: LOADED_DATA },
+    });
+    render(<VisualPlanEditor runId={RUN_ID} apiBase={API} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("visual-plan-scenes")).toBeInTheDocument();
+    });
+
+    // 3 scenes text
+    expect(screen.getByText("3 scenes")).toBeInTheDocument();
+  });
+});

--- a/apps/studio-web/src/components/creator/IdeaForm.tsx
+++ b/apps/studio-web/src/components/creator/IdeaForm.tsx
@@ -1,3 +1,118 @@
-export default function IdeaForm() {
-  return <div>IdeaForm</div>;
+import { useState, useCallback, type FormEvent } from "react";
+
+export interface IdeaFormData {
+  title: string;
+  ideaBrief: string;
+  targetDuration: number;
+  contentGoal: string;
+}
+
+interface IdeaFormProps {
+  onSubmit: (data: IdeaFormData) => void;
+  submitting?: boolean;
+  error?: string | null;
+}
+
+export default function IdeaForm({ onSubmit, submitting = false, error = null }: IdeaFormProps) {
+  const [title, setTitle] = useState("");
+  const [ideaBrief, setIdeaBrief] = useState("");
+  const [targetDuration, setTargetDuration] = useState(60);
+  const [contentGoal, setContentGoal] = useState("");
+
+  const canSubmit = title.trim() !== "" && ideaBrief.trim() !== "" && !submitting;
+
+  const handleSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      if (!canSubmit) return;
+      onSubmit({ title: title.trim(), ideaBrief: ideaBrief.trim(), targetDuration, contentGoal: contentGoal.trim() });
+    },
+    [canSubmit, onSubmit, title, ideaBrief, targetDuration, contentGoal],
+  );
+
+  return (
+    <form data-testid="idea-form" onSubmit={handleSubmit}>
+      {error && (
+        <div
+          data-testid="idea-form-error"
+          role="alert"
+          style={{
+            padding: "8px 12px",
+            marginBottom: 16,
+            background: "#fef2f2",
+            border: "1px solid #fca5a5",
+            borderRadius: 4,
+            color: "#b91c1c",
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ marginBottom: 16 }}>
+        <label htmlFor="idea-title" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+          Title <span style={{ color: "#c00" }}>*</span>
+        </label>
+        <input
+          id="idea-title"
+          type="text"
+          required
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          disabled={submitting}
+          placeholder="Project title"
+          style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
+        />
+      </div>
+
+      <div style={{ marginBottom: 16 }}>
+        <label htmlFor="idea-brief" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+          Idea Brief <span style={{ color: "#c00" }}>*</span>
+        </label>
+        <textarea
+          id="idea-brief"
+          required
+          value={ideaBrief}
+          onChange={(e) => setIdeaBrief(e.target.value)}
+          disabled={submitting}
+          placeholder="Describe your video idea..."
+          rows={4}
+          style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, resize: "vertical", boxSizing: "border-box" }}
+        />
+      </div>
+
+      <div style={{ display: "flex", gap: 16, marginBottom: 16 }}>
+        <div style={{ flex: 1 }}>
+          <label htmlFor="target-duration" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+            Target Duration (seconds)
+          </label>
+          <input
+            id="target-duration"
+            type="number"
+            min={10}
+            max={180}
+            value={targetDuration}
+            onChange={(e) => setTargetDuration(Number(e.target.value))}
+            disabled={submitting}
+            style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
+          />
+        </div>
+        <div style={{ flex: 1 }}>
+          <label htmlFor="content-goal" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+            Content Goal
+          </label>
+          <input
+            id="content-goal"
+            type="text"
+            value={contentGoal}
+            onChange={(e) => setContentGoal(e.target.value)}
+            disabled={submitting}
+            placeholder="e.g., educational, entertainment"
+            style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
+          />
+        </div>
+      </div>
+    </form>
+  );
 }

--- a/apps/studio-web/src/components/creator/MarkdownScriptEditor.tsx
+++ b/apps/studio-web/src/components/creator/MarkdownScriptEditor.tsx
@@ -1,3 +1,257 @@
-export default function MarkdownScriptEditor() {
-  return <div>MarkdownScriptEditor</div>;
+/**
+ * MarkdownScriptEditor — raw markdown editing with save and parse actions.
+ *
+ * Loads markdown content for a given run, lets the user edit it in a plain
+ * textarea, then save via PUT or parse via POST.  Does NOT own fetch logic
+ * for the *page*; it does own its own load/save/parse calls against the
+ * run-scoped script endpoints.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+// --------------- types ---------------
+
+export interface MarkdownScriptEditorProps {
+  /** Base URL for API calls (e.g. "/api/creator"). */
+  apiBase?: string;
+  /** Run ID whose script we're editing. */
+  runId: number;
+  /** Called when save or parse completes successfully. */
+  onSuccess?: (action: "save" | "parse", data: Record<string, unknown>) => void;
+  /** Called when an error occurs. */
+  onError?: (action: "load" | "save" | "parse", message: string) => void;
+  /** Whether the editor should be read-only. */
+  readOnly?: boolean;
+}
+
+// --------------- component ---------------
+
+export default function MarkdownScriptEditor({
+  apiBase = "/api/creator",
+  runId,
+  onSuccess,
+  onError,
+  readOnly = false,
+}: MarkdownScriptEditorProps) {
+  const [markdown, setMarkdown] = useState("");
+  const [savedMarkdown, setSavedMarkdown] = useState("");
+  const [version, setVersion] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [parsing, setParsing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isDirty = markdown !== savedMarkdown;
+
+  // Load markdown on mount / runId change
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`${apiBase}/runs/${runId}/script/markdown`);
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.detail ?? `Failed to load (${res.status})`);
+        }
+        const data = await res.json();
+        if (!cancelled) {
+          setMarkdown(data.markdown ?? "");
+          setSavedMarkdown(data.markdown ?? "");
+          setVersion(data.version ?? null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const msg = err instanceof Error ? err.message : "Failed to load script";
+          setError(msg);
+          onError?.("load", msg);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBase, runId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Save markdown
+  const handleSave = useCallback(async () => {
+    if (!isDirty || saving || !markdown.trim()) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiBase}/runs/${runId}/script/markdown`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ markdown }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? `Save failed (${res.status})`);
+      }
+      const data = await res.json();
+      const draft = (data.draft ?? {}) as Record<string, unknown>;
+      setSavedMarkdown(markdown);
+      setVersion((draft.version as number) ?? version);
+      onSuccess?.("save", data);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to save";
+      setError(msg);
+      onError?.("save", msg);
+    } finally {
+      setSaving(false);
+    }
+  }, [apiBase, runId, markdown, isDirty, saving, version, onSuccess, onError]);
+
+  // Parse markdown → structured sections
+  const handleParse = useCallback(async () => {
+    if (parsing) return;
+
+    setParsing(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiBase}/runs/${runId}/script/parse-markdown`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? `Parse failed (${res.status})`);
+      }
+      const data = await res.json();
+      setVersion(data.version ?? version);
+      onSuccess?.("parse", data);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to parse";
+      setError(msg);
+      onError?.("parse", msg);
+    } finally {
+      setParsing(false);
+    }
+  }, [apiBase, runId, parsing, version, onSuccess, onError]);
+
+  // --------------- render ---------------
+
+  if (loading) {
+    return (
+      <div data-testid="markdown-editor" aria-busy="true">
+        <p data-testid="markdown-loading">Loading script…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="markdown-editor">
+      {error && (
+        <div
+          data-testid="markdown-error"
+          role="alert"
+          style={{
+            padding: "8px 12px",
+            marginBottom: 12,
+            backgroundColor: "#f8d7da",
+            color: "#721c24",
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <label
+        htmlFor={`markdown-textarea-${runId}`}
+        style={{ display: "block", fontWeight: 600, fontSize: 13, marginBottom: 4 }}
+      >
+        Markdown Script
+      </label>
+      <textarea
+        id={`markdown-textarea-${runId}`}
+        data-testid="markdown-textarea"
+        value={markdown}
+        onChange={(e) => setMarkdown(e.target.value)}
+        readOnly={readOnly}
+        disabled={saving || parsing}
+        style={{
+          width: "100%",
+          minHeight: 300,
+          fontFamily: "monospace",
+          fontSize: 13,
+          padding: 8,
+          border: "1px solid #ced4da",
+          borderRadius: 4,
+          resize: "vertical",
+          boxSizing: "border-box",
+        }}
+      />
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginTop: 8,
+        }}
+      >
+        {version !== null && (
+          <span data-testid="markdown-version" style={{ fontSize: 11, color: "#6c757d" }}>
+            v{version}
+          </span>
+        )}
+        {isDirty && (
+          <span data-testid="markdown-dirty" style={{ fontSize: 11, color: "#856404" }}>
+            Unsaved changes
+          </span>
+        )}
+        <span style={{ marginLeft: "auto" }} />
+        {!readOnly && (
+          <>
+            <button
+              type="button"
+              data-testid="markdown-save-btn"
+              disabled={!isDirty || saving || !markdown.trim()}
+              onClick={handleSave}
+              aria-busy={saving}
+              style={{
+                padding: "6px 16px",
+                fontSize: 13,
+                borderRadius: 4,
+                border: "1px solid #6c757d",
+                backgroundColor: "#6c757d",
+                color: "#fff",
+                cursor: isDirty && !saving ? "pointer" : "not-allowed",
+                opacity: isDirty && !saving ? 1 : 0.5,
+              }}
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+            <button
+              type="button"
+              data-testid="markdown-parse-btn"
+              disabled={parsing || isDirty}
+              onClick={handleParse}
+              aria-busy={parsing}
+              style={{
+                padding: "6px 16px",
+                fontSize: 13,
+                borderRadius: 4,
+                border: "1px solid #007bff",
+                backgroundColor: "#007bff",
+                color: "#fff",
+                cursor: !parsing && !isDirty ? "pointer" : "not-allowed",
+                opacity: !parsing && !isDirty ? 1 : 0.5,
+              }}
+            >
+              {parsing ? "Parsing…" : "Parse to Sections"}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/apps/studio-web/src/components/creator/ModelSelector.tsx
+++ b/apps/studio-web/src/components/creator/ModelSelector.tsx
@@ -67,6 +67,10 @@ export default function ModelSelector({
   const onChangeRef = useRef(onSelectionChange);
   onChangeRef.current = onSelectionChange;
 
+  // Ref to stage newly-computed defaults for notification in a follow-up effect.
+  // Keeping notification out of the setLocalSelection updater keeps it pure.
+  const pendingDefaultsRef = useRef<Array<[string, string]>>([]);
+
   // Effect 1: Fetch model catalog when apiBase changes
   useEffect(() => {
     let cancelled = false;
@@ -106,6 +110,7 @@ export default function ModelSelector({
   // Effect 2: Derive default selections when data or visible categories change (uncontrolled mode only).
   // Only initializes selections for categories that don't already have a user-chosen value,
   // so manual selections survive parent re-renders and categories changes.
+  // The updater is kept pure — side-effect notification is staged via ref.
   useEffect(() => {
     if (!data || selectedModels) return;
 
@@ -115,9 +120,8 @@ export default function ModelSelector({
       const newDefaults: Array<[string, string]> = [];
 
       for (const cat of cats) {
-        // Skip categories that already have a selection
+        // Skip categories that already have a selection whose model still exists
         if (next[cat]) {
-          // Verify the selected model still exists in the catalog
           const meta = CATEGORY_MAP[cat];
           if (meta) {
             const models = data[meta.responseKey];
@@ -136,20 +140,29 @@ export default function ModelSelector({
         }
       }
 
-      // Notify parent only for newly defaulted categories
-      if (newDefaults.length > 0) {
-        const cb = onChangeRef.current;
-        if (cb) {
-          // Schedule notification after state update to avoid calling setState during render
-          queueMicrotask(() => {
-            for (const [c, k] of newDefaults) cb(c, k);
-          });
-        }
-      }
+      // If nothing changed, return prev to avoid unnecessary re-render
+      if (newDefaults.length === 0) return prev;
 
+      // Stage defaults for notification in Effect 3
+      pendingDefaultsRef.current = newDefaults;
       return next;
     });
   }, [data, categoriesKey, selectedModels]);
+
+  // Effect 3: Notify parent of newly-computed defaults after state has settled.
+  // Runs after localSelection changes; checks the staged ref to avoid duplicate calls.
+  useEffect(() => {
+    const pending = pendingDefaultsRef.current;
+    if (pending.length === 0) return;
+    pendingDefaultsRef.current = [];
+
+    const cb = onChangeRef.current;
+    if (cb) {
+      for (const [cat, key] of pending) {
+        cb(cat, key);
+      }
+    }
+  }, [localSelection]);
 
   const handleSelect = useCallback(
     (category: string, modelKey: string) => {

--- a/apps/studio-web/src/components/creator/ModelSelector.tsx
+++ b/apps/studio-web/src/components/creator/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 
 /** Shape of a single model entry returned by GET /api/creator/models. */
 interface ModelEntry {
@@ -61,7 +61,7 @@ export default function ModelSelector({
   const [loading, setLoading] = useState(true);
   const [localSelection, setLocalSelection] = useState<Record<string, string>>({});
 
-  const visibleCategories = useMemo(() => categories ?? ALL_CATEGORIES, [categories]);
+  const visibleCategories = categories ?? ALL_CATEGORIES;
 
   // Stable ref for onSelectionChange to avoid effect re-fires when callback identity changes
   const onChangeRef = useRef(onSelectionChange);
@@ -100,31 +100,56 @@ export default function ModelSelector({
     };
   }, [apiBase]);
 
+  // Stable string key for categories to avoid re-triggering effect on array identity changes.
+  const categoriesKey = visibleCategories.join(",");
+
   // Effect 2: Derive default selections when data or visible categories change (uncontrolled mode only).
-  // Also notifies parent of defaults so UI and parent state stay in sync.
+  // Only initializes selections for categories that don't already have a user-chosen value,
+  // so manual selections survive parent re-renders and categories changes.
   useEffect(() => {
     if (!data || selectedModels) return;
 
-    const defaults: Record<string, string> = {};
-    for (const cat of visibleCategories) {
-      const meta = CATEGORY_MAP[cat];
-      if (!meta) continue;
-      const models = data[meta.responseKey];
-      const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
-      if (firstAvailable) {
-        defaults[cat] = firstAvailable.key;
-      }
-    }
-    setLocalSelection(defaults);
+    const cats = categoriesKey.split(",");
+    setLocalSelection((prev) => {
+      const next = { ...prev };
+      const newDefaults: Array<[string, string]> = [];
 
-    // Notify parent of computed defaults
-    const cb = onChangeRef.current;
-    if (cb) {
-      for (const [cat, key] of Object.entries(defaults)) {
-        cb(cat, key);
+      for (const cat of cats) {
+        // Skip categories that already have a selection
+        if (next[cat]) {
+          // Verify the selected model still exists in the catalog
+          const meta = CATEGORY_MAP[cat];
+          if (meta) {
+            const models = data[meta.responseKey];
+            const stillExists = models.some((m) => m.key === next[cat]);
+            if (stillExists) continue;
+          }
+        }
+
+        const meta = CATEGORY_MAP[cat];
+        if (!meta) continue;
+        const models = data[meta.responseKey];
+        const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
+        if (firstAvailable) {
+          next[cat] = firstAvailable.key;
+          newDefaults.push([cat, firstAvailable.key]);
+        }
       }
-    }
-  }, [data, visibleCategories, selectedModels]);
+
+      // Notify parent only for newly defaulted categories
+      if (newDefaults.length > 0) {
+        const cb = onChangeRef.current;
+        if (cb) {
+          // Schedule notification after state update to avoid calling setState during render
+          queueMicrotask(() => {
+            for (const [c, k] of newDefaults) cb(c, k);
+          });
+        }
+      }
+
+      return next;
+    });
+  }, [data, categoriesKey, selectedModels]);
 
   const handleSelect = useCallback(
     (category: string, modelKey: string) => {

--- a/apps/studio-web/src/components/creator/ModelSelector.tsx
+++ b/apps/studio-web/src/components/creator/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 
 /** Shape of a single model entry returned by GET /api/creator/models. */
 interface ModelEntry {
@@ -34,9 +34,9 @@ const CATEGORY_MAP: Record<string, CategoryMeta> = {
 const ALL_CATEGORIES = Object.keys(CATEGORY_MAP);
 
 export interface ModelSelectorProps {
-  /** Explicit selection map: category → model key. Enables override mode. */
+  /** Explicit selection map: category → model key. Enables controlled mode. */
   selectedModels?: Record<string, string>;
-  /** Called when the user selects a model. */
+  /** Called when the user selects a model, or when defaults are computed on load. */
   onSelectionChange?: (category: string, modelKey: string) => void;
   /** Subset of categories to display. Defaults to all. */
   categories?: string[];
@@ -61,8 +61,13 @@ export default function ModelSelector({
   const [loading, setLoading] = useState(true);
   const [localSelection, setLocalSelection] = useState<Record<string, string>>({});
 
-  const visibleCategories = categories ?? ALL_CATEGORIES;
+  const visibleCategories = useMemo(() => categories ?? ALL_CATEGORIES, [categories]);
 
+  // Stable ref for onSelectionChange to avoid effect re-fires when callback identity changes
+  const onChangeRef = useRef(onSelectionChange);
+  onChangeRef.current = onSelectionChange;
+
+  // Effect 1: Fetch model catalog when apiBase changes
   useEffect(() => {
     let cancelled = false;
 
@@ -77,19 +82,6 @@ export default function ModelSelector({
         const json: ModelsResponse = await res.json();
         if (!cancelled) {
           setData(json);
-
-          // Default-selection mode: pick first available model per category
-          const defaults: Record<string, string> = {};
-          for (const cat of visibleCategories) {
-            const meta = CATEGORY_MAP[cat];
-            if (!meta) continue;
-            const models = json[meta.responseKey];
-            const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
-            if (firstAvailable) {
-              defaults[cat] = firstAvailable.key;
-            }
-          }
-          setLocalSelection(defaults);
         }
       } catch (err) {
         if (!cancelled) {
@@ -106,8 +98,33 @@ export default function ModelSelector({
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiBase]);
+
+  // Effect 2: Derive default selections when data or visible categories change (uncontrolled mode only).
+  // Also notifies parent of defaults so UI and parent state stay in sync.
+  useEffect(() => {
+    if (!data || selectedModels) return;
+
+    const defaults: Record<string, string> = {};
+    for (const cat of visibleCategories) {
+      const meta = CATEGORY_MAP[cat];
+      if (!meta) continue;
+      const models = data[meta.responseKey];
+      const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
+      if (firstAvailable) {
+        defaults[cat] = firstAvailable.key;
+      }
+    }
+    setLocalSelection(defaults);
+
+    // Notify parent of computed defaults
+    const cb = onChangeRef.current;
+    if (cb) {
+      for (const [cat, key] of Object.entries(defaults)) {
+        cb(cat, key);
+      }
+    }
+  }, [data, visibleCategories, selectedModels]);
 
   const handleSelect = useCallback(
     (category: string, modelKey: string) => {
@@ -139,6 +156,7 @@ export default function ModelSelector({
         const meta = CATEGORY_MAP[cat];
         if (!meta) return null;
         const models = data[meta.responseKey];
+        const groupName = `model-${cat}`;
 
         return (
           <fieldset key={cat} style={{ marginBottom: 16, border: "1px solid #ddd", borderRadius: 6, padding: 12 }}>
@@ -146,15 +164,14 @@ export default function ModelSelector({
             {models.length === 0 ? (
               <div style={{ color: "#888", fontSize: 13 }}>No models available</div>
             ) : (
-              <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              <div role="radiogroup" aria-label={meta.displayName}>
                 {models.map((model) => {
                   const isSelected = activeSelection[cat] === model.key;
+                  const inputId = `${groupName}-${model.key}`;
                   return (
-                    <li
+                    <label
                       key={model.key}
-                      role="option"
-                      aria-selected={isSelected}
-                      onClick={() => handleSelect(cat, model.key)}
+                      htmlFor={inputId}
                       style={{
                         display: "flex",
                         alignItems: "center",
@@ -167,6 +184,15 @@ export default function ModelSelector({
                         marginBottom: 4,
                       }}
                     >
+                      <input
+                        type="radio"
+                        id={inputId}
+                        name={groupName}
+                        value={model.key}
+                        checked={isSelected}
+                        onChange={() => handleSelect(cat, model.key)}
+                        style={{ margin: 0 }}
+                      />
                       <span style={{ flex: 1, fontSize: 13 }}>{model.label}</span>
                       <span style={STATUS_STYLES[model.status] ?? STATUS_STYLES.unknown}>
                         {model.status}
@@ -176,10 +202,10 @@ export default function ModelSelector({
                           local
                         </span>
                       )}
-                    </li>
+                    </label>
                   );
                 })}
-              </ul>
+              </div>
             )}
           </fieldset>
         );

--- a/apps/studio-web/src/components/creator/ModelSelector.tsx
+++ b/apps/studio-web/src/components/creator/ModelSelector.tsx
@@ -1,3 +1,189 @@
-export default function ModelSelector() {
-  return <div>ModelSelector</div>;
+import { useEffect, useState, useCallback } from "react";
+
+/** Shape of a single model entry returned by GET /api/creator/models. */
+interface ModelEntry {
+  key: string;
+  label: string;
+  provider_type: string;
+  is_local: boolean;
+  requires_gpu: boolean;
+  status: "available" | "unavailable" | "unknown";
+}
+
+/** Full response shape from the models endpoint. */
+interface ModelsResponse {
+  script_models: ModelEntry[];
+  image_models: ModelEntry[];
+  tts_models: ModelEntry[];
+  stt_models: ModelEntry[];
+}
+
+/** Category metadata for rendering. */
+interface CategoryMeta {
+  responseKey: keyof ModelsResponse;
+  displayName: string;
+}
+
+const CATEGORY_MAP: Record<string, CategoryMeta> = {
+  script: { responseKey: "script_models", displayName: "Script Model" },
+  image: { responseKey: "image_models", displayName: "Image Model" },
+  tts: { responseKey: "tts_models", displayName: "TTS Model" },
+  stt: { responseKey: "stt_models", displayName: "STT Model" },
+};
+
+const ALL_CATEGORIES = Object.keys(CATEGORY_MAP);
+
+export interface ModelSelectorProps {
+  /** Explicit selection map: category → model key. Enables override mode. */
+  selectedModels?: Record<string, string>;
+  /** Called when the user selects a model. */
+  onSelectionChange?: (category: string, modelKey: string) => void;
+  /** Subset of categories to display. Defaults to all. */
+  categories?: string[];
+  /** API base URL override (for testing). Defaults to "" (relative). */
+  apiBase?: string;
+}
+
+const STATUS_STYLES: Record<string, React.CSSProperties> = {
+  available: { background: "#d4edda", color: "#155724", borderRadius: 4, padding: "2px 6px", fontSize: 11 },
+  unavailable: { background: "#f8d7da", color: "#721c24", borderRadius: 4, padding: "2px 6px", fontSize: 11 },
+  unknown: { background: "#fff3cd", color: "#856404", borderRadius: 4, padding: "2px 6px", fontSize: 11 },
+};
+
+export default function ModelSelector({
+  selectedModels,
+  onSelectionChange,
+  categories,
+  apiBase = "",
+}: ModelSelectorProps) {
+  const [data, setData] = useState<ModelsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [localSelection, setLocalSelection] = useState<Record<string, string>>({});
+
+  const visibleCategories = categories ?? ALL_CATEGORIES;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchModels() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`${apiBase}/api/creator/models`);
+        if (!res.ok) {
+          throw new Error(`Failed to fetch models: ${res.status}`);
+        }
+        const json: ModelsResponse = await res.json();
+        if (!cancelled) {
+          setData(json);
+
+          // Default-selection mode: pick first available model per category
+          const defaults: Record<string, string> = {};
+          for (const cat of visibleCategories) {
+            const meta = CATEGORY_MAP[cat];
+            if (!meta) continue;
+            const models = json[meta.responseKey];
+            const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
+            if (firstAvailable) {
+              defaults[cat] = firstAvailable.key;
+            }
+          }
+          setLocalSelection(defaults);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Unknown error");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchModels();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiBase]);
+
+  const handleSelect = useCallback(
+    (category: string, modelKey: string) => {
+      if (!selectedModels) {
+        setLocalSelection((prev) => ({ ...prev, [category]: modelKey }));
+      }
+      onSelectionChange?.(category, modelKey);
+    },
+    [selectedModels, onSelectionChange],
+  );
+
+  const activeSelection = selectedModels ?? localSelection;
+
+  if (loading) {
+    return <div data-testid="model-selector-loading">Loading models…</div>;
+  }
+
+  if (error) {
+    return <div data-testid="model-selector-error" style={{ color: "#721c24" }}>Error: {error}</div>;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <div data-testid="model-selector">
+      {visibleCategories.map((cat) => {
+        const meta = CATEGORY_MAP[cat];
+        if (!meta) return null;
+        const models = data[meta.responseKey];
+
+        return (
+          <fieldset key={cat} style={{ marginBottom: 16, border: "1px solid #ddd", borderRadius: 6, padding: 12 }}>
+            <legend style={{ fontWeight: 600, fontSize: 14 }}>{meta.displayName}</legend>
+            {models.length === 0 ? (
+              <div style={{ color: "#888", fontSize: 13 }}>No models available</div>
+            ) : (
+              <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+                {models.map((model) => {
+                  const isSelected = activeSelection[cat] === model.key;
+                  return (
+                    <li
+                      key={model.key}
+                      role="option"
+                      aria-selected={isSelected}
+                      onClick={() => handleSelect(cat, model.key)}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        padding: "6px 8px",
+                        cursor: "pointer",
+                        borderRadius: 4,
+                        background: isSelected ? "#e8f0fe" : "transparent",
+                        border: isSelected ? "1px solid #4285f4" : "1px solid transparent",
+                        marginBottom: 4,
+                      }}
+                    >
+                      <span style={{ flex: 1, fontSize: 13 }}>{model.label}</span>
+                      <span style={STATUS_STYLES[model.status] ?? STATUS_STYLES.unknown}>
+                        {model.status}
+                      </span>
+                      {model.is_local && (
+                        <span style={{ fontSize: 10, color: "#666", background: "#eee", borderRadius: 3, padding: "1px 4px" }}>
+                          local
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </fieldset>
+        );
+      })}
+    </div>
+  );
 }

--- a/apps/studio-web/src/components/creator/PipelineStepper.tsx
+++ b/apps/studio-web/src/components/creator/PipelineStepper.tsx
@@ -1,3 +1,168 @@
-export default function PipelineStepper() {
-  return <div>PipelineStepper</div>;
+/**
+ * PipelineStepper — compact visual indicator of pipeline progress.
+ *
+ * Groups backend RunStage values into 6 user-facing steps and renders them
+ * as a horizontal stepper with distinct completed / current / pending / failed
+ * states.  Accepts run status as props; does NOT own any fetch logic.
+ */
+
+/** User-facing pipeline steps in display order. */
+export const PIPELINE_STEPS = [
+  { key: "idea", label: "Idea" },
+  { key: "script", label: "Script" },
+  { key: "visual_plan", label: "Visual Plan" },
+  { key: "assets", label: "Assets" },
+  { key: "audio_subtitles", label: "Audio / Subs" },
+  { key: "render", label: "Render" },
+] as const;
+
+export type StepKey = (typeof PIPELINE_STEPS)[number]["key"];
+
+/**
+ * Maps every backend RunStage string to the step key it belongs to.
+ * Centralised here so the rest of the UI never deals with raw stage enums.
+ */
+export const STAGE_TO_STEP: Record<string, StepKey> = {
+  IDEA_READY: "idea",
+  SCRIPT_GENERATING: "script",
+  SCRIPT_REVIEW: "script",
+  VISUAL_PLAN_GENERATING: "visual_plan",
+  VISUAL_PLAN_REVIEW: "visual_plan",
+  VISUAL_ASSET_GENERATING: "assets",
+  VISUAL_ASSET_REVIEW: "assets",
+  AUDIO_GENERATING: "audio_subtitles",
+  SUBTITLE_GENERATING: "audio_subtitles",
+  RENDER_GENERATING: "render",
+  FINAL_REVIEW: "render",
+  PUBLISHED: "render",
+};
+
+// --------------- props ---------------
+
+export interface PipelineStepperProps {
+  /** Current backend stage string (e.g. "SCRIPT_REVIEW"). */
+  currentStage: string;
+  /** True when the run is in FAILED state. */
+  failed?: boolean;
+}
+
+// --------------- styles ---------------
+
+type StepStatus = "completed" | "current" | "pending" | "failed";
+
+const COLORS: Record<StepStatus, { bg: string; border: string; text: string; label: string }> = {
+  completed: { bg: "#d4edda", border: "#28a745", text: "#28a745", label: "#155724" },
+  current: { bg: "#cce5ff", border: "#007bff", text: "#007bff", label: "#004085" },
+  pending: { bg: "#f8f9fa", border: "#dee2e6", text: "#adb5bd", label: "#6c757d" },
+  failed: { bg: "#f8d7da", border: "#dc3545", text: "#dc3545", label: "#721c24" },
+};
+
+const CONNECTOR_COMPLETED = "#28a745";
+const CONNECTOR_DEFAULT = "#dee2e6";
+
+// --------------- helpers ---------------
+
+function resolveStepIndex(stage: string): number {
+  const key = STAGE_TO_STEP[stage];
+  if (!key) return -1;
+  return PIPELINE_STEPS.findIndex((s) => s.key === key);
+}
+
+function getStepStatus(stepIdx: number, activeIdx: number, isFailed: boolean): StepStatus {
+  if (isFailed && stepIdx === activeIdx) return "failed";
+  if (stepIdx < activeIdx) return "completed";
+  if (stepIdx === activeIdx) return "current";
+  return "pending";
+}
+
+// --------------- component ---------------
+
+export default function PipelineStepper({ currentStage, failed = false }: PipelineStepperProps) {
+  const activeIdx = resolveStepIndex(currentStage);
+
+  // For PUBLISHED, bump activeIdx past all steps so all show completed.
+  const effectiveIdx = currentStage === "PUBLISHED" ? PIPELINE_STEPS.length : activeIdx;
+
+  return (
+    <nav aria-label="Pipeline progress" data-testid="pipeline-stepper">
+      <ol
+        style={{
+          display: "flex",
+          alignItems: "center",
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+          gap: 0,
+        }}
+      >
+        {PIPELINE_STEPS.map((step, idx) => {
+          const status = getStepStatus(idx, effectiveIdx, failed);
+          const colors = COLORS[status];
+          const isLast = idx === PIPELINE_STEPS.length - 1;
+
+          return (
+            <li
+              key={step.key}
+              style={{ display: "flex", alignItems: "center" }}
+              data-testid={`step-${step.key}`}
+              data-status={status}
+            >
+              {/* Circle + label */}
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  minWidth: 64,
+                }}
+              >
+                <div
+                  aria-current={status === "current" ? "step" : undefined}
+                  style={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: "50%",
+                    border: `2px solid ${colors.border}`,
+                    backgroundColor: colors.bg,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: 12,
+                    fontWeight: status === "current" ? 700 : 500,
+                    color: colors.text,
+                  }}
+                >
+                  {status === "completed" ? "✓" : status === "failed" ? "✕" : idx + 1}
+                </div>
+                <span
+                  style={{
+                    marginTop: 4,
+                    fontSize: 11,
+                    color: colors.label,
+                    fontWeight: status === "current" ? 600 : 400,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {step.label}
+                </span>
+              </div>
+
+              {/* Connector line */}
+              {!isLast && (
+                <div
+                  style={{
+                    width: 32,
+                    height: 2,
+                    backgroundColor: idx < effectiveIdx ? CONNECTOR_COMPLETED : CONNECTOR_DEFAULT,
+                    flexShrink: 0,
+                  }}
+                  aria-hidden="true"
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
 }

--- a/apps/studio-web/src/components/creator/ProgressDialog.tsx
+++ b/apps/studio-web/src/components/creator/ProgressDialog.tsx
@@ -1,3 +1,314 @@
-export default function ProgressDialog() {
-  return <div>ProgressDialog</div>;
+/**
+ * ProgressDialog — modal overlay that polls a pipeline run and shows
+ * real-time stage / status while a long-running generation step proceeds.
+ *
+ * Props:
+ * - open:          Whether the dialog is visible.
+ * - runId:         Pipeline run to poll.
+ * - expectedStage: The *_GENERATING stage we expect to see.
+ *                  The dialog resolves (calls onComplete) once the stage
+ *                  transitions past this value.
+ * - apiBase:       API base URL (default "/api/creator").
+ * - pollInterval:  Milliseconds between polls (default 3000).
+ * - onComplete:    Called when the run moves past expectedStage (success path).
+ * - onFailed:      Called when the run status becomes "failed".
+ * - onClose:       Called when the user manually dismisses the dialog.
+ */
+
+import { useState, useEffect, useRef, useCallback } from "react";
+
+const DEFAULT_API = "/api/creator";
+const DEFAULT_POLL_MS = 3000;
+
+// --------------- types ---------------
+
+export interface ProgressDialogProps {
+  open: boolean;
+  runId: number;
+  expectedStage: string;
+  apiBase?: string;
+  pollInterval?: number;
+  onComplete?: (stage: string, status: string) => void;
+  onFailed?: (stage: string, status: string) => void;
+  onClose?: () => void;
+}
+
+interface RunSnapshot {
+  current_stage: string;
+  status: string;
+}
+
+type Outcome = "running" | "completed" | "failed" | "error";
+
+// Friendly labels for stages
+const STAGE_LABELS: Record<string, string> = {
+  SCRIPT_GENERATING: "Generating script…",
+  VISUAL_PLAN_GENERATING: "Generating visual plan…",
+  VISUAL_ASSET_GENERATING: "Generating visual assets…",
+  AUDIO_GENERATING: "Generating audio…",
+  SUBTITLE_GENERATING: "Generating subtitles…",
+  RENDER_GENERATING: "Rendering video…",
+};
+
+// --------------- component ---------------
+
+export default function ProgressDialog({
+  open,
+  runId,
+  expectedStage,
+  apiBase = DEFAULT_API,
+  pollInterval = DEFAULT_POLL_MS,
+  onComplete,
+  onFailed,
+  onClose,
+}: ProgressDialogProps) {
+  const [snapshot, setSnapshot] = useState<RunSnapshot | null>(null);
+  const [outcome, setOutcome] = useState<Outcome>("running");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [pollCount, setPollCount] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // ---- classify run state ----
+
+  const classify = useCallback(
+    (run: RunSnapshot): Outcome => {
+      if (run.status === "failed") return "failed";
+      // If stage moved past expectedStage, generation completed
+      if (run.current_stage !== expectedStage) return "completed";
+      return "running";
+    },
+    [expectedStage],
+  );
+
+  // ---- poll loop ----
+
+  useEffect(() => {
+    if (!open) {
+      // Reset when closed
+      setSnapshot(null);
+      setOutcome("running");
+      setErrorMsg(null);
+      setPollCount(0);
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`${apiBase}/runs/${runId}`);
+        if (cancelled) return;
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          setErrorMsg(body?.detail ?? `Poll failed (${res.status})`);
+          setOutcome("error");
+          return;
+        }
+        const data: RunSnapshot = await res.json();
+        if (cancelled) return;
+        setSnapshot(data);
+        setPollCount((c) => c + 1);
+        setErrorMsg(null);
+
+        const result = classify(data);
+        if (result === "completed") {
+          setOutcome("completed");
+          if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+          }
+          onComplete?.(data.current_stage, data.status);
+        } else if (result === "failed") {
+          setOutcome("failed");
+          if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+          }
+          onFailed?.(data.current_stage, data.status);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setErrorMsg(err instanceof Error ? err.message : "Network error");
+        setOutcome("error");
+      }
+    };
+
+    // Initial poll immediately
+    poll();
+    timerRef.current = setInterval(poll, pollInterval);
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [open, runId, apiBase, pollInterval, classify, onComplete, onFailed]);
+
+  // ---- don't render when closed ----
+
+  if (!open) return null;
+
+  // ---- derived display values ----
+
+  const stageLabel =
+    snapshot?.current_stage
+      ? STAGE_LABELS[snapshot.current_stage] ?? snapshot.current_stage
+      : STAGE_LABELS[expectedStage] ?? expectedStage;
+
+  const statusText = snapshot?.status ?? "starting";
+
+  const isTerminal = outcome === "completed" || outcome === "failed" || outcome === "error";
+
+  // ---- render ----
+
+  return (
+    <div
+      data-testid="progress-dialog-overlay"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.4)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+      }}
+    >
+      <div
+        data-testid="progress-dialog"
+        role="dialog"
+        aria-label="Generation progress"
+        style={{
+          background: "#fff",
+          borderRadius: 12,
+          padding: "32px 40px",
+          minWidth: 360,
+          maxWidth: 480,
+          boxShadow: "0 8px 30px rgba(0,0,0,0.2)",
+          textAlign: "center",
+        }}
+      >
+        {/* Stage label */}
+        <h3
+          data-testid="progress-stage"
+          style={{ margin: "0 0 8px", fontSize: 18, fontWeight: 600, color: "#111827" }}
+        >
+          {stageLabel}
+        </h3>
+
+        {/* Status line */}
+        <p
+          data-testid="progress-status"
+          style={{ margin: "0 0 16px", fontSize: 13, color: "#6b7280" }}
+        >
+          Status: {statusText}
+        </p>
+
+        {/* Animated indicator (running only) */}
+        {outcome === "running" && (
+          <div
+            data-testid="progress-spinner"
+            style={{
+              width: 40,
+              height: 40,
+              margin: "0 auto 16px",
+              border: "3px solid #e5e7eb",
+              borderTop: "3px solid #4285f4",
+              borderRadius: "50%",
+              animation: "spin 1s linear infinite",
+            }}
+          />
+        )}
+
+        {/* Success state */}
+        {outcome === "completed" && (
+          <div
+            data-testid="progress-completed"
+            style={{
+              margin: "0 0 16px",
+              padding: "8px 16px",
+              background: "#f0fdf4",
+              border: "1px solid #bbf7d0",
+              borderRadius: 6,
+              color: "#166534",
+              fontSize: 13,
+            }}
+          >
+            Generation complete — moved to {snapshot?.current_stage}
+          </div>
+        )}
+
+        {/* Failed state */}
+        {outcome === "failed" && (
+          <div
+            data-testid="progress-failed"
+            style={{
+              margin: "0 0 16px",
+              padding: "8px 16px",
+              background: "#fef2f2",
+              border: "1px solid #fca5a5",
+              borderRadius: 6,
+              color: "#b91c1c",
+              fontSize: 13,
+            }}
+          >
+            Generation failed
+          </div>
+        )}
+
+        {/* Network error state */}
+        {outcome === "error" && errorMsg && (
+          <div
+            data-testid="progress-error"
+            style={{
+              margin: "0 0 16px",
+              padding: "8px 16px",
+              background: "#fffbeb",
+              border: "1px solid #fde68a",
+              borderRadius: 6,
+              color: "#92400e",
+              fontSize: 13,
+            }}
+          >
+            {errorMsg}
+          </div>
+        )}
+
+        {/* Poll count (subtle, for debugging) */}
+        <p
+          data-testid="progress-poll-count"
+          style={{ margin: "0 0 16px", fontSize: 11, color: "#9ca3af" }}
+        >
+          {pollCount} poll{pollCount !== 1 ? "s" : ""}
+        </p>
+
+        {/* Close / Dismiss button */}
+        <button
+          data-testid="progress-close"
+          onClick={onClose}
+          style={{
+            padding: "8px 24px",
+            border: "1px solid #d1d5db",
+            borderRadius: 6,
+            background: isTerminal ? "#4285f4" : "#fff",
+            color: isTerminal ? "#fff" : "#374151",
+            cursor: "pointer",
+            fontSize: 13,
+            fontWeight: 500,
+          }}
+        >
+          {isTerminal ? "Close" : "Dismiss"}
+        </button>
+      </div>
+
+      {/* Keyframe for spinner */}
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
 }

--- a/apps/studio-web/src/components/creator/StageActionBar.tsx
+++ b/apps/studio-web/src/components/creator/StageActionBar.tsx
@@ -1,3 +1,147 @@
-export default function StageActionBar() {
-  return <div>StageActionBar</div>;
+/**
+ * StageActionBar — a presentational action bar shared across pipeline stages.
+ *
+ * Provides slots for save, approve, generate-next-stage, and restart actions.
+ * Pages own the endpoint calls; this component only renders buttons and
+ * forwards callbacks.  Actions can be individually shown, disabled, and
+ * labelled from the parent.
+ */
+
+// --------------- types ---------------
+
+export interface ActionConfig {
+  /** Whether the action button is rendered. */
+  visible?: boolean;
+  /** Whether the action button is disabled (greyed out). */
+  disabled?: boolean;
+  /** Optional custom label override. */
+  label?: string;
+  /** Click handler forwarded to the button. */
+  onClick?: () => void;
+  /** Whether the action is currently loading / in-progress. */
+  loading?: boolean;
+}
+
+export interface StageActionBarProps {
+  /** Save / persist draft action. */
+  save?: ActionConfig;
+  /** Approve current stage and advance. */
+  approve?: ActionConfig;
+  /** Trigger generation for the next stage. */
+  generate?: ActionConfig;
+  /** Restart / regenerate current stage. */
+  restart?: ActionConfig;
+  /** Optional status message displayed at the leading edge. */
+  statusMessage?: string;
+}
+
+// --------------- defaults ---------------
+
+const DEFAULT_LABELS: Record<string, string> = {
+  save: "Save",
+  approve: "Approve",
+  generate: "Generate",
+  restart: "Restart",
+};
+
+// --------------- styles ---------------
+
+const BAR_STYLE: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "10px 16px",
+  borderTop: "1px solid #dee2e6",
+  backgroundColor: "#f8f9fa",
+};
+
+const BTN_BASE: React.CSSProperties = {
+  padding: "6px 16px",
+  borderRadius: 4,
+  border: "1px solid transparent",
+  fontSize: 13,
+  fontWeight: 500,
+  cursor: "pointer",
+  lineHeight: "20px",
+  transition: "opacity 0.15s",
+};
+
+const BTN_VARIANTS: Record<string, React.CSSProperties> = {
+  save: { backgroundColor: "#6c757d", color: "#fff", borderColor: "#6c757d" },
+  approve: { backgroundColor: "#28a745", color: "#fff", borderColor: "#28a745" },
+  generate: { backgroundColor: "#007bff", color: "#fff", borderColor: "#007bff" },
+  restart: { backgroundColor: "#ffc107", color: "#212529", borderColor: "#ffc107" },
+};
+
+const DISABLED_STYLE: React.CSSProperties = {
+  opacity: 0.5,
+  cursor: "not-allowed",
+};
+
+const STATUS_STYLE: React.CSSProperties = {
+  fontSize: 12,
+  color: "#6c757d",
+  marginRight: "auto",
+};
+
+// --------------- helpers ---------------
+
+function renderButton(key: string, config: ActionConfig | undefined) {
+  if (!config || config.visible === false) return null;
+
+  const label = config.loading
+    ? `${config.label ?? DEFAULT_LABELS[key]}…`
+    : (config.label ?? DEFAULT_LABELS[key]);
+
+  const isDisabled = config.disabled || config.loading;
+
+  return (
+    <button
+      key={key}
+      type="button"
+      data-testid={`action-${key}`}
+      disabled={isDisabled}
+      onClick={config.onClick}
+      style={{
+        ...BTN_BASE,
+        ...BTN_VARIANTS[key],
+        ...(isDisabled ? DISABLED_STYLE : {}),
+      }}
+      aria-busy={config.loading ?? false}
+    >
+      {label}
+    </button>
+  );
+}
+
+// --------------- component ---------------
+
+export default function StageActionBar({
+  save,
+  approve,
+  generate,
+  restart,
+  statusMessage,
+}: StageActionBarProps) {
+  const buttons = [
+    renderButton("save", save),
+    renderButton("approve", approve),
+    renderButton("generate", generate),
+    renderButton("restart", restart),
+  ].filter(Boolean);
+
+  // Don't render the bar at all if no actions are visible
+  if (buttons.length === 0 && !statusMessage) return null;
+
+  return (
+    <div data-testid="stage-action-bar" role="toolbar" aria-label="Stage actions" style={BAR_STYLE}>
+      {statusMessage && (
+        <span data-testid="action-status" style={STATUS_STYLE}>
+          {statusMessage}
+        </span>
+      )}
+      {!statusMessage && <span style={{ marginRight: "auto" }} />}
+      {buttons}
+    </div>
+  );
 }

--- a/apps/studio-web/src/components/creator/StructuredScriptEditor.tsx
+++ b/apps/studio-web/src/components/creator/StructuredScriptEditor.tsx
@@ -1,3 +1,442 @@
-export default function StructuredScriptEditor() {
-  return <div>StructuredScriptEditor</div>;
+/**
+ * StructuredScriptEditor — section-card editor for structured scripts.
+ *
+ * Loads structured sections from GET /runs/{runId}/script/structured,
+ * renders editable cards, supports reorder via up/down, and saves via
+ * PUT /runs/{runId}/script/structured.  Section IDs are opaque — the
+ * backend owns ID preservation.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+// --------------- types ---------------
+
+export interface VisualOverrideData {
+  type: "prompt" | "image_url" | "none";
+  value?: string | null;
+}
+
+export interface SectionData {
+  section_id: string;
+  type: string;
+  text: string;
+  display_text?: string | null;
+  speaker?: string | null;
+  duration?: number | null;
+  turn_kind?: string | null;
+  visual_override?: VisualOverrideData | null;
+}
+
+export interface StructuredScriptEditorProps {
+  apiBase?: string;
+  runId: number;
+  onSuccess?: (data: Record<string, unknown>) => void;
+  onError?: (action: "load" | "save", message: string) => void;
+  readOnly?: boolean;
+}
+
+// --------------- helpers ---------------
+
+function deepEqual(a: SectionData[], b: SectionData[]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function swap<T>(arr: T[], i: number, j: number): T[] {
+  const copy = [...arr];
+  [copy[i], copy[j]] = [copy[j], copy[i]];
+  return copy;
+}
+
+// --------------- styles ---------------
+
+const CARD_STYLE: React.CSSProperties = {
+  border: "1px solid #dee2e6",
+  borderRadius: 6,
+  padding: 12,
+  marginBottom: 8,
+  backgroundColor: "#fff",
+};
+
+const FIELD_LABEL: React.CSSProperties = {
+  display: "block",
+  fontSize: 11,
+  fontWeight: 600,
+  color: "#495057",
+  marginBottom: 2,
+};
+
+const INPUT_STYLE: React.CSSProperties = {
+  width: "100%",
+  padding: "4px 8px",
+  fontSize: 13,
+  border: "1px solid #ced4da",
+  borderRadius: 4,
+  boxSizing: "border-box",
+};
+
+const TEXTAREA_STYLE: React.CSSProperties = {
+  ...INPUT_STYLE,
+  minHeight: 60,
+  resize: "vertical",
+  fontFamily: "inherit",
+};
+
+const SMALL_BTN: React.CSSProperties = {
+  padding: "2px 8px",
+  fontSize: 12,
+  border: "1px solid #ced4da",
+  borderRadius: 3,
+  backgroundColor: "#f8f9fa",
+  cursor: "pointer",
+};
+
+// --------------- section card ---------------
+
+interface SectionCardProps {
+  section: SectionData;
+  index: number;
+  total: number;
+  readOnly: boolean;
+  disabled: boolean;
+  onChange: (index: number, field: keyof SectionData, value: string | number | null) => void;
+  onMoveUp: (index: number) => void;
+  onMoveDown: (index: number) => void;
+}
+
+function SectionCard({
+  section,
+  index,
+  total,
+  readOnly,
+  disabled,
+  onChange,
+  onMoveUp,
+  onMoveDown,
+}: SectionCardProps) {
+  const fieldDisabled = readOnly || disabled;
+  const prefix = `section-${index}`;
+
+  return (
+    <div data-testid={`section-card-${index}`} style={CARD_STYLE}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+        <span style={{ fontSize: 12, fontWeight: 700, color: "#6c757d" }}>
+          #{index + 1}
+        </span>
+        <span style={{ fontSize: 11, color: "#adb5bd" }}>{section.section_id}</span>
+        <span style={{ marginLeft: "auto" }} />
+        {!readOnly && (
+          <>
+            <button
+              type="button"
+              data-testid={`${prefix}-move-up`}
+              disabled={index === 0 || disabled}
+              onClick={() => onMoveUp(index)}
+              style={SMALL_BTN}
+              aria-label={`Move section ${index + 1} up`}
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              data-testid={`${prefix}-move-down`}
+              disabled={index === total - 1 || disabled}
+              onClick={() => onMoveDown(index)}
+              style={SMALL_BTN}
+              aria-label={`Move section ${index + 1} down`}
+            >
+              ↓
+            </button>
+          </>
+        )}
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 8 }}>
+        <div>
+          <label style={FIELD_LABEL} htmlFor={`${prefix}-type`}>Type</label>
+          <input
+            id={`${prefix}-type`}
+            data-testid={`${prefix}-type`}
+            style={INPUT_STYLE}
+            value={section.type}
+            readOnly={fieldDisabled}
+            onChange={(e) => onChange(index, "type", e.target.value)}
+          />
+        </div>
+        <div>
+          <label style={FIELD_LABEL} htmlFor={`${prefix}-speaker`}>Speaker</label>
+          <input
+            id={`${prefix}-speaker`}
+            data-testid={`${prefix}-speaker`}
+            style={INPUT_STYLE}
+            value={section.speaker ?? ""}
+            readOnly={fieldDisabled}
+            onChange={(e) => onChange(index, "speaker", e.target.value || null)}
+          />
+        </div>
+      </div>
+
+      <div style={{ marginBottom: 8 }}>
+        <label style={FIELD_LABEL} htmlFor={`${prefix}-text`}>Text</label>
+        <textarea
+          id={`${prefix}-text`}
+          data-testid={`${prefix}-text`}
+          style={TEXTAREA_STYLE}
+          value={section.text}
+          readOnly={fieldDisabled}
+          onChange={(e) => onChange(index, "text", e.target.value)}
+        />
+      </div>
+
+      <div style={{ marginBottom: 8 }}>
+        <label style={FIELD_LABEL} htmlFor={`${prefix}-display-text`}>Display Text</label>
+        <input
+          id={`${prefix}-display-text`}
+          data-testid={`${prefix}-display-text`}
+          style={INPUT_STYLE}
+          value={section.display_text ?? ""}
+          readOnly={fieldDisabled}
+          onChange={(e) => onChange(index, "display_text", e.target.value || null)}
+        />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+        <div>
+          <label style={FIELD_LABEL} htmlFor={`${prefix}-duration`}>Duration (s)</label>
+          <input
+            id={`${prefix}-duration`}
+            data-testid={`${prefix}-duration`}
+            type="number"
+            step="0.1"
+            min="0"
+            style={INPUT_STYLE}
+            value={section.duration ?? ""}
+            readOnly={fieldDisabled}
+            onChange={(e) =>
+              onChange(index, "duration", e.target.value ? parseFloat(e.target.value) : null)
+            }
+          />
+        </div>
+        <div>
+          <label style={FIELD_LABEL} htmlFor={`${prefix}-visual-override`}>Visual Override</label>
+          <input
+            id={`${prefix}-visual-override`}
+            data-testid={`${prefix}-visual-override`}
+            style={INPUT_STYLE}
+            placeholder="prompt text or image URL"
+            value={section.visual_override?.value ?? ""}
+            readOnly={fieldDisabled}
+            onChange={(e) => {
+              // Simplified: treat any non-empty value as a "prompt" visual override
+              onChange(index, "visual_override" as keyof SectionData, e.target.value || null);
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --------------- main component ---------------
+
+export default function StructuredScriptEditor({
+  apiBase = "/api/creator",
+  runId,
+  onSuccess,
+  onError,
+  readOnly = false,
+}: StructuredScriptEditorProps) {
+  const [sections, setSections] = useState<SectionData[]>([]);
+  const [savedSections, setSavedSections] = useState<SectionData[]>([]);
+  const [version, setVersion] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isDirty = !deepEqual(sections, savedSections);
+
+  // Load sections
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`${apiBase}/runs/${runId}/script/structured`);
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.detail ?? `Failed to load (${res.status})`);
+        }
+        const data = await res.json();
+        const loaded = (data.sections ?? []) as SectionData[];
+        if (!cancelled) {
+          setSections(loaded);
+          setSavedSections(loaded);
+          setVersion(data.version ?? null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const msg = err instanceof Error ? err.message : "Failed to load sections";
+          setError(msg);
+          onError?.("load", msg);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [apiBase, runId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Field change
+  const handleChange = useCallback(
+    (index: number, field: keyof SectionData, value: string | number | null) => {
+      setSections((prev) => {
+        const next = [...prev];
+        const section = { ...next[index] };
+
+        if (field === "visual_override") {
+          section.visual_override = value
+            ? { type: "prompt", value: value as string }
+            : null;
+        } else {
+          (section as Record<string, unknown>)[field] = value;
+        }
+
+        next[index] = section;
+        return next;
+      });
+    },
+    [],
+  );
+
+  // Reorder
+  const handleMoveUp = useCallback((index: number) => {
+    if (index <= 0) return;
+    setSections((prev) => swap(prev, index, index - 1));
+  }, []);
+
+  const handleMoveDown = useCallback((index: number) => {
+    setSections((prev) => {
+      if (index >= prev.length - 1) return prev;
+      return swap(prev, index, index + 1);
+    });
+  }, []);
+
+  // Save
+  const handleSave = useCallback(async () => {
+    if (!isDirty || saving) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiBase}/runs/${runId}/script/structured`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sections }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? `Save failed (${res.status})`);
+      }
+      const data = await res.json();
+      const draft = (data.draft ?? {}) as Record<string, unknown>;
+      setSavedSections(sections);
+      setVersion((draft.version as number) ?? version);
+      onSuccess?.(data);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to save";
+      setError(msg);
+      onError?.("save", msg);
+    } finally {
+      setSaving(false);
+    }
+  }, [apiBase, runId, sections, isDirty, saving, version, onSuccess, onError]);
+
+  // --------------- render ---------------
+
+  if (loading) {
+    return (
+      <div data-testid="structured-editor" aria-busy="true">
+        <p data-testid="structured-loading">Loading sections…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="structured-editor">
+      {error && (
+        <div
+          data-testid="structured-error"
+          role="alert"
+          style={{
+            padding: "8px 12px",
+            marginBottom: 12,
+            backgroundColor: "#f8d7da",
+            color: "#721c24",
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {sections.length === 0 ? (
+        <p data-testid="structured-empty" style={{ color: "#6c757d", fontSize: 13 }}>
+          No sections yet. Use the Markdown editor to write content, then parse it into sections.
+        </p>
+      ) : (
+        <div data-testid="structured-sections">
+          {sections.map((section, idx) => (
+            <SectionCard
+              key={section.section_id}
+              section={section}
+              index={idx}
+              total={sections.length}
+              readOnly={readOnly}
+              disabled={saving}
+              onChange={handleChange}
+              onMoveUp={handleMoveUp}
+              onMoveDown={handleMoveDown}
+            />
+          ))}
+        </div>
+      )}
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 8 }}>
+        {version !== null && (
+          <span data-testid="structured-version" style={{ fontSize: 11, color: "#6c757d" }}>
+            v{version}
+          </span>
+        )}
+        {isDirty && (
+          <span data-testid="structured-dirty" style={{ fontSize: 11, color: "#856404" }}>
+            Unsaved changes
+          </span>
+        )}
+        <span style={{ marginLeft: "auto" }} />
+        {!readOnly && sections.length > 0 && (
+          <button
+            type="button"
+            data-testid="structured-save-btn"
+            disabled={!isDirty || saving}
+            onClick={handleSave}
+            aria-busy={saving}
+            style={{
+              padding: "6px 16px",
+              fontSize: 13,
+              borderRadius: 4,
+              border: "1px solid #6c757d",
+              backgroundColor: "#6c757d",
+              color: "#fff",
+              cursor: isDirty && !saving ? "pointer" : "not-allowed",
+              opacity: isDirty && !saving ? 1 : 0.5,
+            }}
+          >
+            {saving ? "Saving…" : "Save Sections"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/apps/studio-web/src/components/creator/VisualAssetGrid.tsx
+++ b/apps/studio-web/src/components/creator/VisualAssetGrid.tsx
@@ -1,3 +1,309 @@
-export default function VisualAssetGrid() {
-  return <div>VisualAssetGrid</div>;
+/**
+ * VisualAssetGrid — displays scene-grouped visual assets with version selection.
+ *
+ * Props:
+ * - runId: Pipeline run ID
+ * - apiBase: API base URL (default: "/api/creator")
+ * - readOnly: If true, hide selection controls
+ * - onSelect: Callback when user selects a new active asset
+ * - onError: Callback for error messages
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+const DEFAULT_API = "/api/creator";
+
+// --------------- types ---------------
+
+export interface AssetData {
+  id: number;
+  run_id: number;
+  scene_id: string;
+  version: number;
+  asset_path: string;
+  prompt_snapshot: string | null;
+  model_used: string | null;
+  provider_type: string | null;
+  is_active: boolean;
+  created_at: string;
+}
+
+interface AssetsResponse {
+  run_id: number;
+  scenes: Record<string, AssetData[]>;
+  total_scenes: number;
+  total_assets: number;
+}
+
+interface VisualAssetGridProps {
+  runId: number;
+  apiBase?: string;
+  readOnly?: boolean;
+  onSelect?: (asset: AssetData) => void;
+  onError?: (action: string, message: string) => void;
+}
+
+// --------------- component ---------------
+
+export default function VisualAssetGrid({
+  runId,
+  apiBase = DEFAULT_API,
+  readOnly = false,
+  onSelect,
+  onError,
+}: VisualAssetGridProps) {
+  const [data, setData] = useState<AssetsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selecting, setSelecting] = useState<number | null>(null); // asset id being selected
+
+  // ---- fetch assets ----
+
+  const fetchAssets = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiBase}/runs/${runId}/visual-assets`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        const msg = body?.detail ?? `Failed to load assets (${res.status})`;
+        setError(msg);
+        onError?.("load", msg);
+        return;
+      }
+      const json: AssetsResponse = await res.json();
+      setData(json);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to load assets";
+      setError(msg);
+      onError?.("load", msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [runId, apiBase, onError]);
+
+  useEffect(() => {
+    fetchAssets();
+  }, [fetchAssets]);
+
+  // ---- select active ----
+
+  const handleSelect = useCallback(
+    async (sceneId: string, assetId: number) => {
+      setSelecting(assetId);
+      try {
+        const res = await fetch(
+          `${apiBase}/runs/${runId}/visual-assets/${sceneId}/select/${assetId}`,
+          { method: "POST" },
+        );
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          const msg = body?.detail ?? `Select failed (${res.status})`;
+          onError?.("select", msg);
+          return;
+        }
+        const updated: AssetData = await res.json();
+        onSelect?.(updated);
+        // Re-fetch to update active states
+        await fetchAssets();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Select failed";
+        onError?.("select", msg);
+      } finally {
+        setSelecting(null);
+      }
+    },
+    [runId, apiBase, onSelect, onError, fetchAssets],
+  );
+
+  // ---- render: loading ----
+
+  if (loading) {
+    return (
+      <div data-testid="asset-grid-loading" style={{ padding: 24, textAlign: "center", color: "#6b7280" }}>
+        Loading visual assets…
+      </div>
+    );
+  }
+
+  // ---- render: error ----
+
+  if (error) {
+    return (
+      <div
+        data-testid="asset-grid-error"
+        style={{
+          padding: "12px 16px",
+          background: "#fef2f2",
+          border: "1px solid #fca5a5",
+          borderRadius: 6,
+          color: "#b91c1c",
+          fontSize: 13,
+        }}
+      >
+        {error}
+      </div>
+    );
+  }
+
+  // ---- render: empty ----
+
+  if (!data || data.total_assets === 0) {
+    return (
+      <div
+        data-testid="asset-grid-empty"
+        style={{
+          textAlign: "center",
+          padding: 32,
+          background: "#f9fafb",
+          borderRadius: 8,
+          border: "1px dashed #d1d5db",
+          color: "#6b7280",
+        }}
+      >
+        <p style={{ margin: "0 0 4px", fontWeight: 600 }}>No visual assets yet</p>
+        <p style={{ margin: 0, fontSize: 13 }}>
+          Generate images to see them here.
+        </p>
+      </div>
+    );
+  }
+
+  // ---- render: grid ----
+
+  const sceneIds = Object.keys(data.scenes).sort();
+
+  return (
+    <div data-testid="asset-grid" style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      <div style={{ fontSize: 13, color: "#6b7280" }}>
+        {data.total_scenes} scene{data.total_scenes !== 1 ? "s" : ""} · {data.total_assets} asset{data.total_assets !== 1 ? "s" : ""}
+      </div>
+
+      {sceneIds.map((sceneId) => {
+        const assets = data.scenes[sceneId];
+        return (
+          <div
+            key={sceneId}
+            data-testid={`scene-group-${sceneId}`}
+            style={{
+              border: "1px solid #e5e7eb",
+              borderRadius: 8,
+              padding: 16,
+              background: "#fff",
+            }}
+          >
+            <h3 style={{ margin: "0 0 12px", fontSize: 15, fontWeight: 600 }}>
+              {sceneId}
+            </h3>
+
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              {assets.map((asset) => (
+                <div
+                  key={asset.id}
+                  data-testid={`asset-${asset.id}`}
+                  style={{
+                    width: 180,
+                    border: asset.is_active
+                      ? "2px solid #4285f4"
+                      : "1px solid #d1d5db",
+                    borderRadius: 8,
+                    padding: 8,
+                    background: asset.is_active ? "#eff6ff" : "#f9fafb",
+                    position: "relative",
+                  }}
+                >
+                  {/* Active badge */}
+                  {asset.is_active && (
+                    <span
+                      data-testid={`asset-${asset.id}-active`}
+                      style={{
+                        position: "absolute",
+                        top: 4,
+                        right: 4,
+                        background: "#4285f4",
+                        color: "#fff",
+                        padding: "1px 6px",
+                        borderRadius: 4,
+                        fontSize: 10,
+                        fontWeight: 600,
+                      }}
+                    >
+                      Active
+                    </span>
+                  )}
+
+                  {/* Thumbnail placeholder */}
+                  <div
+                    data-testid={`asset-${asset.id}-thumb`}
+                    style={{
+                      width: "100%",
+                      height: 100,
+                      background: "#e5e7eb",
+                      borderRadius: 4,
+                      marginBottom: 8,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontSize: 11,
+                      color: "#9ca3af",
+                    }}
+                  >
+                    v{asset.version}
+                  </div>
+
+                  {/* Meta info */}
+                  <div style={{ fontSize: 11, color: "#6b7280", lineHeight: 1.5 }}>
+                    {asset.prompt_snapshot && (
+                      <div
+                        data-testid={`asset-${asset.id}-prompt`}
+                        style={{
+                          whiteSpace: "nowrap",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          marginBottom: 2,
+                        }}
+                        title={asset.prompt_snapshot}
+                      >
+                        {asset.prompt_snapshot}
+                      </div>
+                    )}
+                    {asset.model_used && (
+                      <div data-testid={`asset-${asset.id}-model`}>
+                        Model: {asset.model_used}
+                      </div>
+                    )}
+                    <div data-testid={`asset-${asset.id}-time`}>
+                      {new Date(asset.created_at).toLocaleString()}
+                    </div>
+                  </div>
+
+                  {/* Select button */}
+                  {!readOnly && !asset.is_active && (
+                    <button
+                      data-testid={`asset-${asset.id}-select`}
+                      disabled={selecting === asset.id}
+                      onClick={() => handleSelect(sceneId, asset.id)}
+                      style={{
+                        width: "100%",
+                        marginTop: 8,
+                        padding: "4px 8px",
+                        border: "1px solid #d1d5db",
+                        borderRadius: 4,
+                        background: "#fff",
+                        cursor: selecting === asset.id ? "wait" : "pointer",
+                        fontSize: 11,
+                        color: "#374151",
+                      }}
+                    >
+                      {selecting === asset.id ? "Selecting…" : "Set Active"}
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
 }

--- a/apps/studio-web/src/components/creator/VisualPlanEditor.tsx
+++ b/apps/studio-web/src/components/creator/VisualPlanEditor.tsx
@@ -1,3 +1,516 @@
-export default function VisualPlanEditor() {
-  return <div>VisualPlanEditor</div>;
+/**
+ * VisualPlanEditor — scene-card editor for visual plans.
+ *
+ * Loads visual plan from GET /runs/{runId}/visual-plan, renders
+ * editable scene cards keyed by scene_id, saves individual scenes
+ * via PATCH /runs/{runId}/visual-plan/scenes/{sceneId}.
+ * Per-scene regenerate and image-model override controls are present
+ * but disabled until Phase 4 wiring.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+// --------------- types ---------------
+
+export interface SceneData {
+  scene_id: string;
+  section_id: string;
+  scene_index: number;
+  section_type: string;
+  original_text: string;
+  prompt: string;
+  prompt_edited: boolean;
+  prompt_source: "auto_generated" | "user_edited" | "model_suggested";
+  style_tags: string[];
+  mood: string | null;
+  composition: string | null;
+  generation_status: "pending" | "generating" | "completed" | "failed";
+  latest_asset_id: number | null;
+}
+
+export interface VisualPlanEditorProps {
+  apiBase?: string;
+  runId: number;
+  onSuccess?: (data: Record<string, unknown>) => void;
+  onError?: (action: "load" | "save", message: string) => void;
+  readOnly?: boolean;
+}
+
+// --------------- styles ---------------
+
+const CARD_STYLE: React.CSSProperties = {
+  border: "1px solid #dee2e6",
+  borderRadius: 6,
+  padding: 12,
+  marginBottom: 10,
+  backgroundColor: "#fff",
+};
+
+const FIELD_LABEL: React.CSSProperties = {
+  display: "block",
+  fontSize: 11,
+  fontWeight: 600,
+  color: "#495057",
+  marginBottom: 2,
+};
+
+const INPUT_STYLE: React.CSSProperties = {
+  width: "100%",
+  padding: "4px 8px",
+  fontSize: 13,
+  border: "1px solid #ced4da",
+  borderRadius: 4,
+  boxSizing: "border-box",
+};
+
+const TEXTAREA_STYLE: React.CSSProperties = {
+  ...INPUT_STYLE,
+  minHeight: 60,
+  resize: "vertical",
+  fontFamily: "inherit",
+};
+
+const TAG_STYLE: React.CSSProperties = {
+  display: "inline-block",
+  padding: "2px 8px",
+  fontSize: 11,
+  backgroundColor: "#e9ecef",
+  borderRadius: 10,
+  marginRight: 4,
+  marginBottom: 4,
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: "#6c757d",
+  generating: "#0d6efd",
+  completed: "#198754",
+  failed: "#dc3545",
+};
+
+const SMALL_BTN: React.CSSProperties = {
+  padding: "4px 10px",
+  fontSize: 12,
+  border: "1px solid #ced4da",
+  borderRadius: 3,
+  backgroundColor: "#f8f9fa",
+  cursor: "pointer",
+};
+
+// --------------- scene card ---------------
+
+interface SceneCardProps {
+  scene: SceneData;
+  readOnly: boolean;
+  saving: boolean;
+  onPromptChange: (sceneId: string, value: string) => void;
+  onMoodChange: (sceneId: string, value: string) => void;
+  onCompositionChange: (sceneId: string, value: string) => void;
+  onStyleTagsChange: (sceneId: string, value: string) => void;
+  onSaveScene: (sceneId: string) => void;
+  dirtyFields: Set<string>;
+}
+
+function SceneCard({
+  scene,
+  readOnly,
+  saving,
+  onPromptChange,
+  onMoodChange,
+  onCompositionChange,
+  onStyleTagsChange,
+  onSaveScene,
+  dirtyFields,
+}: SceneCardProps) {
+  const fieldDisabled = readOnly || saving;
+  const prefix = `scene-${scene.scene_id}`;
+  const isDirty = dirtyFields.has(scene.scene_id);
+  const statusColor = STATUS_COLORS[scene.generation_status] ?? "#6c757d";
+
+  return (
+    <div data-testid={prefix} style={CARD_STYLE}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+        <span style={{ fontSize: 12, fontWeight: 700, color: "#6c757d" }}>
+          #{scene.scene_index + 1}
+        </span>
+        <span style={{ fontSize: 11, color: "#adb5bd" }}>{scene.scene_id}</span>
+        <span
+          data-testid={`${prefix}-status`}
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: statusColor,
+            textTransform: "uppercase",
+          }}
+        >
+          {scene.generation_status}
+        </span>
+        <span style={{ marginLeft: "auto" }} />
+        {/* Regenerate — disabled until Phase 4 */}
+        <button
+          type="button"
+          data-testid={`${prefix}-regenerate`}
+          disabled
+          style={{ ...SMALL_BTN, opacity: 0.4, cursor: "not-allowed" }}
+          title="Regenerate image (Phase 4)"
+        >
+          🔄 Regenerate
+        </button>
+      </div>
+
+      {/* Original text (read-only) */}
+      <div style={{ marginBottom: 8 }}>
+        <span style={FIELD_LABEL}>Original Text</span>
+        <div
+          data-testid={`${prefix}-original-text`}
+          style={{
+            padding: "6px 8px",
+            fontSize: 13,
+            backgroundColor: "#f8f9fa",
+            borderRadius: 4,
+            color: "#495057",
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          {scene.original_text}
+        </div>
+      </div>
+
+      {/* Prompt (editable) */}
+      <div style={{ marginBottom: 8 }}>
+        <label style={FIELD_LABEL} htmlFor={`${prefix}-prompt`}>
+          Prompt
+          {scene.prompt_source !== "auto_generated" && (
+            <span style={{ fontWeight: 400, color: "#6c757d", marginLeft: 4 }}>
+              ({scene.prompt_source})
+            </span>
+          )}
+        </label>
+        <textarea
+          id={`${prefix}-prompt`}
+          data-testid={`${prefix}-prompt`}
+          style={TEXTAREA_STYLE}
+          value={scene.prompt}
+          readOnly={fieldDisabled}
+          onChange={(e) => onPromptChange(scene.scene_id, e.target.value)}
+        />
+      </div>
+
+      {/* Mood + Composition (side by side) */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 8 }}>
+        <div>
+          <label style={FIELD_LABEL} htmlFor={`${prefix}-mood`}>Mood</label>
+          <input
+            id={`${prefix}-mood`}
+            data-testid={`${prefix}-mood`}
+            style={INPUT_STYLE}
+            value={scene.mood ?? ""}
+            readOnly={fieldDisabled}
+            onChange={(e) => onMoodChange(scene.scene_id, e.target.value)}
+          />
+        </div>
+        <div>
+          <label style={FIELD_LABEL} htmlFor={`${prefix}-composition`}>Composition</label>
+          <input
+            id={`${prefix}-composition`}
+            data-testid={`${prefix}-composition`}
+            style={INPUT_STYLE}
+            value={scene.composition ?? ""}
+            readOnly={fieldDisabled}
+            onChange={(e) => onCompositionChange(scene.scene_id, e.target.value)}
+          />
+        </div>
+      </div>
+
+      {/* Style tags */}
+      <div style={{ marginBottom: 8 }}>
+        <label style={FIELD_LABEL} htmlFor={`${prefix}-style-tags`}>
+          Style Tags (comma-separated)
+        </label>
+        <input
+          id={`${prefix}-style-tags`}
+          data-testid={`${prefix}-style-tags`}
+          style={INPUT_STYLE}
+          value={scene.style_tags.join(", ")}
+          readOnly={fieldDisabled}
+          onChange={(e) => onStyleTagsChange(scene.scene_id, e.target.value)}
+        />
+        {scene.style_tags.length > 0 && (
+          <div style={{ marginTop: 4 }}>
+            {scene.style_tags.map((tag) => (
+              <span key={tag} style={TAG_STYLE}>{tag}</span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Image model override — disabled until Phase 4 */}
+      <div style={{ marginBottom: 8 }}>
+        <span style={FIELD_LABEL}>Image Model Override</span>
+        <select
+          data-testid={`${prefix}-model-override`}
+          disabled
+          style={{ ...INPUT_STYLE, opacity: 0.5, cursor: "not-allowed" }}
+          title="Image model override (Phase 4)"
+        >
+          <option value="">Default model</option>
+        </select>
+      </div>
+
+      {/* Per-scene save button */}
+      {!readOnly && (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4 }}>
+          {isDirty && (
+            <span data-testid={`${prefix}-dirty`} style={{ fontSize: 11, color: "#856404" }}>
+              Unsaved changes
+            </span>
+          )}
+          <span style={{ marginLeft: "auto" }} />
+          <button
+            type="button"
+            data-testid={`${prefix}-save`}
+            disabled={!isDirty || saving}
+            onClick={() => onSaveScene(scene.scene_id)}
+            style={{
+              ...SMALL_BTN,
+              backgroundColor: isDirty && !saving ? "#6c757d" : "#f8f9fa",
+              color: isDirty && !saving ? "#fff" : "#6c757d",
+              cursor: isDirty && !saving ? "pointer" : "not-allowed",
+              opacity: isDirty && !saving ? 1 : 0.5,
+            }}
+          >
+            {saving ? "Saving…" : "Save Scene"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --------------- main component ---------------
+
+export default function VisualPlanEditor({
+  apiBase = "/api/creator",
+  runId,
+  onSuccess,
+  onError,
+  readOnly = false,
+}: VisualPlanEditorProps) {
+  const [scenes, setScenes] = useState<SceneData[]>([]);
+  const [savedScenes, setSavedScenes] = useState<Record<string, SceneData>>({});
+  const [version, setVersion] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dirtyFields, setDirtyFields] = useState<Set<string>>(new Set());
+
+  // Load plan
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`${apiBase}/runs/${runId}/visual-plan`);
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.detail ?? `Failed to load (${res.status})`);
+        }
+        const data = await res.json();
+        const loaded = (data.scenes ?? []) as SceneData[];
+        if (!cancelled) {
+          setScenes(loaded);
+          const saved: Record<string, SceneData> = {};
+          for (const s of loaded) {
+            saved[s.scene_id] = { ...s };
+          }
+          setSavedScenes(saved);
+          setVersion(data.version ?? null);
+          setDirtyFields(new Set());
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const msg = err instanceof Error ? err.message : "Failed to load visual plan";
+          setError(msg);
+          onError?.("load", msg);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [apiBase, runId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Mark scene dirty
+  const markDirty = useCallback((sceneId: string) => {
+    setDirtyFields((prev) => {
+      if (prev.has(sceneId)) return prev;
+      const next = new Set(prev);
+      next.add(sceneId);
+      return next;
+    });
+  }, []);
+
+  // Field handlers
+  const handlePromptChange = useCallback((sceneId: string, value: string) => {
+    setScenes((prev) =>
+      prev.map((s) =>
+        s.scene_id === sceneId
+          ? { ...s, prompt: value, prompt_edited: true, prompt_source: "user_edited" as const }
+          : s
+      )
+    );
+    markDirty(sceneId);
+  }, [markDirty]);
+
+  const handleMoodChange = useCallback((sceneId: string, value: string) => {
+    setScenes((prev) =>
+      prev.map((s) => (s.scene_id === sceneId ? { ...s, mood: value || null } : s))
+    );
+    markDirty(sceneId);
+  }, [markDirty]);
+
+  const handleCompositionChange = useCallback((sceneId: string, value: string) => {
+    setScenes((prev) =>
+      prev.map((s) => (s.scene_id === sceneId ? { ...s, composition: value || null } : s))
+    );
+    markDirty(sceneId);
+  }, [markDirty]);
+
+  const handleStyleTagsChange = useCallback((sceneId: string, value: string) => {
+    const tags = value.split(",").map((t) => t.trim()).filter(Boolean);
+    setScenes((prev) =>
+      prev.map((s) => (s.scene_id === sceneId ? { ...s, style_tags: tags } : s))
+    );
+    markDirty(sceneId);
+  }, [markDirty]);
+
+  // Save single scene via PATCH
+  const handleSaveScene = useCallback(async (sceneId: string) => {
+    const scene = scenes.find((s) => s.scene_id === sceneId);
+    const saved = savedScenes[sceneId];
+    if (!scene || !saved) return;
+
+    // Build diff
+    const updates: Record<string, unknown> = {};
+    if (scene.prompt !== saved.prompt) updates.prompt = scene.prompt;
+    if (scene.prompt_edited !== saved.prompt_edited) updates.prompt_edited = scene.prompt_edited;
+    if (scene.prompt_source !== saved.prompt_source) updates.prompt_source = scene.prompt_source;
+    if (JSON.stringify(scene.style_tags) !== JSON.stringify(saved.style_tags))
+      updates.style_tags = scene.style_tags;
+    if (scene.mood !== saved.mood) updates.mood = scene.mood;
+    if (scene.composition !== saved.composition) updates.composition = scene.composition;
+
+    if (Object.keys(updates).length === 0) return;
+
+    if (version !== null) {
+      updates.expected_version = version;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${apiBase}/runs/${runId}/visual-plan/scenes/${sceneId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(updates),
+        }
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? `Save failed (${res.status})`);
+      }
+      const data = await res.json();
+      const updatedScenes = (data.scenes ?? []) as SceneData[];
+
+      setScenes(updatedScenes);
+      const newSaved: Record<string, SceneData> = {};
+      for (const s of updatedScenes) {
+        newSaved[s.scene_id] = { ...s };
+      }
+      setSavedScenes(newSaved);
+      setVersion(data.version ?? version);
+      setDirtyFields((prev) => {
+        const next = new Set(prev);
+        next.delete(sceneId);
+        return next;
+      });
+      onSuccess?.(data);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to save scene";
+      setError(msg);
+      onError?.("save", msg);
+    } finally {
+      setSaving(false);
+    }
+  }, [apiBase, runId, scenes, savedScenes, version, onSuccess, onError]);
+
+  // --------------- render ---------------
+
+  if (loading) {
+    return (
+      <div data-testid="visual-plan-editor" aria-busy="true">
+        <p data-testid="visual-plan-loading">Loading visual plan…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="visual-plan-editor">
+      {error && (
+        <div
+          data-testid="visual-plan-error"
+          role="alert"
+          style={{
+            padding: "8px 12px",
+            marginBottom: 12,
+            backgroundColor: "#f8d7da",
+            color: "#721c24",
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {scenes.length === 0 ? (
+        <p data-testid="visual-plan-empty" style={{ color: "#6c757d", fontSize: 13 }}>
+          No scenes in visual plan. Generate a visual plan first.
+        </p>
+      ) : (
+        <>
+          <div data-testid="visual-plan-scenes">
+            {scenes.map((scene) => (
+              <SceneCard
+                key={scene.scene_id}
+                scene={scene}
+                readOnly={readOnly}
+                saving={saving}
+                onPromptChange={handlePromptChange}
+                onMoodChange={handleMoodChange}
+                onCompositionChange={handleCompositionChange}
+                onStyleTagsChange={handleStyleTagsChange}
+                onSaveScene={handleSaveScene}
+                dirtyFields={dirtyFields}
+              />
+            ))}
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 8 }}>
+            {version !== null && (
+              <span data-testid="visual-plan-version" style={{ fontSize: 11, color: "#6c757d" }}>
+                v{version}
+              </span>
+            )}
+            <span style={{ fontSize: 11, color: "#6c757d" }}>
+              {scenes.length} scene{scenes.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
 }

--- a/apps/studio-web/src/pages/CreatePage.tsx
+++ b/apps/studio-web/src/pages/CreatePage.tsx
@@ -107,15 +107,57 @@ export default function CreatePage() {
     [navigate],
   );
 
-  const handleMarkdownSubmit = useCallback(() => {
-    // eslint-disable-next-line no-console
-    console.log("CreatePage markdown submit (stub):", {
-      tab: "markdown",
-      ...markdownForm,
-      stylePreset,
-      modelDefaults,
-    });
-  }, [markdownForm, stylePreset, modelDefaults]);
+  const handleMarkdownSubmit = useCallback(async () => {
+    const title = markdownForm.title.trim();
+    const markdown = markdownForm.markdown.trim();
+    if (!markdown) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      // 1. Create project
+      const projRes = await fetch(`${API_BASE}/projects`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title || "Untitled",
+          source_type: "markdown",
+          markdown_source: markdown,
+        }),
+      });
+
+      if (!projRes.ok) {
+        const body = await projRes.json().catch(() => null);
+        throw new Error(body?.detail ?? `Failed to create project (${projRes.status})`);
+      }
+
+      const project = await projRes.json();
+
+      // 2. Import markdown (creates run + saves draft in one call)
+      const importRes = await fetch(`${API_BASE}/projects/${project.id}/script/import-markdown`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          markdown,
+          model_defaults: modelDefaultsRef.current,
+          style_preset: stylePresetRef.current,
+        }),
+      });
+
+      if (!importRes.ok) {
+        const body = await importRes.json().catch(() => null);
+        throw new Error(body?.detail ?? `Failed to import markdown (${importRes.status})`);
+      }
+
+      // 3. Navigate to project page
+      navigate(`/projects/${project.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An unexpected error occurred");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [markdownForm, navigate]);
 
   return (
     <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
@@ -173,6 +215,24 @@ export default function CreatePage() {
       {/* Markdown tab panel */}
       {activeTab === "markdown" && (
         <div role="tabpanel" id="tabpanel-markdown" aria-labelledby="tab-markdown">
+          {error && (
+            <div
+              data-testid="markdown-form-error"
+              role="alert"
+              style={{
+                padding: "8px 12px",
+                marginBottom: 16,
+                background: "#fef2f2",
+                border: "1px solid #fca5a5",
+                borderRadius: 4,
+                color: "#b91c1c",
+                fontSize: 13,
+              }}
+            >
+              {error}
+            </div>
+          )}
+
           <div style={{ marginBottom: 16 }}>
             <label htmlFor="md-title" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
               Title
@@ -182,6 +242,7 @@ export default function CreatePage() {
               type="text"
               value={markdownForm.title}
               onChange={(e) => setMarkdownForm((prev) => ({ ...prev, title: e.target.value }))}
+              disabled={submitting}
               placeholder="Project title"
               style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
             />
@@ -189,12 +250,14 @@ export default function CreatePage() {
 
           <div style={{ marginBottom: 16 }}>
             <label htmlFor="md-content" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
-              Markdown Content
+              Markdown Content <span style={{ color: "#c00" }}>*</span>
             </label>
             <textarea
               id="md-content"
+              required
               value={markdownForm.markdown}
               onChange={(e) => setMarkdownForm((prev) => ({ ...prev, markdown: e.target.value }))}
+              disabled={submitting}
               placeholder="Paste your script markdown here..."
               rows={10}
               style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, fontFamily: "monospace", resize: "vertical", boxSizing: "border-box" }}
@@ -210,6 +273,7 @@ export default function CreatePage() {
               type="file"
               accept=".md,.txt"
               onChange={handleFileUpload}
+              disabled={submitting}
               style={{ fontSize: 13 }}
             />
           </div>

--- a/apps/studio-web/src/pages/CreatePage.tsx
+++ b/apps/studio-web/src/pages/CreatePage.tsx
@@ -1,30 +1,20 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import ModelSelector from "../components/creator/ModelSelector";
+import IdeaForm, { type IdeaFormData } from "../components/creator/IdeaForm";
 
 type Tab = "idea" | "markdown";
-
-interface IdeaFormState {
-  title: string;
-  ideaBrief: string;
-  targetDuration: number;
-  contentGoal: string;
-}
 
 interface MarkdownFormState {
   title: string;
   markdown: string;
 }
 
-export default function CreatePage() {
-  const [activeTab, setActiveTab] = useState<Tab>("idea");
+const API_BASE = "/api/creator";
 
-  // Idea form state
-  const [ideaForm, setIdeaForm] = useState<IdeaFormState>({
-    title: "",
-    ideaBrief: "",
-    targetDuration: 60,
-    contentGoal: "",
-  });
+export default function CreatePage() {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<Tab>("idea");
 
   // Markdown form state
   const [markdownForm, setMarkdownForm] = useState<MarkdownFormState>({
@@ -35,6 +25,16 @@ export default function CreatePage() {
   // Shared state
   const [stylePreset, setStylePreset] = useState("default");
   const [modelDefaults, setModelDefaults] = useState<Record<string, string>>({});
+
+  // Submission state
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Stable ref for modelDefaults so IdeaForm submit handler always has latest
+  const modelDefaultsRef = useRef(modelDefaults);
+  modelDefaultsRef.current = modelDefaults;
+  const stylePresetRef = useRef(stylePreset);
+  stylePresetRef.current = stylePreset;
 
   const handleModelChange = useCallback((category: string, modelKey: string) => {
     setModelDefaults((prev) => ({ ...prev, [category]: modelKey }));
@@ -53,16 +53,69 @@ export default function CreatePage() {
     reader.readAsText(file);
   }, []);
 
-  const handleSubmit = useCallback(() => {
-    const formData = {
-      tab: activeTab,
-      ...(activeTab === "idea" ? ideaForm : markdownForm),
+  const handleIdeaSubmit = useCallback(
+    async (data: IdeaFormData) => {
+      setSubmitting(true);
+      setError(null);
+
+      try {
+        // 1. Create project
+        const projRes = await fetch(`${API_BASE}/projects`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: data.title,
+            source_type: "idea",
+            idea_brief: data.ideaBrief,
+          }),
+        });
+
+        if (!projRes.ok) {
+          const body = await projRes.json().catch(() => null);
+          throw new Error(body?.detail ?? `Failed to create project (${projRes.status})`);
+        }
+
+        const project = await projRes.json();
+
+        // 2. Create run
+        const runRes = await fetch(`${API_BASE}/projects/${project.id}/runs`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model_defaults: modelDefaultsRef.current,
+            style_preset: stylePresetRef.current,
+            metadata: {
+              content_goal: data.contentGoal || undefined,
+              target_duration: data.targetDuration,
+            },
+          }),
+        });
+
+        if (!runRes.ok) {
+          const body = await runRes.json().catch(() => null);
+          throw new Error(body?.detail ?? `Failed to create run (${runRes.status})`);
+        }
+
+        // 3. Navigate to project page
+        navigate(`/projects/${project.id}`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An unexpected error occurred");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [navigate],
+  );
+
+  const handleMarkdownSubmit = useCallback(() => {
+    // eslint-disable-next-line no-console
+    console.log("CreatePage markdown submit (stub):", {
+      tab: "markdown",
+      ...markdownForm,
       stylePreset,
       modelDefaults,
-    };
-    // eslint-disable-next-line no-console
-    console.log("CreatePage submit (stub):", formData);
-  }, [activeTab, ideaForm, markdownForm, stylePreset, modelDefaults]);
+    });
+  }, [markdownForm, stylePreset, modelDefaults]);
 
   return (
     <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
@@ -113,65 +166,7 @@ export default function CreatePage() {
       {/* Idea tab panel */}
       {activeTab === "idea" && (
         <div role="tabpanel" id="tabpanel-idea" aria-labelledby="tab-idea">
-          <div style={{ marginBottom: 16 }}>
-            <label htmlFor="idea-title" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
-              Title <span style={{ color: "#c00" }}>*</span>
-            </label>
-            <input
-              id="idea-title"
-              type="text"
-              required
-              value={ideaForm.title}
-              onChange={(e) => setIdeaForm((prev) => ({ ...prev, title: e.target.value }))}
-              placeholder="Project title"
-              style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
-            />
-          </div>
-
-          <div style={{ marginBottom: 16 }}>
-            <label htmlFor="idea-brief" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
-              Idea Brief <span style={{ color: "#c00" }}>*</span>
-            </label>
-            <textarea
-              id="idea-brief"
-              required
-              value={ideaForm.ideaBrief}
-              onChange={(e) => setIdeaForm((prev) => ({ ...prev, ideaBrief: e.target.value }))}
-              placeholder="Describe your video idea..."
-              rows={4}
-              style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, resize: "vertical", boxSizing: "border-box" }}
-            />
-          </div>
-
-          <div style={{ display: "flex", gap: 16, marginBottom: 16 }}>
-            <div style={{ flex: 1 }}>
-              <label htmlFor="target-duration" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
-                Target Duration (seconds)
-              </label>
-              <input
-                id="target-duration"
-                type="number"
-                min={10}
-                max={180}
-                value={ideaForm.targetDuration}
-                onChange={(e) => setIdeaForm((prev) => ({ ...prev, targetDuration: Number(e.target.value) }))}
-                style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
-              />
-            </div>
-            <div style={{ flex: 1 }}>
-              <label htmlFor="content-goal" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
-                Content Goal
-              </label>
-              <input
-                id="content-goal"
-                type="text"
-                value={ideaForm.contentGoal}
-                onChange={(e) => setIdeaForm((prev) => ({ ...prev, contentGoal: e.target.value }))}
-                placeholder="e.g., educational, entertainment"
-                style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
-              />
-            </div>
-          </div>
+          <IdeaForm onSubmit={handleIdeaSubmit} submitting={submitting} error={error} />
         </div>
       )}
 
@@ -249,19 +244,23 @@ export default function CreatePage() {
       <div style={{ marginTop: 24 }}>
         <button
           type="button"
-          onClick={handleSubmit}
+          disabled={submitting}
+          onClick={activeTab === "idea" ? () => {
+            const form = document.querySelector<HTMLFormElement>('[data-testid="idea-form"]');
+            form?.requestSubmit();
+          } : handleMarkdownSubmit}
           style={{
             padding: "10px 24px",
-            background: "#4285f4",
+            background: submitting ? "#93b4f4" : "#4285f4",
             color: "#fff",
             border: "none",
             borderRadius: 6,
             fontSize: 14,
             fontWeight: 600,
-            cursor: "pointer",
+            cursor: submitting ? "not-allowed" : "pointer",
           }}
         >
-          Create Project
+          {submitting ? "Creating…" : "Create Project"}
         </button>
       </div>
     </div>

--- a/apps/studio-web/src/pages/CreatePage.tsx
+++ b/apps/studio-web/src/pages/CreatePage.tsx
@@ -1,3 +1,269 @@
+import { useState, useCallback } from "react";
+import ModelSelector from "../components/creator/ModelSelector";
+
+type Tab = "idea" | "markdown";
+
+interface IdeaFormState {
+  title: string;
+  ideaBrief: string;
+  targetDuration: number;
+  contentGoal: string;
+}
+
+interface MarkdownFormState {
+  title: string;
+  markdown: string;
+}
+
 export default function CreatePage() {
-  return <div>CreatePage</div>;
+  const [activeTab, setActiveTab] = useState<Tab>("idea");
+
+  // Idea form state
+  const [ideaForm, setIdeaForm] = useState<IdeaFormState>({
+    title: "",
+    ideaBrief: "",
+    targetDuration: 60,
+    contentGoal: "",
+  });
+
+  // Markdown form state
+  const [markdownForm, setMarkdownForm] = useState<MarkdownFormState>({
+    title: "",
+    markdown: "",
+  });
+
+  // Shared state
+  const [stylePreset, setStylePreset] = useState("default");
+  const [modelDefaults, setModelDefaults] = useState<Record<string, string>>({});
+
+  const handleModelChange = useCallback((category: string, modelKey: string) => {
+    setModelDefaults((prev) => ({ ...prev, [category]: modelKey }));
+  }, []);
+
+  const handleFileUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target?.result;
+      if (typeof text === "string") {
+        setMarkdownForm((prev) => ({ ...prev, markdown: text }));
+      }
+    };
+    reader.readAsText(file);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    const formData = {
+      tab: activeTab,
+      ...(activeTab === "idea" ? ideaForm : markdownForm),
+      stylePreset,
+      modelDefaults,
+    };
+    // eslint-disable-next-line no-console
+    console.log("CreatePage submit (stub):", formData);
+  }, [activeTab, ideaForm, markdownForm, stylePreset, modelDefaults]);
+
+  return (
+    <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 24 }}>Create New Project</h1>
+
+      {/* Tab list */}
+      <div role="tablist" style={{ display: "flex", gap: 4, marginBottom: 16, borderBottom: "2px solid #ddd" }}>
+        <button
+          role="tab"
+          id="tab-idea"
+          aria-selected={activeTab === "idea"}
+          aria-controls="tabpanel-idea"
+          onClick={() => setActiveTab("idea")}
+          style={{
+            padding: "8px 16px",
+            border: "none",
+            borderBottom: activeTab === "idea" ? "2px solid #4285f4" : "2px solid transparent",
+            background: "transparent",
+            cursor: "pointer",
+            fontWeight: activeTab === "idea" ? 600 : 400,
+            color: activeTab === "idea" ? "#4285f4" : "#666",
+            fontSize: 14,
+          }}
+        >
+          Start from Idea
+        </button>
+        <button
+          role="tab"
+          id="tab-markdown"
+          aria-selected={activeTab === "markdown"}
+          aria-controls="tabpanel-markdown"
+          onClick={() => setActiveTab("markdown")}
+          style={{
+            padding: "8px 16px",
+            border: "none",
+            borderBottom: activeTab === "markdown" ? "2px solid #4285f4" : "2px solid transparent",
+            background: "transparent",
+            cursor: "pointer",
+            fontWeight: activeTab === "markdown" ? 600 : 400,
+            color: activeTab === "markdown" ? "#4285f4" : "#666",
+            fontSize: 14,
+          }}
+        >
+          Start from Markdown
+        </button>
+      </div>
+
+      {/* Idea tab panel */}
+      {activeTab === "idea" && (
+        <div role="tabpanel" id="tabpanel-idea" aria-labelledby="tab-idea">
+          <div style={{ marginBottom: 16 }}>
+            <label htmlFor="idea-title" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+              Title <span style={{ color: "#c00" }}>*</span>
+            </label>
+            <input
+              id="idea-title"
+              type="text"
+              required
+              value={ideaForm.title}
+              onChange={(e) => setIdeaForm((prev) => ({ ...prev, title: e.target.value }))}
+              placeholder="Project title"
+              style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
+            />
+          </div>
+
+          <div style={{ marginBottom: 16 }}>
+            <label htmlFor="idea-brief" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+              Idea Brief <span style={{ color: "#c00" }}>*</span>
+            </label>
+            <textarea
+              id="idea-brief"
+              required
+              value={ideaForm.ideaBrief}
+              onChange={(e) => setIdeaForm((prev) => ({ ...prev, ideaBrief: e.target.value }))}
+              placeholder="Describe your video idea..."
+              rows={4}
+              style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, resize: "vertical", boxSizing: "border-box" }}
+            />
+          </div>
+
+          <div style={{ display: "flex", gap: 16, marginBottom: 16 }}>
+            <div style={{ flex: 1 }}>
+              <label htmlFor="target-duration" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+                Target Duration (seconds)
+              </label>
+              <input
+                id="target-duration"
+                type="number"
+                min={10}
+                max={180}
+                value={ideaForm.targetDuration}
+                onChange={(e) => setIdeaForm((prev) => ({ ...prev, targetDuration: Number(e.target.value) }))}
+                style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
+              />
+            </div>
+            <div style={{ flex: 1 }}>
+              <label htmlFor="content-goal" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+                Content Goal
+              </label>
+              <input
+                id="content-goal"
+                type="text"
+                value={ideaForm.contentGoal}
+                onChange={(e) => setIdeaForm((prev) => ({ ...prev, contentGoal: e.target.value }))}
+                placeholder="e.g., educational, entertainment"
+                style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Markdown tab panel */}
+      {activeTab === "markdown" && (
+        <div role="tabpanel" id="tabpanel-markdown" aria-labelledby="tab-markdown">
+          <div style={{ marginBottom: 16 }}>
+            <label htmlFor="md-title" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+              Title
+            </label>
+            <input
+              id="md-title"
+              type="text"
+              value={markdownForm.title}
+              onChange={(e) => setMarkdownForm((prev) => ({ ...prev, title: e.target.value }))}
+              placeholder="Project title"
+              style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, boxSizing: "border-box" }}
+            />
+          </div>
+
+          <div style={{ marginBottom: 16 }}>
+            <label htmlFor="md-content" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+              Markdown Content
+            </label>
+            <textarea
+              id="md-content"
+              value={markdownForm.markdown}
+              onChange={(e) => setMarkdownForm((prev) => ({ ...prev, markdown: e.target.value }))}
+              placeholder="Paste your script markdown here..."
+              rows={10}
+              style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, fontFamily: "monospace", resize: "vertical", boxSizing: "border-box" }}
+            />
+          </div>
+
+          <div style={{ marginBottom: 16 }}>
+            <label htmlFor="md-upload" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+              Or upload a file
+            </label>
+            <input
+              id="md-upload"
+              type="file"
+              accept=".md,.txt"
+              onChange={handleFileUpload}
+              style={{ fontSize: 13 }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Shared: Model Defaults */}
+      <div style={{ marginTop: 24, padding: 16, background: "#f9f9f9", borderRadius: 8, border: "1px solid #eee" }}>
+        <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 12 }}>Model Defaults</h2>
+        <ModelSelector categories={["script", "image"]} onSelectionChange={handleModelChange} />
+      </div>
+
+      {/* Shared: Style Preset */}
+      <div style={{ marginTop: 16 }}>
+        <label htmlFor="style-preset" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+          Style Preset
+        </label>
+        <select
+          id="style-preset"
+          value={stylePreset}
+          onChange={(e) => setStylePreset(e.target.value)}
+          style={{ padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14 }}
+        >
+          <option value="default">default</option>
+          <option value="cinematic">cinematic</option>
+          <option value="dynamic">dynamic</option>
+          <option value="minimal">minimal</option>
+        </select>
+      </div>
+
+      {/* Submit */}
+      <div style={{ marginTop: 24 }}>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          style={{
+            padding: "10px 24px",
+            background: "#4285f4",
+            color: "#fff",
+            border: "none",
+            borderRadius: 6,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          Create Project
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -1,3 +1,456 @@
+/**
+ * ProjectPage — main working page for a short-form video project.
+ *
+ * Loads the project detail and its latest run, then renders:
+ * - PipelineStepper (header progress bar)
+ * - Editor area with markdown / structured toggle (during script stages)
+ * - StageActionBar (save / approve / generate / restart)
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams, Link } from "react-router-dom";
+
+import PipelineStepper from "../components/creator/PipelineStepper";
+import StageActionBar, {
+  type ActionConfig,
+} from "../components/creator/StageActionBar";
+import MarkdownScriptEditor from "../components/creator/MarkdownScriptEditor";
+import StructuredScriptEditor from "../components/creator/StructuredScriptEditor";
+
+const API_BASE = "/api/creator";
+
+// --------------- types ---------------
+
+interface ProjectDetail {
+  id: number;
+  title: string | null;
+  source_type: string;
+  status: string;
+}
+
+interface RunDetail {
+  id: number;
+  project_id: number;
+  current_stage: string;
+  status: string;
+  restart_from: string | null;
+}
+
+type EditorMode = "markdown" | "structured";
+
+// Script stages where the editor area is relevant
+const SCRIPT_STAGES = new Set(["SCRIPT_GENERATING", "SCRIPT_REVIEW"]);
+
+// Stages where editing is allowed (not generating)
+const EDITABLE_STAGES = new Set(["SCRIPT_REVIEW"]);
+
 export default function ProjectPage() {
-  return <div>ProjectPage</div>;
+  const { projectId } = useParams<{ projectId: string }>();
+  const numericProjectId = Number(projectId);
+
+  // Data state
+  const [project, setProject] = useState<ProjectDetail | null>(null);
+  const [run, setRun] = useState<RunDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Editor mode
+  const [editorMode, setEditorMode] = useState<EditorMode>("markdown");
+
+  // Action loading states
+  const [approving, setApproving] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [restarting, setRestarting] = useState(false);
+
+  // Status toast
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  // ---- data fetching ----
+
+  const fetchProjectAndRun = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // 1. Fetch project
+      const projRes = await fetch(`${API_BASE}/projects/${numericProjectId}`);
+      if (!projRes.ok) {
+        if (projRes.status === 404) throw new Error("Project not found");
+        const body = await projRes.json().catch(() => null);
+        throw new Error(body?.detail ?? `Failed to load project (${projRes.status})`);
+      }
+      const projData: ProjectDetail = await projRes.json();
+      setProject(projData);
+
+      // 2. Fetch runs for this project (newest first), take the latest
+      const runsRes = await fetch(`${API_BASE}/projects/${numericProjectId}/runs`);
+      if (runsRes.ok) {
+        const runsData: { runs: RunDetail[]; total: number } = await runsRes.json();
+        setRun(runsData.runs.length > 0 ? runsData.runs[0] : null);
+      } else {
+        setRun(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An unexpected error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }, [numericProjectId]);
+
+  useEffect(() => {
+    if (!Number.isNaN(numericProjectId)) {
+      fetchProjectAndRun();
+    }
+  }, [numericProjectId, fetchProjectAndRun]);
+
+  // ---- refresh run ----
+
+  const refreshRun = useCallback(async (runId: number) => {
+    try {
+      const res = await fetch(`${API_BASE}/runs/${runId}`);
+      if (res.ok) {
+        const data: RunDetail = await res.json();
+        setRun(data);
+      }
+    } catch {
+      // silent — non-critical
+    }
+  }, []);
+
+  // ---- actions ----
+
+  const handleApprove = useCallback(async () => {
+    if (!run) return;
+    setApproving(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/approve-script`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviewer: "agent" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Approve failed (${res.status})`);
+      }
+      setStatusMessage("Script approved");
+      await refreshRun(run.id);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Approve failed");
+    } finally {
+      setApproving(false);
+    }
+  }, [run, refreshRun]);
+
+  const handleGenerate = useCallback(async () => {
+    if (!run) return;
+    setGenerating(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/generate-script`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model_key: "qwen3-4b" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Generate failed (${res.status})`);
+      }
+      setStatusMessage("Script generation started");
+      setTimeout(() => refreshRun(run.id), 2000);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Generate failed");
+    } finally {
+      setGenerating(false);
+    }
+  }, [run, refreshRun]);
+
+  const handleRestart = useCallback(async () => {
+    if (!run) return;
+    setRestarting(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/restart`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ stage: "SCRIPT_GENERATING" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Restart failed (${res.status})`);
+      }
+      setStatusMessage("Restarting script generation…");
+      await refreshRun(run.id);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Restart failed");
+    } finally {
+      setRestarting(false);
+    }
+  }, [run, refreshRun]);
+
+  // ---- derived state ----
+
+  const currentStage = run?.current_stage ?? "IDEA_READY";
+  const isFailed = run?.status === "failed";
+  const isScriptStage = SCRIPT_STAGES.has(currentStage);
+  const isEditable = EDITABLE_STAGES.has(currentStage);
+  const isGenerating = currentStage === "SCRIPT_GENERATING";
+
+  // ---- action bar config ----
+
+  const buildActionBar = (): {
+    save: ActionConfig;
+    approve: ActionConfig;
+    generate: ActionConfig;
+    restart: ActionConfig;
+  } => {
+    return {
+      save: {
+        // Save is handled inside the editor components directly
+        visible: false,
+      },
+      approve: {
+        visible: currentStage === "SCRIPT_REVIEW",
+        disabled: approving,
+        loading: approving,
+        onClick: handleApprove,
+        label: "Approve Script",
+      },
+      generate: {
+        visible: currentStage === "IDEA_READY",
+        disabled: generating,
+        loading: generating,
+        onClick: handleGenerate,
+        label: "Generate Script",
+      },
+      restart: {
+        visible: currentStage === "SCRIPT_REVIEW",
+        disabled: restarting,
+        loading: restarting,
+        onClick: handleRestart,
+        label: "Regenerate",
+      },
+    };
+  };
+
+  // ---- render ----
+
+  // Invalid project ID
+  if (Number.isNaN(numericProjectId)) {
+    return (
+      <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
+        <p style={{ color: "#b91c1c" }}>Invalid project ID.</p>
+        <Link to="/runs" style={{ color: "#4285f4" }}>
+          Back to projects
+        </Link>
+      </div>
+    );
+  }
+
+  // Loading
+  if (loading) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading project"
+        style={{ maxWidth: 720, margin: "0 auto", padding: 24, textAlign: "center", color: "#6b7280" }}
+      >
+        Loading project…
+      </div>
+    );
+  }
+
+  // Error
+  if (error) {
+    return (
+      <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
+        <div
+          role="alert"
+          style={{
+            padding: "12px 16px",
+            background: "#fef2f2",
+            border: "1px solid #fca5a5",
+            borderRadius: 6,
+            color: "#b91c1c",
+            fontSize: 13,
+            marginBottom: 16,
+          }}
+        >
+          {error}
+        </div>
+        <Link to="/runs" style={{ color: "#4285f4", fontSize: 13 }}>
+          Back to projects
+        </Link>
+      </div>
+    );
+  }
+
+  // No project
+  if (!project) {
+    return (
+      <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
+        <p>Project not found.</p>
+        <Link to="/runs" style={{ color: "#4285f4" }}>
+          Back to projects
+        </Link>
+      </div>
+    );
+  }
+
+  const actions = buildActionBar();
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: 24 }}>
+      {/* Header */}
+      <div style={{ marginBottom: 16 }}>
+        <Link to="/runs" style={{ color: "#6b7280", fontSize: 12, textDecoration: "none" }}>
+          ← Projects
+        </Link>
+        <h1 style={{ fontSize: 22, fontWeight: 700, margin: "8px 0 4px" }}>
+          {project.title || "Untitled Project"}
+        </h1>
+        <span style={{ fontSize: 12, color: "#6b7280" }}>
+          Source: {project.source_type} · Status: {project.status}
+        </span>
+      </div>
+
+      {/* Pipeline stepper */}
+      {run && (
+        <div style={{ marginBottom: 24 }}>
+          <PipelineStepper currentStage={currentStage} failed={isFailed} />
+        </div>
+      )}
+
+      {/* No run state */}
+      {!run && (
+        <div
+          data-testid="no-run"
+          style={{
+            textAlign: "center",
+            padding: 32,
+            background: "#f9fafb",
+            borderRadius: 8,
+            border: "1px dashed #d1d5db",
+            color: "#6b7280",
+            marginBottom: 24,
+          }}
+        >
+          <p style={{ margin: "0 0 8px", fontWeight: 600 }}>No runs yet</p>
+          <p style={{ margin: 0, fontSize: 13 }}>
+            This project has no pipeline runs. Go back to create a new one.
+          </p>
+        </div>
+      )}
+
+      {/* Generating indicator */}
+      {run && isGenerating && (
+        <div
+          data-testid="generating-indicator"
+          style={{
+            textAlign: "center",
+            padding: 32,
+            background: "#eff6ff",
+            borderRadius: 8,
+            border: "1px solid #bfdbfe",
+            color: "#1e40af",
+            marginBottom: 24,
+          }}
+        >
+          <p style={{ margin: "0 0 4px", fontWeight: 600 }}>Generating Script…</p>
+          <p style={{ margin: 0, fontSize: 13 }}>
+            The AI model is writing your script. This may take a moment.
+          </p>
+        </div>
+      )}
+
+      {/* Script editor area */}
+      {run && isScriptStage && !isGenerating && (
+        <div style={{ marginBottom: 24 }}>
+          {/* Editor mode toggle */}
+          <div
+            role="tablist"
+            style={{
+              display: "flex",
+              gap: 4,
+              marginBottom: 12,
+              borderBottom: "2px solid #ddd",
+            }}
+          >
+            <button
+              role="tab"
+              id="tab-markdown"
+              aria-selected={editorMode === "markdown"}
+              aria-controls="panel-markdown"
+              onClick={() => setEditorMode("markdown")}
+              style={{
+                padding: "6px 14px",
+                border: "none",
+                borderBottom: editorMode === "markdown" ? "2px solid #4285f4" : "2px solid transparent",
+                background: "transparent",
+                cursor: "pointer",
+                fontWeight: editorMode === "markdown" ? 600 : 400,
+                color: editorMode === "markdown" ? "#4285f4" : "#666",
+                fontSize: 13,
+              }}
+            >
+              Markdown
+            </button>
+            <button
+              role="tab"
+              id="tab-structured"
+              aria-selected={editorMode === "structured"}
+              aria-controls="panel-structured"
+              onClick={() => setEditorMode("structured")}
+              style={{
+                padding: "6px 14px",
+                border: "none",
+                borderBottom: editorMode === "structured" ? "2px solid #4285f4" : "2px solid transparent",
+                background: "transparent",
+                cursor: "pointer",
+                fontWeight: editorMode === "structured" ? 600 : 400,
+                color: editorMode === "structured" ? "#4285f4" : "#666",
+                fontSize: 13,
+              }}
+            >
+              Structured
+            </button>
+          </div>
+
+          {/* Markdown editor panel */}
+          {editorMode === "markdown" && (
+            <div role="tabpanel" id="panel-markdown" aria-labelledby="tab-markdown">
+              <MarkdownScriptEditor
+                runId={run.id}
+                readOnly={!isEditable}
+                onSuccess={() => setStatusMessage("Script saved")}
+                onError={(_action, msg) => setStatusMessage(msg)}
+              />
+            </div>
+          )}
+
+          {/* Structured editor panel */}
+          {editorMode === "structured" && (
+            <div role="tabpanel" id="panel-structured" aria-labelledby="tab-structured">
+              <StructuredScriptEditor
+                runId={run.id}
+                readOnly={!isEditable}
+                onSuccess={() => setStatusMessage("Script saved")}
+                onError={(_action, msg) => setStatusMessage(msg)}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Stage action bar */}
+      {run && (
+        <StageActionBar
+          save={actions.save}
+          approve={actions.approve}
+          generate={actions.generate}
+          restart={actions.restart}
+          statusMessage={statusMessage ?? undefined}
+        />
+      )}
+    </div>
+  );
 }

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -4,6 +4,7 @@
  * Loads the project detail and its latest run, then renders:
  * - PipelineStepper (header progress bar)
  * - Editor area with markdown / structured toggle (during script stages)
+ * - VisualPlanEditor (during visual plan stages)
  * - StageActionBar (save / approve / generate / restart)
  */
 
@@ -16,6 +17,7 @@ import StageActionBar, {
 } from "../components/creator/StageActionBar";
 import MarkdownScriptEditor from "../components/creator/MarkdownScriptEditor";
 import StructuredScriptEditor from "../components/creator/StructuredScriptEditor";
+import VisualPlanEditor from "../components/creator/VisualPlanEditor";
 
 const API_BASE = "/api/creator";
 
@@ -41,8 +43,11 @@ type EditorMode = "markdown" | "structured";
 // Script stages where the editor area is relevant
 const SCRIPT_STAGES = new Set(["SCRIPT_GENERATING", "SCRIPT_REVIEW"]);
 
+// Visual plan stages where the editor area is relevant
+const VISUAL_PLAN_STAGES = new Set(["VISUAL_PLAN_GENERATING", "VISUAL_PLAN_REVIEW"]);
+
 // Stages where editing is allowed (not generating)
-const EDITABLE_STAGES = new Set(["SCRIPT_REVIEW"]);
+const EDITABLE_STAGES = new Set(["SCRIPT_REVIEW", "VISUAL_PLAN_REVIEW"]);
 
 export default function ProjectPage() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -187,14 +192,84 @@ export default function ProjectPage() {
     }
   }, [run, refreshRun]);
 
+  const handleApproveVisualPlan = useCallback(async () => {
+    if (!run) return;
+    setApproving(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/approve-visual-plan`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviewer: "agent" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Approve failed (${res.status})`);
+      }
+      setStatusMessage("Visual plan approved");
+      await refreshRun(run.id);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Approve failed");
+    } finally {
+      setApproving(false);
+    }
+  }, [run, refreshRun]);
+
+  const handleGenerateVisualPlan = useCallback(async () => {
+    if (!run) return;
+    setGenerating(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/generate-visual-plan`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model_key: "qwen3-4b" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Generate failed (${res.status})`);
+      }
+      setStatusMessage("Visual plan generation started");
+      setTimeout(() => refreshRun(run.id), 2000);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Generate failed");
+    } finally {
+      setGenerating(false);
+    }
+  }, [run, refreshRun]);
+
+  const handleRestartVisualPlan = useCallback(async () => {
+    if (!run) return;
+    setRestarting(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/restart`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ stage: "VISUAL_PLAN_GENERATING" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Restart failed (${res.status})`);
+      }
+      setStatusMessage("Restarting visual plan generation…");
+      await refreshRun(run.id);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Restart failed");
+    } finally {
+      setRestarting(false);
+    }
+  }, [run, refreshRun]);
+
   // ---- derived state ----
 
   const currentStage = run?.current_stage ?? "IDEA_READY";
   const isFailed = run?.status === "failed";
   const isScriptStage = SCRIPT_STAGES.has(currentStage);
+  const isVisualPlanStage = VISUAL_PLAN_STAGES.has(currentStage);
   const isEditable = EDITABLE_STAGES.has(currentStage);
   const isGenerating = currentStage === "SCRIPT_GENERATING";
-
+  const isVPGenerating = currentStage === "VISUAL_PLAN_GENERATING";
   // ---- action bar config ----
 
   const buildActionBar = (): {
@@ -203,11 +278,31 @@ export default function ProjectPage() {
     generate: ActionConfig;
     restart: ActionConfig;
   } => {
+    // Visual plan stages
+    if (isVisualPlanStage) {
+      return {
+        save: { visible: false },
+        approve: {
+          visible: currentStage === "VISUAL_PLAN_REVIEW",
+          disabled: approving,
+          loading: approving,
+          onClick: handleApproveVisualPlan,
+          label: "Approve Visual Plan",
+        },
+        generate: { visible: false },
+        restart: {
+          visible: currentStage === "VISUAL_PLAN_REVIEW",
+          disabled: restarting,
+          loading: restarting,
+          onClick: handleRestartVisualPlan,
+          label: "Regenerate Plan",
+        },
+      };
+    }
+
+    // Script stages and transitions
     return {
-      save: {
-        // Save is handled inside the editor components directly
-        visible: false,
-      },
+      save: { visible: false },
       approve: {
         visible: currentStage === "SCRIPT_REVIEW",
         disabled: approving,
@@ -216,18 +311,18 @@ export default function ProjectPage() {
         label: "Approve Script",
       },
       generate: {
-        visible: currentStage === "IDEA_READY",
+        visible: currentStage === "IDEA_READY" || currentStage === "SCRIPT_REVIEW",
         disabled: generating,
         loading: generating,
-        onClick: handleGenerate,
-        label: "Generate Script",
+        onClick: currentStage === "SCRIPT_REVIEW" ? handleGenerateVisualPlan : handleGenerate,
+        label: currentStage === "SCRIPT_REVIEW" ? "Generate Visual Plan" : "Generate Script",
       },
       restart: {
         visible: currentStage === "SCRIPT_REVIEW",
         disabled: restarting,
         loading: restarting,
         onClick: handleRestart,
-        label: "Regenerate",
+        label: "Regenerate Script",
       },
     };
   };
@@ -362,6 +457,27 @@ export default function ProjectPage() {
         </div>
       )}
 
+      {/* Visual plan generating indicator */}
+      {run && isVPGenerating && (
+        <div
+          data-testid="vp-generating-indicator"
+          style={{
+            textAlign: "center",
+            padding: 32,
+            background: "#f0fdf4",
+            borderRadius: 8,
+            border: "1px solid #bbf7d0",
+            color: "#166534",
+            marginBottom: 24,
+          }}
+        >
+          <p style={{ margin: "0 0 4px", fontWeight: 600 }}>Generating Visual Plan…</p>
+          <p style={{ margin: 0, fontSize: 13 }}>
+            The AI model is creating scene descriptions. This may take a moment.
+          </p>
+        </div>
+      )}
+
       {/* Script editor area */}
       {run && isScriptStage && !isGenerating && (
         <div style={{ marginBottom: 24 }}>
@@ -438,6 +554,17 @@ export default function ProjectPage() {
               />
             </div>
           )}
+        </div>
+      )}
+      {/* Visual plan editor area */}
+      {run && isVisualPlanStage && !isVPGenerating && (
+        <div style={{ marginBottom: 24 }}>
+          <VisualPlanEditor
+            runId={run.id}
+            readOnly={currentStage !== "VISUAL_PLAN_REVIEW"}
+            onSuccess={() => setStatusMessage("Visual plan saved")}
+            onError={(_action, msg) => setStatusMessage(msg)}
+          />
         </div>
       )}
 

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -5,6 +5,7 @@
  * - PipelineStepper (header progress bar)
  * - Editor area with markdown / structured toggle (during script stages)
  * - VisualPlanEditor (during visual plan stages)
+ * - VisualAssetGrid + ProgressDialog (during visual asset stages)
  * - StageActionBar (save / approve / generate / restart)
  */
 
@@ -18,6 +19,9 @@ import StageActionBar, {
 import MarkdownScriptEditor from "../components/creator/MarkdownScriptEditor";
 import StructuredScriptEditor from "../components/creator/StructuredScriptEditor";
 import VisualPlanEditor from "../components/creator/VisualPlanEditor";
+import VisualAssetGrid from "../components/creator/VisualAssetGrid";
+import ProgressDialog from "../components/creator/ProgressDialog";
+import ModelSelector from "../components/creator/ModelSelector";
 
 const API_BASE = "/api/creator";
 
@@ -46,6 +50,9 @@ const SCRIPT_STAGES = new Set(["SCRIPT_GENERATING", "SCRIPT_REVIEW"]);
 // Visual plan stages where the editor area is relevant
 const VISUAL_PLAN_STAGES = new Set(["VISUAL_PLAN_GENERATING", "VISUAL_PLAN_REVIEW"]);
 
+// Visual asset stages
+const VISUAL_ASSET_STAGES = new Set(["VISUAL_ASSET_GENERATING", "VISUAL_ASSET_REVIEW"]);
+
 // Stages where editing is allowed (not generating)
 const EDITABLE_STAGES = new Set(["SCRIPT_REVIEW", "VISUAL_PLAN_REVIEW"]);
 
@@ -69,6 +76,16 @@ export default function ProjectPage() {
 
   // Status toast
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  // Progress dialog state
+  const [progressOpen, setProgressOpen] = useState(false);
+  const [progressExpectedStage, setProgressExpectedStage] = useState("VISUAL_ASSET_GENERATING");
+
+  // Scene regeneration model override
+  const [regenModelKey, setRegenModelKey] = useState<string | null>(null);
+
+  // Asset grid refresh key — increment to force re-fetch
+  const [assetRefreshKey, setAssetRefreshKey] = useState(0);
 
   // ---- data fetching ----
 
@@ -121,7 +138,7 @@ export default function ProjectPage() {
     }
   }, []);
 
-  // ---- actions ----
+  // ---- script actions ----
 
   const handleApprove = useCallback(async () => {
     if (!run) return;
@@ -192,6 +209,8 @@ export default function ProjectPage() {
     }
   }, [run, refreshRun]);
 
+  // ---- visual plan actions ----
+
   const handleApproveVisualPlan = useCallback(async () => {
     if (!run) return;
     setApproving(true);
@@ -261,15 +280,174 @@ export default function ProjectPage() {
     }
   }, [run, refreshRun]);
 
+  // ---- visual asset actions ----
+
+  const handleGenerateAllAssets = useCallback(async () => {
+    if (!run) return;
+    setGenerating(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/generate-visual-assets`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model_key: "sd15" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Generate assets failed (${res.status})`);
+      }
+      setStatusMessage("Visual asset generation started");
+      setProgressExpectedStage("VISUAL_ASSET_GENERATING");
+      setProgressOpen(true);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Generate assets failed");
+    } finally {
+      setGenerating(false);
+    }
+  }, [run]);
+
+  const handleRegenerateScene = useCallback(
+    async (sceneId: string) => {
+      if (!run) return;
+      setStatusMessage(null);
+      try {
+        const payload: Record<string, string> = {};
+        if (regenModelKey) payload.model_key = regenModelKey;
+        const res = await fetch(
+          `${API_BASE}/runs/${run.id}/visual-plan/scenes/${sceneId}/regenerate-image`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          },
+        );
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          throw new Error(body?.detail ?? `Regenerate failed (${res.status})`);
+        }
+        setStatusMessage(`Regenerating scene ${sceneId}…`);
+        // Refresh asset grid after a short delay for task to complete
+        setTimeout(() => {
+          setAssetRefreshKey((k) => k + 1);
+          if (run) refreshRun(run.id);
+        }, 3000);
+      } catch (err) {
+        setStatusMessage(err instanceof Error ? err.message : "Regenerate failed");
+      }
+    },
+    [run, regenModelKey, refreshRun],
+  );
+
+  const handleGenerateScene = useCallback(
+    async (sceneId: string) => {
+      if (!run) return;
+      setStatusMessage(null);
+      try {
+        const res = await fetch(
+          `${API_BASE}/runs/${run.id}/visual-plan/scenes/${sceneId}/generate-image`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ model_key: "sd15" }),
+          },
+        );
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          throw new Error(body?.detail ?? `Generate scene failed (${res.status})`);
+        }
+        setStatusMessage(`Generating image for scene ${sceneId}…`);
+        setTimeout(() => {
+          setAssetRefreshKey((k) => k + 1);
+          if (run) refreshRun(run.id);
+        }, 3000);
+      } catch (err) {
+        setStatusMessage(err instanceof Error ? err.message : "Generate scene failed");
+      }
+    },
+    [run, refreshRun],
+  );
+
+  const handleApproveAssets = useCallback(async () => {
+    if (!run) return;
+    setApproving(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/approve-visual-assets`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviewer: "agent" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Approve failed (${res.status})`);
+      }
+      setStatusMessage("Visual assets approved");
+      await refreshRun(run.id);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Approve assets failed");
+    } finally {
+      setApproving(false);
+    }
+  }, [run, refreshRun]);
+
+  const handleRestartAssets = useCallback(async () => {
+    if (!run) return;
+    setRestarting(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/restart`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ stage: "VISUAL_ASSET_GENERATING" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Restart failed (${res.status})`);
+      }
+      setStatusMessage("Restarting visual asset generation…");
+      await refreshRun(run.id);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Restart failed");
+    } finally {
+      setRestarting(false);
+    }
+  }, [run, refreshRun]);
+
+  // ---- progress dialog callbacks ----
+
+  const handleProgressComplete = useCallback(
+    (stage: string) => {
+      setProgressOpen(false);
+      setStatusMessage(`Generation complete — now at ${stage}`);
+      if (run) {
+        refreshRun(run.id);
+        setAssetRefreshKey((k) => k + 1);
+      }
+    },
+    [run, refreshRun],
+  );
+
+  const handleProgressFailed = useCallback(
+    (_stage: string) => {
+      setProgressOpen(false);
+      setStatusMessage("Generation failed");
+      if (run) refreshRun(run.id);
+    },
+    [run, refreshRun],
+  );
+
   // ---- derived state ----
 
   const currentStage = run?.current_stage ?? "IDEA_READY";
   const isFailed = run?.status === "failed";
   const isScriptStage = SCRIPT_STAGES.has(currentStage);
   const isVisualPlanStage = VISUAL_PLAN_STAGES.has(currentStage);
+  const isVisualAssetStage = VISUAL_ASSET_STAGES.has(currentStage);
   const isEditable = EDITABLE_STAGES.has(currentStage);
   const isGenerating = currentStage === "SCRIPT_GENERATING";
   const isVPGenerating = currentStage === "VISUAL_PLAN_GENERATING";
+  const isVAGenerating = currentStage === "VISUAL_ASSET_GENERATING";
+
   // ---- action bar config ----
 
   const buildActionBar = (): {
@@ -278,6 +456,34 @@ export default function ProjectPage() {
     generate: ActionConfig;
     restart: ActionConfig;
   } => {
+    // Visual asset stages
+    if (isVisualAssetStage) {
+      return {
+        save: { visible: false },
+        approve: {
+          visible: currentStage === "VISUAL_ASSET_REVIEW",
+          disabled: approving,
+          loading: approving,
+          onClick: handleApproveAssets,
+          label: "Approve Assets",
+        },
+        generate: {
+          visible: currentStage === "VISUAL_ASSET_REVIEW",
+          disabled: generating,
+          loading: generating,
+          onClick: handleGenerateAllAssets,
+          label: "Regenerate All",
+        },
+        restart: {
+          visible: currentStage === "VISUAL_ASSET_REVIEW",
+          disabled: restarting,
+          loading: restarting,
+          onClick: handleRestartAssets,
+          label: "Restart Assets",
+        },
+      };
+    }
+
     // Visual plan stages
     if (isVisualPlanStage) {
       return {
@@ -556,6 +762,7 @@ export default function ProjectPage() {
           )}
         </div>
       )}
+
       {/* Visual plan editor area */}
       {run && isVisualPlanStage && !isVPGenerating && (
         <div style={{ marginBottom: 24 }}>
@@ -566,6 +773,136 @@ export default function ProjectPage() {
             onError={(_action, msg) => setStatusMessage(msg)}
           />
         </div>
+      )}
+
+      {/* Visual asset area */}
+      {run && isVisualAssetStage && (
+        <div data-testid="visual-asset-section" style={{ marginBottom: 24 }}>
+          {/* Asset generating indicator (inline — ProgressDialog also available) */}
+          {isVAGenerating && !progressOpen && (
+            <div
+              data-testid="va-generating-indicator"
+              style={{
+                textAlign: "center",
+                padding: 32,
+                background: "#fdf4ff",
+                borderRadius: 8,
+                border: "1px solid #e9d5ff",
+                color: "#6b21a8",
+                marginBottom: 16,
+              }}
+            >
+              <p style={{ margin: "0 0 4px", fontWeight: 600 }}>Generating Visual Assets…</p>
+              <p style={{ margin: 0, fontSize: 13 }}>
+                Image generation is in progress. This may take several minutes.
+              </p>
+            </div>
+          )}
+
+          {/* Asset grid — visible in review or generating (read-only during generation) */}
+          <VisualAssetGrid
+            key={assetRefreshKey}
+            runId={run.id}
+            apiBase={API_BASE}
+            readOnly={isVAGenerating}
+            onSelect={() => setStatusMessage("Active asset updated")}
+            onError={(_action, msg) => setStatusMessage(msg)}
+          />
+
+          {/* Scene-level regeneration controls (review stage only) */}
+          {currentStage === "VISUAL_ASSET_REVIEW" && (
+            <div
+              data-testid="scene-regen-controls"
+              style={{
+                marginTop: 16,
+                padding: 16,
+                border: "1px solid #e5e7eb",
+                borderRadius: 8,
+                background: "#f9fafb",
+              }}
+            >
+              <h4 style={{ margin: "0 0 12px", fontSize: 14, fontWeight: 600 }}>
+                Regenerate Single Scene
+              </h4>
+
+              {/* Model override selector — image category only */}
+              <div style={{ marginBottom: 12 }}>
+                <ModelSelector
+                  categories={["image"]}
+                  apiBase={API_BASE}
+                  onSelectionChange={(_cat, modelKey) => setRegenModelKey(modelKey)}
+                />
+              </div>
+
+              {/* Scene action buttons — rendered per-scene from the asset grid data is impractical
+                  without lifting scene IDs up. Instead, provide a text input for scene ID. */}
+              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <input
+                  data-testid="scene-id-input"
+                  type="text"
+                  placeholder="Scene ID (e.g. scene-0)"
+                  style={{
+                    flex: 1,
+                    padding: "6px 10px",
+                    border: "1px solid #d1d5db",
+                    borderRadius: 4,
+                    fontSize: 13,
+                  }}
+                  id="regen-scene-id"
+                />
+                <button
+                  data-testid="regen-scene-btn"
+                  onClick={() => {
+                    const input = document.getElementById("regen-scene-id") as HTMLInputElement;
+                    const sceneId = input?.value?.trim();
+                    if (sceneId) handleRegenerateScene(sceneId);
+                  }}
+                  style={{
+                    padding: "6px 16px",
+                    border: "1px solid #d1d5db",
+                    borderRadius: 4,
+                    background: "#fff",
+                    cursor: "pointer",
+                    fontSize: 13,
+                  }}
+                >
+                  Regenerate
+                </button>
+                <button
+                  data-testid="generate-scene-btn"
+                  onClick={() => {
+                    const input = document.getElementById("regen-scene-id") as HTMLInputElement;
+                    const sceneId = input?.value?.trim();
+                    if (sceneId) handleGenerateScene(sceneId);
+                  }}
+                  style={{
+                    padding: "6px 16px",
+                    border: "1px solid #d1d5db",
+                    borderRadius: 4,
+                    background: "#fff",
+                    cursor: "pointer",
+                    fontSize: 13,
+                  }}
+                >
+                  Generate New
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ProgressDialog for long-running generation */}
+      {run && (
+        <ProgressDialog
+          open={progressOpen}
+          runId={run.id}
+          expectedStage={progressExpectedStage}
+          apiBase={API_BASE}
+          onComplete={handleProgressComplete}
+          onFailed={handleProgressFailed}
+          onClose={() => setProgressOpen(false)}
+        />
       )}
 
       {/* Stage action bar */}

--- a/apps/studio-web/src/pages/ReviewPage.tsx
+++ b/apps/studio-web/src/pages/ReviewPage.tsx
@@ -1,3 +1,471 @@
+/**
+ * ReviewPage — read-only review of a run's outputs at various stages.
+ *
+ * Fetches the run detail plus preview artifacts and renders:
+ * - PipelineStepper (header progress bar)
+ * - Script section (from GET /runs/:runId/script)
+ * - Visual plan section (from GET /runs/:runId/visual-plan)
+ * - Visual assets section (from GET /runs/:runId/visual-assets)
+ * - Audio / subtitle / video preview metadata (from GET /runs/:runId/preview)
+ * - Links back to the ProjectPage editor for each stage
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams, Link } from "react-router-dom";
+
+import PipelineStepper from "../components/creator/PipelineStepper";
+
+const API_BASE = "/api/creator";
+
+// --------------- types ---------------
+
+interface RunDetail {
+  id: number;
+  project_id: number;
+  current_stage: string;
+  status: string;
+  restart_from: string | null;
+}
+
+interface PreviewData {
+  run_id: number;
+  current_stage: string;
+  video: {
+    id: number;
+    path: string;
+    render_profile: string | null;
+    created_at: string;
+  } | null;
+  audio: {
+    id: number;
+    path: string;
+    model_used: string;
+    created_at: string;
+  } | null;
+  subtitle: {
+    id: number;
+    path: string;
+    format: string;
+    created_at: string;
+  } | null;
+}
+
+interface ScriptData {
+  script: string | null;
+  structured_script: Record<string, unknown> | null;
+}
+
+interface VisualPlanScene {
+  scene_id: string;
+  description: string;
+  image_prompt: string;
+}
+
+// Stages that have passed script
+const POST_SCRIPT_STAGES = new Set([
+  "SCRIPT_REVIEW",
+  "VISUAL_PLAN_GENERATING",
+  "VISUAL_PLAN_REVIEW",
+  "VISUAL_ASSET_GENERATING",
+  "VISUAL_ASSET_REVIEW",
+  "AUDIO_GENERATING",
+  "SUBTITLE_GENERATING",
+  "RENDER_GENERATING",
+  "FINAL_REVIEW",
+  "PUBLISHED",
+]);
+
+const POST_VISUAL_PLAN_STAGES = new Set([
+  "VISUAL_PLAN_REVIEW",
+  "VISUAL_ASSET_GENERATING",
+  "VISUAL_ASSET_REVIEW",
+  "AUDIO_GENERATING",
+  "SUBTITLE_GENERATING",
+  "RENDER_GENERATING",
+  "FINAL_REVIEW",
+  "PUBLISHED",
+]);
+
+const POST_VISUAL_ASSET_STAGES = new Set([
+  "VISUAL_ASSET_REVIEW",
+  "AUDIO_GENERATING",
+  "SUBTITLE_GENERATING",
+  "RENDER_GENERATING",
+  "FINAL_REVIEW",
+  "PUBLISHED",
+]);
+
+const POST_AUDIO_STAGES = new Set([
+  "SUBTITLE_GENERATING",
+  "RENDER_GENERATING",
+  "FINAL_REVIEW",
+  "PUBLISHED",
+]);
+
+// --------------- styles ---------------
+
+const cardStyle: React.CSSProperties = {
+  marginBottom: 24,
+  padding: 20,
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  background: "#fff",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  marginBottom: 12,
+};
+
+const sectionTitle: React.CSSProperties = {
+  fontSize: 16,
+  fontWeight: 600,
+  margin: 0,
+};
+
+const metaStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "#6b7280",
+};
+
+const editLinkStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "#4285f4",
+  textDecoration: "none",
+};
+
+const previewBoxStyle: React.CSSProperties = {
+  padding: 12,
+  background: "#f9fafb",
+  borderRadius: 6,
+  fontSize: 13,
+  fontFamily: "monospace",
+  whiteSpace: "pre-wrap",
+  overflowX: "auto",
+  maxHeight: 300,
+  overflowY: "auto",
+};
+
+// --------------- component ---------------
+
 export default function ReviewPage() {
-  return <div>ReviewPage</div>;
+  const { runId } = useParams<{ runId: string }>();
+  const numericRunId = Number(runId);
+
+  const [run, setRun] = useState<RunDetail | null>(null);
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+  const [script, setScript] = useState<ScriptData | null>(null);
+  const [scenes, setScenes] = useState<VisualPlanScene[]>([]);
+  const [assets, setAssets] = useState<Record<string, { asset_path: string; model_used: string; is_active: boolean }[]>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // Fetch run detail
+      const runRes = await fetch(`${API_BASE}/runs/${numericRunId}`);
+      if (!runRes.ok) {
+        if (runRes.status === 404) throw new Error("Run not found");
+        throw new Error(`Failed to load run (${runRes.status})`);
+      }
+      const runData: RunDetail = await runRes.json();
+      setRun(runData);
+
+      const stage = runData.current_stage;
+
+      // Fetch script if past idea
+      if (POST_SCRIPT_STAGES.has(stage)) {
+        const scriptRes = await fetch(`${API_BASE}/runs/${numericRunId}/script`);
+        if (scriptRes.ok) {
+          setScript(await scriptRes.json());
+        }
+      }
+
+      // Fetch visual plan if past script
+      if (POST_VISUAL_PLAN_STAGES.has(stage)) {
+        const vpRes = await fetch(`${API_BASE}/runs/${numericRunId}/visual-plan`);
+        if (vpRes.ok) {
+          const vpData = await vpRes.json();
+          setScenes(vpData.scenes ?? []);
+        }
+      }
+
+      // Fetch visual assets if past visual plan
+      if (POST_VISUAL_ASSET_STAGES.has(stage)) {
+        const assetsRes = await fetch(`${API_BASE}/runs/${numericRunId}/visual-assets`);
+        if (assetsRes.ok) {
+          setAssets(await assetsRes.json());
+        }
+      }
+
+      // Fetch preview (audio/subtitle/video) if past visual assets
+      if (POST_AUDIO_STAGES.has(stage)) {
+        const previewRes = await fetch(`${API_BASE}/runs/${numericRunId}/preview`);
+        if (previewRes.ok) {
+          setPreview(await previewRes.json());
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An unexpected error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }, [numericRunId]);
+
+  useEffect(() => {
+    if (!Number.isNaN(numericRunId)) {
+      fetchAll();
+    }
+  }, [numericRunId, fetchAll]);
+
+  // ---- render ----
+
+  if (Number.isNaN(numericRunId)) {
+    return (
+      <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
+        <p style={{ color: "#b91c1c" }}>Invalid run ID.</p>
+        <Link to="/runs" style={{ color: "#4285f4" }}>Back to projects</Link>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading review"
+        style={{ maxWidth: 720, margin: "0 auto", padding: 24, textAlign: "center", color: "#6b7280" }}
+      >
+        Loading review...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
+        <div
+          role="alert"
+          style={{
+            padding: "12px 16px",
+            background: "#fef2f2",
+            border: "1px solid #fca5a5",
+            borderRadius: 6,
+            color: "#b91c1c",
+            fontSize: 13,
+            marginBottom: 16,
+          }}
+        >
+          {error}
+        </div>
+        <Link to="/runs" style={{ color: "#4285f4", fontSize: 13 }}>Back to projects</Link>
+      </div>
+    );
+  }
+
+  if (!run) {
+    return (
+      <div style={{ maxWidth: 720, margin: "0 auto", padding: 24 }}>
+        <p>Run not found.</p>
+        <Link to="/runs" style={{ color: "#4285f4" }}>Back to projects</Link>
+      </div>
+    );
+  }
+
+  const stage = run.current_stage;
+  const isFailed = run.status === "failed";
+  const editUrl = `/projects/${run.project_id}`;
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: 24 }}>
+      {/* Header */}
+      <div style={{ marginBottom: 16 }}>
+        <Link to="/runs" style={{ color: "#6b7280", fontSize: 12, textDecoration: "none" }}>
+          &larr; Projects
+        </Link>
+        <h1 style={{ fontSize: 22, fontWeight: 700, margin: "8px 0 4px" }}>
+          Review &mdash; Run #{run.id}
+        </h1>
+        <span style={{ fontSize: 12, color: "#6b7280" }}>
+          Stage: {stage} &middot; Status: {run.status}
+          {isFailed && <span style={{ color: "#b91c1c", fontWeight: 600 }}> (FAILED)</span>}
+        </span>
+      </div>
+
+      {/* Pipeline stepper */}
+      <div style={{ marginBottom: 24 }}>
+        <PipelineStepper currentStage={stage} failed={isFailed} />
+      </div>
+
+      {/* Script section */}
+      {script && (
+        <div style={cardStyle} data-testid="review-script-section">
+          <div style={headerStyle}>
+            <h3 style={sectionTitle}>Script</h3>
+            <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
+          </div>
+          <div style={previewBoxStyle}>
+            {script.script ?? "(No script content)"}
+          </div>
+        </div>
+      )}
+
+      {/* Visual Plan section */}
+      {scenes.length > 0 && (
+        <div style={cardStyle} data-testid="review-visual-plan-section">
+          <div style={headerStyle}>
+            <h3 style={sectionTitle}>Visual Plan ({scenes.length} scenes)</h3>
+            <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {scenes.map((scene) => (
+              <div
+                key={scene.scene_id}
+                style={{
+                  padding: 12,
+                  background: "#f9fafb",
+                  borderRadius: 6,
+                  border: "1px solid #e5e7eb",
+                }}
+              >
+                <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 4 }}>
+                  {scene.scene_id}
+                </div>
+                <div style={{ fontSize: 13, color: "#374151", marginBottom: 4 }}>
+                  {scene.description}
+                </div>
+                <div style={metaStyle}>Prompt: {scene.image_prompt}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Visual Assets section */}
+      {Object.keys(assets).length > 0 && (
+        <div style={cardStyle} data-testid="review-assets-section">
+          <div style={headerStyle}>
+            <h3 style={sectionTitle}>Visual Assets</h3>
+            <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {Object.entries(assets).map(([sceneId, sceneAssets]) => (
+              <div key={sceneId}>
+                <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 4 }}>{sceneId}</div>
+                {sceneAssets.map((asset, idx) => (
+                  <div
+                    key={idx}
+                    style={{
+                      padding: 8,
+                      background: asset.is_active ? "#f0fdf4" : "#f9fafb",
+                      borderRadius: 4,
+                      border: asset.is_active ? "1px solid #bbf7d0" : "1px solid #e5e7eb",
+                      marginBottom: 4,
+                    }}
+                  >
+                    <span style={{ fontSize: 13 }}>{asset.asset_path}</span>
+                    <span style={metaStyle}> &middot; Model: {asset.model_used}</span>
+                    {asset.is_active && (
+                      <span style={{ fontSize: 11, color: "#166534", fontWeight: 600, marginLeft: 8 }}>
+                        ACTIVE
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Audio section */}
+      {preview?.audio && (
+        <div style={cardStyle} data-testid="review-audio-section">
+          <div style={headerStyle}>
+            <h3 style={sectionTitle}>Audio</h3>
+            <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
+          </div>
+          <div style={{ fontSize: 13 }}>
+            <div><strong>Path:</strong> {preview.audio.path}</div>
+            <div><strong>Model:</strong> {preview.audio.model_used}</div>
+            <div style={metaStyle}>Created: {preview.audio.created_at}</div>
+          </div>
+        </div>
+      )}
+
+      {/* Subtitle section */}
+      {preview?.subtitle && (
+        <div style={cardStyle} data-testid="review-subtitle-section">
+          <div style={headerStyle}>
+            <h3 style={sectionTitle}>Subtitles</h3>
+            <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
+          </div>
+          <div style={{ fontSize: 13 }}>
+            <div><strong>Path:</strong> {preview.subtitle.path}</div>
+            <div><strong>Format:</strong> {preview.subtitle.format}</div>
+            <div style={metaStyle}>Created: {preview.subtitle.created_at}</div>
+          </div>
+        </div>
+      )}
+
+      {/* Video / Render section */}
+      {preview?.video && (
+        <div style={cardStyle} data-testid="review-video-section">
+          <div style={headerStyle}>
+            <h3 style={sectionTitle}>Rendered Video</h3>
+            <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
+          </div>
+          <div style={{ fontSize: 13 }}>
+            <div><strong>Path:</strong> {preview.video.path}</div>
+            <div><strong>Profile:</strong> {preview.video.render_profile ?? "default"}</div>
+            <div style={metaStyle}>Created: {preview.video.created_at}</div>
+          </div>
+        </div>
+      )}
+
+      {/* No content message for very early stages */}
+      {!script && scenes.length === 0 && Object.keys(assets).length === 0 && !preview && (
+        <div
+          data-testid="review-empty"
+          style={{
+            textAlign: "center",
+            padding: 32,
+            background: "#f9fafb",
+            borderRadius: 8,
+            border: "1px dashed #d1d5db",
+            color: "#6b7280",
+          }}
+        >
+          <p style={{ margin: "0 0 8px", fontWeight: 600 }}>No outputs yet</p>
+          <p style={{ margin: 0, fontSize: 13 }}>
+            This run hasn't generated any content to review.{" "}
+            <Link to={editUrl} style={{ color: "#4285f4" }}>Go to editor</Link>
+          </p>
+        </div>
+      )}
+
+      {/* Back to editor CTA */}
+      <div style={{ textAlign: "center", marginTop: 24 }}>
+        <Link
+          to={editUrl}
+          style={{
+            display: "inline-block",
+            padding: "10px 24px",
+            background: "#4285f4",
+            color: "#fff",
+            borderRadius: 6,
+            textDecoration: "none",
+            fontSize: 14,
+            fontWeight: 600,
+          }}
+        >
+          Back to Editor
+        </Link>
+      </div>
+    </div>
+  );
 }

--- a/apps/studio-web/src/pages/RunsPage.tsx
+++ b/apps/studio-web/src/pages/RunsPage.tsx
@@ -1,3 +1,334 @@
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+const API_BASE = "/api/creator";
+
+interface ProjectSummary {
+  id: number;
+  title: string | null;
+  source_type: "idea" | "markdown" | "url";
+  status: "draft" | "active" | "completed" | "archived";
+  created_at: string;
+  updated_at: string;
+}
+
+interface ProjectListResponse {
+  projects: ProjectSummary[];
+  total: number;
+}
+
+const PAGE_SIZE = 20;
+
+const STATUS_COLORS: Record<string, { bg: string; fg: string }> = {
+  draft: { bg: "#e2e8f0", fg: "#475569" },
+  active: { bg: "#dbeafe", fg: "#1e40af" },
+  completed: { bg: "#dcfce7", fg: "#166534" },
+  archived: { bg: "#f3f4f6", fg: "#6b7280" },
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  idea: "Idea",
+  markdown: "Markdown",
+  url: "URL",
+};
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
 export default function RunsPage() {
-  return <div>RunsPage</div>;
+  const navigate = useNavigate();
+
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProjects = useCallback(async (pageOffset: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${API_BASE}/projects?limit=${PAGE_SIZE}&offset=${pageOffset}`,
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Failed to load projects (${res.status})`);
+      }
+      const data: ProjectListResponse = await res.json();
+      setProjects(data.projects);
+      setTotal(data.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An unexpected error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProjects(offset);
+  }, [fetchProjects, offset]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: 24 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24 }}>
+        <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>Projects</h1>
+        <button
+          onClick={() => navigate("/create")}
+          style={{
+            padding: "8px 16px",
+            background: "#4285f4",
+            color: "#fff",
+            border: "none",
+            borderRadius: 6,
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          + New Project
+        </button>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div
+          role="alert"
+          style={{
+            padding: "12px 16px",
+            marginBottom: 16,
+            background: "#fef2f2",
+            border: "1px solid #fca5a5",
+            borderRadius: 6,
+            color: "#b91c1c",
+            fontSize: 13,
+          }}
+        >
+          {error}
+          <button
+            onClick={() => fetchProjects(offset)}
+            style={{
+              marginLeft: 12,
+              padding: "4px 10px",
+              background: "#b91c1c",
+              color: "#fff",
+              border: "none",
+              borderRadius: 4,
+              fontSize: 12,
+              cursor: "pointer",
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {loading && (
+        <div
+          role="status"
+          aria-label="Loading projects"
+          style={{
+            textAlign: "center",
+            padding: 48,
+            color: "#6b7280",
+            fontSize: 14,
+          }}
+        >
+          Loading projects…
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !error && projects.length === 0 && (
+        <div
+          data-testid="empty-state"
+          style={{
+            textAlign: "center",
+            padding: 48,
+            color: "#6b7280",
+            background: "#f9fafb",
+            borderRadius: 8,
+            border: "1px dashed #d1d5db",
+          }}
+        >
+          <p style={{ fontSize: 16, fontWeight: 600, margin: "0 0 8px" }}>
+            No projects yet
+          </p>
+          <p style={{ fontSize: 13, margin: "0 0 16px" }}>
+            Create your first short-form video project to get started.
+          </p>
+          <button
+            onClick={() => navigate("/create")}
+            style={{
+              padding: "8px 16px",
+              background: "#4285f4",
+              color: "#fff",
+              border: "none",
+              borderRadius: 6,
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Create Project
+          </button>
+        </div>
+      )}
+
+      {/* Project list */}
+      {!loading && projects.length > 0 && (
+        <>
+          <table
+            style={{
+              width: "100%",
+              borderCollapse: "collapse",
+              fontSize: 14,
+            }}
+          >
+            <thead>
+              <tr
+                style={{
+                  borderBottom: "2px solid #e5e7eb",
+                  textAlign: "left",
+                }}
+              >
+                <th style={{ padding: "8px 12px", fontWeight: 600, color: "#374151" }}>
+                  Title
+                </th>
+                <th style={{ padding: "8px 12px", fontWeight: 600, color: "#374151" }}>
+                  Source
+                </th>
+                <th style={{ padding: "8px 12px", fontWeight: 600, color: "#374151" }}>
+                  Status
+                </th>
+                <th style={{ padding: "8px 12px", fontWeight: 600, color: "#374151" }}>
+                  Created
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {projects.map((proj) => {
+                const statusColor = STATUS_COLORS[proj.status] ?? STATUS_COLORS.draft;
+                return (
+                  <tr
+                    key={proj.id}
+                    role="link"
+                    tabIndex={0}
+                    onClick={() => navigate(`/projects/${proj.id}`)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        navigate(`/projects/${proj.id}`);
+                      }
+                    }}
+                    style={{
+                      borderBottom: "1px solid #f3f4f6",
+                      cursor: "pointer",
+                    }}
+                    onMouseEnter={(e) => {
+                      (e.currentTarget as HTMLTableRowElement).style.background = "#f9fafb";
+                    }}
+                    onMouseLeave={(e) => {
+                      (e.currentTarget as HTMLTableRowElement).style.background = "";
+                    }}
+                  >
+                    <td style={{ padding: "10px 12px", fontWeight: 500 }}>
+                      {proj.title || "Untitled"}
+                    </td>
+                    <td style={{ padding: "10px 12px", color: "#6b7280" }}>
+                      {SOURCE_LABELS[proj.source_type] ?? proj.source_type}
+                    </td>
+                    <td style={{ padding: "10px 12px" }}>
+                      <span
+                        style={{
+                          display: "inline-block",
+                          padding: "2px 8px",
+                          borderRadius: 9999,
+                          fontSize: 12,
+                          fontWeight: 500,
+                          background: statusColor.bg,
+                          color: statusColor.fg,
+                        }}
+                      >
+                        {proj.status}
+                      </span>
+                    </td>
+                    <td style={{ padding: "10px 12px", color: "#6b7280" }}>
+                      {formatDate(proj.created_at)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+
+          {/* Pagination */}
+          {total > PAGE_SIZE && (
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginTop: 16,
+                fontSize: 13,
+                color: "#6b7280",
+              }}
+            >
+              <span>
+                Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+              </span>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button
+                  disabled={currentPage <= 1}
+                  onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                  aria-label="Previous page"
+                  style={{
+                    padding: "6px 12px",
+                    border: "1px solid #d1d5db",
+                    borderRadius: 4,
+                    background: currentPage <= 1 ? "#f3f4f6" : "#fff",
+                    color: currentPage <= 1 ? "#9ca3af" : "#374151",
+                    cursor: currentPage <= 1 ? "not-allowed" : "pointer",
+                    fontSize: 13,
+                  }}
+                >
+                  Previous
+                </button>
+                <button
+                  disabled={currentPage >= totalPages}
+                  onClick={() => setOffset(offset + PAGE_SIZE)}
+                  aria-label="Next page"
+                  style={{
+                    padding: "6px 12px",
+                    border: "1px solid #d1d5db",
+                    borderRadius: 4,
+                    background: currentPage >= totalPages ? "#f3f4f6" : "#fff",
+                    color: currentPage >= totalPages ? "#9ca3af" : "#374151",
+                    cursor: currentPage >= totalPages ? "not-allowed" : "pointer",
+                    fontSize: 13,
+                  }}
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
 }

--- a/apps/studio-web/src/test-setup.ts
+++ b/apps/studio-web/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/apps/studio-web/vitest.config.ts
+++ b/apps/studio-web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});

--- a/apps/studio-web/vitest.config.ts
+++ b/apps/studio-web/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/test-setup.ts'],
   },
 });

--- a/apps/worker-orchestrator/celery_app.py
+++ b/apps/worker-orchestrator/celery_app.py
@@ -1,11 +1,25 @@
 # pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false
-"""Minimal Celery app configuration."""
+"""Minimal Celery app configuration with structured JSON logging."""
 
+import logging
 import os
+import sys
 
 from celery import Celery
+from celery.signals import after_setup_logger
+
+# Add packages to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../..", "packages"))
+
+from creator_service.logging_config import setup_json_logging
 
 redis_url = os.getenv("REDIS_URL", "redis://redis:6379/0")
 
 celery_app = Celery("worker-orchestrator", broker=redis_url, backend=redis_url)
 celery_app.conf.task_default_queue = "creator"
+
+
+@after_setup_logger.connect
+def setup_celery_logger(logger: logging.Logger, **kwargs: object) -> None:
+    """Configure Celery logger with JSON formatting."""
+    setup_json_logging(service_name="worker", level="INFO")

--- a/apps/worker-orchestrator/requirements.txt
+++ b/apps/worker-orchestrator/requirements.txt
@@ -1,3 +1,7 @@
 celery
 redis
 watchfiles
+
+
+# Dev dependencies
+ruff

--- a/apps/worker-orchestrator/requirements.txt
+++ b/apps/worker-orchestrator/requirements.txt
@@ -5,3 +5,4 @@ watchfiles
 
 # Dev dependencies
 ruff
+pytest

--- a/apps/worker-orchestrator/tasks/generate_audio.py
+++ b/apps/worker-orchestrator/tasks/generate_audio.py
@@ -1,1 +1,246 @@
-"""Placeholder for generate_audio."""
+# pyright: reportMissingImports=false
+"""Celery task for run-level TTS audio generation via audio providers.
+
+Consumes an approved script draft and generates a single audio artifact
+for the run. The artifact is stored via the audio_service.
+
+Key design decisions:
+- Audio generation is all-or-nothing for a run (no partial scene-level success).
+- GPU lock is held for the full generation window when required by provider.
+- Audio is saved to local filesystem: data/artifacts/{run_id}/audio/audio.wav
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
+
+try:
+    import redis
+except ImportError:
+    redis = None  # type: ignore[assignment]
+
+from celery_app import celery_app
+
+try:
+    from creator_domain.models.stage import RunStage
+except ImportError:
+    from models.stage import RunStage
+
+try:
+    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from creator_provider.registry import ProviderRegistry
+except ImportError:
+    from gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from registry import ProviderRegistry
+
+try:
+    from creator_service.run_service import run_service as _run_service
+except ImportError:
+    from run_service import run_service as _run_service
+
+try:
+    from creator_service.audio_service import audio_service as _audio_service
+except ImportError:
+    from audio_service import audio_service as _audio_service
+
+try:
+    from creator_service.script_service import script_service as _script_service
+except ImportError:
+    from script_service import script_service as _script_service
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_STAGES = frozenset({RunStage.VISUAL_ASSET_REVIEW, RunStage.AUDIO_GENERATING})
+
+# Stages where writing SUBTITLE_GENERATING or FAILED is safe — the run
+# hasn't advanced past audio generation.
+_SAFE_STAGES = frozenset({RunStage.VISUAL_ASSET_REVIEW.value, RunStage.AUDIO_GENERATING.value})
+
+
+class _StageGuardError(ValueError):
+    """Raised when a run is not in an acceptable stage for audio generation.
+
+    This is a validation/rejection error — the run state must NOT be mutated
+    to FAILED because the run may already be in a later stage.
+    """
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _get_redis_client() -> Any | None:
+    if redis is None:
+        return None
+    return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+@celery_app.task(bind=True, name="generate_audio")
+def generate_audio(
+    self,
+    run_id: int,
+    tts_model: str = "piper",
+    voice: str = "en_US-lessac-medium",
+) -> dict[str, object]:
+    start_time = datetime.now(timezone.utc)
+    start_iso = start_time.isoformat()
+    task_id = str(getattr(getattr(self, "request", None), "id", None) or f"run-{run_id}")
+
+    provider_type: str | None = None
+    endpoint: str | None = None
+    gpu_lock_acquired_at: str | None = None
+    gpu_lock_released_at: str | None = None
+    redis_client: Any | None = None
+    lock_acquired = False
+
+    async def _run_task() -> dict[str, object]:
+        nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
+        nonlocal redis_client, lock_acquired
+
+        # 1. Stage guard — reject before any side effects.
+        run = await _run_service.storage.get_run(run_id)
+        if run is None:
+            raise _StageGuardError(f"Run {run_id} not found")
+
+        try:
+            current = RunStage(run["current_stage"])
+        except ValueError as exc:
+            raise _StageGuardError(
+                f"Run {run_id} has invalid stage {run['current_stage']!r}"
+            ) from exc
+        if current not in _ALLOWED_STAGES:
+            raise _StageGuardError(
+                f"Run {run_id} is in stage {current.value}, "
+                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+            )
+
+        # 2. Fetch approved script draft.
+        draft = await _script_service.get_active_draft(run_id)
+        if draft is None:
+            raise _StageGuardError(f"No script draft found for run {run_id}")
+
+        script_text = (draft.markdown_content or "").strip()
+        if not script_text and draft.structured_script:
+            script_text = "\n".join(
+                (section.display_text or section.text).strip()
+                for section in draft.structured_script
+                if (section.display_text or section.text).strip()
+            )
+
+        if not script_text:
+            raise _StageGuardError(f"Script draft for run {run_id} has no content")
+
+        # 3. Provider resolution (sync — blocks briefly, fine in Celery worker).
+        registry = ProviderRegistry.create_default()
+        entry = registry.resolve(tts_model)
+        provider = registry.get_provider(tts_model)
+
+        provider_type = entry.provider_type
+        endpoint = entry.endpoint
+
+        # 4. GPU lock acquisition (sync).
+        if entry.requires_gpu:
+            redis_client = _get_redis_client()
+            if redis_client is None:
+                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+            acquire_gpu_lock(redis_client, task_id)
+            lock_acquired = True
+            gpu_lock_acquired_at = _utc_now_iso()
+
+        audio_path = f"data/artifacts/{run_id}/audio/audio.wav"
+
+        try:
+            # 5. Generate audio via provider.
+            params = dict(entry.default_params or {})
+            params["voice"] = voice
+            params["output_path"] = audio_path
+            await provider.generate(script_text, params)
+
+            # 6. Save audio artifact via service.
+            artifact = await _audio_service.create_artifact(
+                run_id=run_id,
+                path=audio_path,
+                model_used=tts_model,
+                provider_type=entry.provider_type,
+                voice=voice,
+            )
+
+            # 7. Atomic success transition.
+            applied, _ = await _run_service.storage.conditional_update_run(
+                run_id,
+                {
+                    "current_stage": RunStage.SUBTITLE_GENERATING.value,
+                    "status": "running",
+                },
+                expected_stages=_SAFE_STAGES,
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during audio generation -- skipping transition",
+                    run_id,
+                )
+        finally:
+            if lock_acquired:
+                try:
+                    release_gpu_lock(redis_client, task_id)
+                    gpu_lock_released_at = _utc_now_iso()
+                except Exception:
+                    logger.exception("Failed to release GPU lock for task %s", task_id)
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "tts_model": tts_model,
+            "voice": voice,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+            "gpu_lock_released_at": gpu_lock_released_at,
+            "audio_artifact_id": artifact.id,
+            "audio_path": artifact.path,
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "success",
+        }
+
+    try:
+        return asyncio.run(_run_task())
+    except _StageGuardError:
+        # Validation rejection — do NOT mutate run state to FAILED.
+        raise
+    except Exception:
+        # Unexpected error — atomic conditional fail.
+        try:
+            applied, _ = asyncio.run(
+                _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.FAILED.value,
+                        "status": "failed",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during audio generation -- skipping FAILED transition",
+                    run_id,
+                )
+        except Exception:
+            logger.exception("Failed to mark run %d as FAILED after task error", run_id)
+
+        raise

--- a/apps/worker-orchestrator/tasks/generate_scene_image.py
+++ b/apps/worker-orchestrator/tasks/generate_scene_image.py
@@ -292,6 +292,7 @@ def generate_scene_image(
                     )
             except Exception:
                 logger.exception("Failed to mark run %d as FAILED", run_id)
+                raise
         else:
             # At least some scenes succeeded — advance to VISUAL_ASSET_REVIEW.
             overall_status = "success" if failed == 0 else "partial"

--- a/apps/worker-orchestrator/tasks/generate_scene_image.py
+++ b/apps/worker-orchestrator/tasks/generate_scene_image.py
@@ -1,1 +1,358 @@
-"""Placeholder for generate_scene_image."""
+# pyright: reportMissingImports=false
+"""Celery task for scene image generation via image providers.
+
+Consumes an approved visual plan and generates images for one or all scenes.
+Each generated image is stored as a VisualAsset via the visual_asset_service.
+
+Key design decisions:
+- Partial failure: if one scene fails, already-completed scenes are retained.
+- Regenerated assets are created as new versions; is_active defaults to True
+  (auto-replaces the previous active asset for the scene).
+- GPU lock is held per-scene, not for the entire batch, so other tasks can
+  interleave between scenes.
+- Images are saved to local filesystem: data/artifacts/{run_id}/scenes/
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
+
+try:
+    import redis
+except ImportError:
+    redis = None  # type: ignore[assignment]
+
+from celery_app import celery_app
+
+try:
+    from creator_domain.models.stage import RunStage
+except ImportError:
+    from models.stage import RunStage
+
+try:
+    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from creator_provider.registry import ProviderRegistry
+except ImportError:
+    from gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from registry import ProviderRegistry
+
+try:
+    from creator_service.run_service import run_service as _run_service
+except ImportError:
+    from run_service import run_service as _run_service
+
+try:
+    from creator_service.visual_plan_service import visual_plan_service as _visual_plan_service
+except ImportError:
+    from visual_plan_service import visual_plan_service as _visual_plan_service
+
+try:
+    from creator_service.visual_asset_service import visual_asset_service as _visual_asset_service
+except ImportError:
+    from visual_asset_service import visual_asset_service as _visual_asset_service
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_STAGES = frozenset({RunStage.VISUAL_PLAN_REVIEW, RunStage.VISUAL_ASSET_GENERATING})
+
+# Stages where writing VISUAL_ASSET_REVIEW or FAILED is safe — the run
+# hasn't advanced past image generation.
+_SAFE_STAGES = frozenset({RunStage.VISUAL_PLAN_REVIEW.value, RunStage.VISUAL_ASSET_GENERATING.value})
+
+# Base directory for artifact storage (relative to project root).
+_ARTIFACTS_BASE = os.getenv("ARTIFACTS_BASE", "data/artifacts")
+
+
+class _StageGuardError(ValueError):
+    """Raised when a run is not in an acceptable stage for image generation.
+
+    This is a validation/rejection error — the run state must NOT be mutated
+    to FAILED because the run may already be in a later stage.
+    """
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _get_redis_client() -> Any | None:
+    if redis is None:
+        return None
+    return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+def _asset_dir(run_id: int) -> Path:
+    """Return the directory for storing scene image assets."""
+    return Path(_ARTIFACTS_BASE) / str(run_id) / "scenes"
+
+
+@celery_app.task(bind=True, name="generate_scene_image")
+def generate_scene_image(
+    self,
+    run_id: int,
+    scene_id: str | None = None,
+    model_key: str = "sd15",
+    prompt_override: str | None = None,
+    is_active: bool = True,
+) -> dict[str, object]:
+    """Generate image(s) for visual plan scenes.
+
+    Args:
+        run_id: The run to generate images for.
+        scene_id: If provided, generate for this single scene only.
+                  If None, generate for ALL scenes in the visual plan.
+        model_key: Image model to use (default: sd15).
+        prompt_override: If provided, overrides the scene prompt for a
+                         single-scene generation. Ignored for all-scene mode.
+        is_active: Whether new assets are marked active (default: True).
+    """
+    start_time = datetime.now(timezone.utc)
+    start_iso = start_time.isoformat()
+    task_id = str(getattr(getattr(self, "request", None), "id", None) or f"run-{run_id}")
+
+    provider_type: str | None = None
+    endpoint: str | None = None
+
+    async def _run_task() -> dict[str, object]:
+        nonlocal provider_type, endpoint
+
+        # 1. Stage guard — reject before any side effects.
+        run = await _run_service.storage.get_run(run_id)
+        if run is None:
+            raise _StageGuardError(f"Run {run_id} not found")
+
+        try:
+            current = RunStage(run["current_stage"])
+        except ValueError as exc:
+            raise _StageGuardError(
+                f"Run {run_id} has invalid stage {run['current_stage']!r}"
+            ) from exc
+        if current not in _ALLOWED_STAGES:
+            raise _StageGuardError(
+                f"Run {run_id} is in stage {current.value}, "
+                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+            )
+
+        # 2. Fetch active visual plan.
+        plan = await _visual_plan_service.get_active_plan(run_id)
+        if plan is None:
+            raise _StageGuardError(f"No active visual plan for run {run_id}")
+
+        # 3. Determine scenes to generate.
+        if scene_id is not None:
+            # Single-scene mode.
+            target_scenes = [s for s in plan.scenes if s.scene_id == scene_id]
+            if not target_scenes:
+                raise _StageGuardError(
+                    f"Scene '{scene_id}' not found in visual plan for run {run_id}"
+                )
+        else:
+            target_scenes = list(plan.scenes)
+
+        if not target_scenes:
+            raise _StageGuardError(f"Visual plan for run {run_id} has no scenes")
+
+        # 4. Provider resolution (sync — blocks briefly, fine in Celery worker).
+        registry = ProviderRegistry.create_default()
+        entry = registry.resolve(model_key)
+        provider = registry.get_provider(model_key)
+
+        provider_type = entry.provider_type
+        endpoint = entry.endpoint
+
+        # 5. Ensure artifact output directory exists.
+        asset_dir = _asset_dir(run_id)
+        asset_dir.mkdir(parents=True, exist_ok=True)
+
+        # 6. Generate images per scene.
+        results: list[dict[str, object]] = []
+        failed_scenes: list[dict[str, object]] = []
+        redis_client: Any | None = None
+
+        for target_scene in target_scenes:
+            scene_result: dict[str, object] = {
+                "scene_id": target_scene.scene_id,
+                "status": "pending",
+            }
+            lock_acquired = False
+            gpu_lock_acquired_at: str | None = None
+            gpu_lock_released_at: str | None = None
+
+            try:
+                # Use prompt override for single-scene, otherwise scene prompt.
+                effective_prompt = (
+                    prompt_override
+                    if prompt_override is not None and scene_id is not None
+                    else target_scene.prompt
+                )
+
+                # GPU lock (per-scene).
+                if entry.requires_gpu:
+                    redis_client = _get_redis_client()
+                    if redis_client is None:
+                        raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+                    scene_task_id = f"{task_id}:{target_scene.scene_id}"
+                    acquire_gpu_lock(redis_client, scene_task_id)
+                    lock_acquired = True
+                    gpu_lock_acquired_at = _utc_now_iso()
+
+                try:
+                    # Generate image via provider.
+                    params = dict(entry.default_params or {})
+                    image_result = await provider.generate(effective_prompt, params)
+
+                    # Determine asset path — provider returns image_path,
+                    # or we construct one.
+                    if hasattr(image_result, "image_path") and image_result.image_path:
+                        asset_path = image_result.image_path
+                    else:
+                        # Fallback: store in our artifacts directory.
+                        asset_path = str(asset_dir / f"{target_scene.scene_id}.png")
+
+                    # Save as visual asset via service.
+                    asset = await _visual_asset_service.create_asset(
+                        run_id=run_id,
+                        scene_id=target_scene.scene_id,
+                        asset_path=asset_path,
+                        prompt_snapshot=effective_prompt,
+                        model_used=model_key,
+                        provider_type=entry.provider_type,
+                        is_active=is_active,
+                    )
+
+                    scene_result.update({
+                        "status": "success",
+                        "asset_id": asset.id,
+                        "asset_path": asset.asset_path,
+                        "version": asset.version,
+                        "gpu_lock_acquired_at": gpu_lock_acquired_at,
+                        "gpu_lock_released_at": None,  # Set below
+                    })
+                finally:
+                    if lock_acquired:
+                        try:
+                            scene_task_id = f"{task_id}:{target_scene.scene_id}"
+                            release_gpu_lock(redis_client, scene_task_id)
+                            gpu_lock_released_at = _utc_now_iso()
+                            scene_result["gpu_lock_released_at"] = gpu_lock_released_at
+                        except Exception:
+                            logger.exception(
+                                "Failed to release GPU lock for scene %s",
+                                target_scene.scene_id,
+                            )
+
+                results.append(scene_result)
+
+            except Exception as exc:
+                scene_result.update({
+                    "status": "failed",
+                    "error": str(exc),
+                })
+                failed_scenes.append(scene_result)
+                logger.error(
+                    "Failed to generate image for scene %s in run %d: %s",
+                    target_scene.scene_id,
+                    run_id,
+                    exc,
+                )
+                # Continue to next scene — partial failure tolerance.
+
+        # 7. Determine overall status and stage transition.
+        total = len(target_scenes)
+        succeeded = len(results)
+        failed = len(failed_scenes)
+
+        if failed == total:
+            # All scenes failed — mark run as FAILED.
+            overall_status = "failed"
+            try:
+                applied, _ = await _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.FAILED.value,
+                        "status": "failed",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+                if not applied:
+                    logger.info(
+                        "Run %d stage changed during image generation -- skipping FAILED transition",
+                        run_id,
+                    )
+            except Exception:
+                logger.exception("Failed to mark run %d as FAILED", run_id)
+        else:
+            # At least some scenes succeeded — advance to VISUAL_ASSET_REVIEW.
+            overall_status = "success" if failed == 0 else "partial"
+            applied, _ = await _run_service.storage.conditional_update_run(
+                run_id,
+                {
+                    "current_stage": RunStage.VISUAL_ASSET_REVIEW.value,
+                    "status": "running",
+                },
+                expected_stages=_SAFE_STAGES,
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during image generation -- skipping transition",
+                    run_id,
+                )
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "model_key": model_key,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "scene_id": scene_id,
+            "total_scenes": total,
+            "succeeded": succeeded,
+            "failed": failed,
+            "scene_results": results + failed_scenes,
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": overall_status,
+        }
+
+    try:
+        return asyncio.run(_run_task())
+    except _StageGuardError:
+        # Validation rejection — do NOT mutate run state to FAILED.
+        raise
+    except Exception:
+        # Unexpected error (not scene-level) — atomic conditional fail.
+        try:
+            applied, _ = asyncio.run(
+                _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.FAILED.value,
+                        "status": "failed",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during image generation -- skipping FAILED transition",
+                    run_id,
+                )
+        except Exception:
+            logger.exception("Failed to mark run %d as FAILED after task error", run_id)
+
+        raise

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -48,6 +48,9 @@ logger = logging.getLogger(__name__)
 
 _ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 
+# Stages where marking FAILED is safe — the run hasn't advanced past generation.
+_FAIL_SAFE_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
+
 
 class _StageGuardError(ValueError):
     """Raised when a run is not in an acceptable stage for generation.
@@ -186,16 +189,34 @@ def generate_script(
         # A stale/duplicate task should not downgrade a run already past generation.
         raise
     except Exception:
+        # Only mark FAILED if the run is still in a generating-compatible stage.
+        # A competing task may have already advanced the run (e.g. to SCRIPT_REVIEW);
+        # unconditionally writing FAILED would downgrade it.
         try:
-            asyncio.run(
-                _run_service.storage.update_run(
+            async def _conditional_fail() -> None:
+                run = await _run_service.storage.get_run(run_id)
+                if run is None:
+                    return
+                try:
+                    current = RunStage(run["current_stage"])
+                except ValueError:
+                    return  # Corrupted stage — don't make it worse
+                if current not in _FAIL_SAFE_STAGES:
+                    logger.info(
+                        "Run %d is in stage %s — skipping FAILED transition",
+                        run_id,
+                        current.value,
+                    )
+                    return
+                await _run_service.storage.update_run(
                     run_id,
                     {
                         "current_stage": RunStage.FAILED.value,
                         "status": "failed",
                     },
                 )
-            )
+
+            asyncio.run(_conditional_fail())
         except Exception:
             logger.exception("Failed to mark run %d as FAILED after task error", run_id)
 

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -49,6 +49,14 @@ logger = logging.getLogger(__name__)
 _ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 
 
+class _StageGuardError(ValueError):
+    """Raised when a run is not in an acceptable stage for generation.
+
+    This is a validation/rejection error — the run state must NOT be mutated
+    to FAILED because the run may already be in a later stage (e.g. SCRIPT_REVIEW).
+    """
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -96,11 +104,16 @@ def generate_script(
         # Stage guard: verify run is in an acceptable stage
         run = await _run_service.storage.get_run(run_id)
         if run is None:
-            raise ValueError(f"Run {run_id} not found")
+            raise _StageGuardError(f"Run {run_id} not found")
 
-        current = RunStage(run["current_stage"])
+        try:
+            current = RunStage(run["current_stage"])
+        except ValueError as exc:
+            raise _StageGuardError(
+                f"Run {run_id} has invalid stage {run['current_stage']!r}"
+            ) from exc
         if current not in _ALLOWED_STAGES:
-            raise ValueError(
+            raise _StageGuardError(
                 f"Run {run_id} is in stage {current.value}, "
                 f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
             )
@@ -164,6 +177,11 @@ def generate_script(
             "status": "success",
             "error": None,
         }
+    except _StageGuardError:
+        # Validation rejection — do NOT mutate run state to FAILED.
+        # A stale/duplicate task should not downgrade a run already past generation.
+        raise
+
     except Exception:
         try:
             asyncio.run(

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -99,8 +99,11 @@ def generate_script(
     redis_client: Any | None = None
     lock_acquired = False
 
-    async def _check_stage_guard() -> None:
-        """Validate run stage BEFORE any provider/GPU setup."""
+    async def _run_task() -> dict[str, object]:
+        nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
+        nonlocal redis_client, lock_acquired
+
+        # 1. Stage guard — reject before any side effects.
         run = await _run_service.storage.get_run(run_id)
         if run is None:
             raise _StageGuardError(f"Run {run_id} not found")
@@ -117,29 +120,7 @@ def generate_script(
                 f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
             )
 
-    async def _run_generation() -> str:
-        """Execute generation, save draft, advance stage."""
-        params = dict(entry.default_params or {})
-        generated = await provider.generate(prompt, params)
-        await _script_service.save_draft(
-            run_id=run_id,
-            source_type="generated_by_model",
-            markdown_content=generated,
-        )
-        await _run_service.storage.update_run(
-            run_id,
-            {
-                "current_stage": RunStage.SCRIPT_REVIEW.value,
-                "status": "running",
-            },
-        )
-        return generated
-
-    try:
-        # Stage guard FIRST — before any provider resolution or GPU lock.
-        # If the run is not in an allowed stage, reject immediately.
-        asyncio.run(_check_stage_guard())
-
+        # 2. Provider resolution (sync — blocks briefly, fine in Celery worker).
         registry = ProviderRegistry.create_default()
         entry = registry.resolve(model_key)
         provider = registry.get_provider(model_key)
@@ -147,6 +128,7 @@ def generate_script(
         provider_type = entry.provider_type
         endpoint = entry.endpoint
 
+        # 3. GPU lock acquisition (sync).
         if entry.requires_gpu:
             redis_client = _get_redis_client()
             if redis_client is None:
@@ -156,7 +138,21 @@ def generate_script(
             gpu_lock_acquired_at = _utc_now_iso()
 
         try:
-            asyncio.run(_run_generation())
+            # 4. Generation, save, advance stage.
+            params = dict(entry.default_params or {})
+            generated = await provider.generate(prompt, params)
+            await _script_service.save_draft(
+                run_id=run_id,
+                source_type="generated_by_model",
+                markdown_content=generated,
+            )
+            await _run_service.storage.update_run(
+                run_id,
+                {
+                    "current_stage": RunStage.SCRIPT_REVIEW.value,
+                    "status": "running",
+                },
+            )
         finally:
             if lock_acquired:
                 try:
@@ -182,11 +178,13 @@ def generate_script(
             "status": "success",
             "error": None,
         }
+
+    try:
+        return asyncio.run(_run_task())
     except _StageGuardError:
         # Validation rejection — do NOT mutate run state to FAILED.
         # A stale/duplicate task should not downgrade a run already past generation.
         raise
-
     except Exception:
         try:
             asyncio.run(

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 from datetime import datetime, timezone
@@ -42,6 +43,10 @@ try:
     from creator_service.script_service import script_service as _script_service
 except ImportError:
     from script_service import script_service as _script_service
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 
 
 def _utc_now_iso() -> str:
@@ -86,6 +91,36 @@ def generate_script(
     redis_client: Any | None = None
     lock_acquired = False
 
+    async def _run_generation() -> str:
+        """Single async coroutine wrapping all async operations."""
+        # Stage guard: verify run is in an acceptable stage
+        run = await _run_service.storage.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        current = RunStage(run["current_stage"])
+        if current not in _ALLOWED_STAGES:
+            raise ValueError(
+                f"Run {run_id} is in stage {current.value}, "
+                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+            )
+
+        params = dict(entry.default_params or {})
+        generated = await provider.generate(prompt, params)
+        await _script_service.save_draft(
+            run_id=run_id,
+            source_type="generated_by_model",
+            markdown_content=generated,
+        )
+        await _run_service.storage.update_run(
+            run_id,
+            {
+                "current_stage": RunStage.SCRIPT_REVIEW.value,
+                "status": "running",
+            },
+        )
+        return generated
+
     try:
         registry = ProviderRegistry.create_default()
         entry = registry.resolve(model_key)
@@ -103,28 +138,14 @@ def generate_script(
             gpu_lock_acquired_at = _utc_now_iso()
 
         try:
-            params = dict(entry.default_params or {})
-            generated_script = asyncio.run(provider.generate(prompt, params))
-            asyncio.run(
-                _script_service.save_draft(
-                    run_id=run_id,
-                    source_type="generated_by_model",
-                    markdown_content=generated_script,
-                )
-            )
-            asyncio.run(
-                _run_service.storage.update_run(
-                    run_id,
-                    {
-                        "current_stage": RunStage.SCRIPT_REVIEW.value,
-                        "status": "running",
-                    },
-                )
-            )
+            asyncio.run(_run_generation())
         finally:
             if lock_acquired:
-                release_gpu_lock(redis_client, task_id)
-                gpu_lock_released_at = _utc_now_iso()
+                try:
+                    release_gpu_lock(redis_client, task_id)
+                    gpu_lock_released_at = _utc_now_iso()
+                except Exception:
+                    logger.exception("Failed to release GPU lock for task %s", task_id)
 
         end_time = datetime.now(timezone.utc)
         duration_seconds = (end_time - start_time).total_seconds()
@@ -143,7 +164,7 @@ def generate_script(
             "status": "success",
             "error": None,
         }
-    except Exception as exc:
+    except Exception:
         try:
             asyncio.run(
                 _run_service.storage.update_run(
@@ -155,22 +176,6 @@ def generate_script(
                 )
             )
         except Exception:
-            pass
+            logger.exception("Failed to mark run %d as FAILED after task error", run_id)
 
-        end_time = datetime.now(timezone.utc)
-        duration_seconds = (end_time - start_time).total_seconds()
-        return {
-            "task_id": task_id,
-            "run_id": run_id,
-            "model_key": model_key,
-            "provider_type": provider_type,
-            "endpoint": endpoint,
-            "gpu_lock_acquired_at": gpu_lock_acquired_at,
-            "gpu_lock_released_at": gpu_lock_released_at,
-            "prompt_summary": idea_brief[:200],
-            "start_time": start_iso,
-            "end_time": end_time.isoformat(),
-            "duration_seconds": duration_seconds,
-            "status": "failed",
-            "error": str(exc),
-        }
+        raise

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -99,9 +99,8 @@ def generate_script(
     redis_client: Any | None = None
     lock_acquired = False
 
-    async def _run_generation() -> str:
-        """Single async coroutine wrapping all async operations."""
-        # Stage guard: verify run is in an acceptable stage
+    async def _check_stage_guard() -> None:
+        """Validate run stage BEFORE any provider/GPU setup."""
         run = await _run_service.storage.get_run(run_id)
         if run is None:
             raise _StageGuardError(f"Run {run_id} not found")
@@ -118,6 +117,8 @@ def generate_script(
                 f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
             )
 
+    async def _run_generation() -> str:
+        """Execute generation, save draft, advance stage."""
         params = dict(entry.default_params or {})
         generated = await provider.generate(prompt, params)
         await _script_service.save_draft(
@@ -135,6 +136,10 @@ def generate_script(
         return generated
 
     try:
+        # Stage guard FIRST — before any provider resolution or GPU lock.
+        # If the run is not in an allowed stage, reject immediately.
+        asyncio.run(_check_stage_guard())
+
         registry = ProviderRegistry.create_default()
         entry = registry.resolve(model_key)
         provider = registry.get_provider(model_key)

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -149,13 +149,29 @@ def generate_script(
                 source_type="generated_by_model",
                 markdown_content=generated,
             )
-            await _run_service.storage.update_run(
-                run_id,
-                {
-                    "current_stage": RunStage.SCRIPT_REVIEW.value,
-                    "status": "running",
-                },
-            )
+            # Conditional success transition: only advance if run is still in a
+            # generating-compatible stage. A competing task may have already
+            # advanced the run past generation.
+            current_run = await _run_service.storage.get_run(run_id)
+            if current_run is not None:
+                try:
+                    cur_stage = RunStage(current_run["current_stage"])
+                except ValueError:
+                    cur_stage = None
+                if cur_stage in _FAIL_SAFE_STAGES:
+                    await _run_service.storage.update_run(
+                        run_id,
+                        {
+                            "current_stage": RunStage.SCRIPT_REVIEW.value,
+                            "status": "running",
+                        },
+                    )
+                else:
+                    logger.info(
+                        "Run %d is in stage %s after generation -- skipping SCRIPT_REVIEW transition",
+                        run_id,
+                        current_run["current_stage"],
+                    )
         finally:
             if lock_acquired:
                 try:

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -1,1 +1,176 @@
-"""Placeholder for generate_script."""
+# pyright: reportMissingImports=false
+"""Celery task for script generation via model providers."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
+
+try:
+    import redis
+except ImportError:
+    redis = None  # type: ignore[assignment]
+
+from celery_app import celery_app
+
+try:
+    from creator_domain.models.stage import RunStage
+except ImportError:
+    from models.stage import RunStage
+
+try:
+    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from creator_provider.registry import ProviderRegistry
+except ImportError:
+    from gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from registry import ProviderRegistry
+
+try:
+    from creator_service.run_service import run_service as _run_service
+except ImportError:
+    from run_service import run_service as _run_service
+
+try:
+    from creator_service.script_service import script_service as _script_service
+except ImportError:
+    from script_service import script_service as _script_service
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _build_prompt(idea_brief: str, instructions: str | None) -> str:
+    idea = idea_brief.strip()
+    if not instructions:
+        return idea
+
+    extra = instructions.strip()
+    if not extra:
+        return idea
+
+    return f"{idea}\n\nAdditional instructions:\n{extra}"
+
+
+def _get_redis_client() -> Any | None:
+    if redis is None:
+        return None
+    return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+@celery_app.task(bind=True, name="generate_script")
+def generate_script(
+    self,
+    run_id: int,
+    idea_brief: str,
+    model_key: str = "qwen3-4b",
+    instructions: str | None = None,
+) -> dict[str, object]:
+    start_time = datetime.now(timezone.utc)
+    start_iso = start_time.isoformat()
+    task_id = str(getattr(getattr(self, "request", None), "id", None) or f"run-{run_id}")
+    prompt = _build_prompt(idea_brief, instructions)
+
+    provider_type: str | None = None
+    endpoint: str | None = None
+    gpu_lock_acquired_at: str | None = None
+    gpu_lock_released_at: str | None = None
+    redis_client: Any | None = None
+    lock_acquired = False
+
+    try:
+        registry = ProviderRegistry.create_default()
+        entry = registry.resolve(model_key)
+        provider = registry.get_provider(model_key)
+
+        provider_type = entry.provider_type
+        endpoint = entry.endpoint
+
+        if entry.requires_gpu:
+            redis_client = _get_redis_client()
+            if redis_client is None:
+                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+            acquire_gpu_lock(redis_client, task_id)
+            lock_acquired = True
+            gpu_lock_acquired_at = _utc_now_iso()
+
+        try:
+            params = dict(entry.default_params or {})
+            generated_script = asyncio.run(provider.generate(prompt, params))
+            asyncio.run(
+                _script_service.save_draft(
+                    run_id=run_id,
+                    source_type="generated_by_model",
+                    markdown_content=generated_script,
+                )
+            )
+            asyncio.run(
+                _run_service.storage.update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.SCRIPT_REVIEW.value,
+                        "status": "running",
+                    },
+                )
+            )
+        finally:
+            if lock_acquired:
+                release_gpu_lock(redis_client, task_id)
+                gpu_lock_released_at = _utc_now_iso()
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "model_key": model_key,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+            "gpu_lock_released_at": gpu_lock_released_at,
+            "prompt_summary": idea_brief[:200],
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "success",
+            "error": None,
+        }
+    except Exception as exc:
+        try:
+            asyncio.run(
+                _run_service.storage.update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.FAILED.value,
+                        "status": "failed",
+                    },
+                )
+            )
+        except Exception:
+            pass
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "model_key": model_key,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+            "gpu_lock_released_at": gpu_lock_released_at,
+            "prompt_summary": idea_brief[:200],
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "failed",
+            "error": str(exc),
+        }

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -48,8 +48,10 @@ logger = logging.getLogger(__name__)
 
 _ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 
-# Stages where marking FAILED is safe — the run hasn't advanced past generation.
-_FAIL_SAFE_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
+# Stages where writing SCRIPT_REVIEW or FAILED is safe — the run hasn't
+# advanced past generation.  Used as the expected_stages argument to
+# conditional_update_run for atomic compare-and-set.
+_SAFE_STAGES = frozenset({RunStage.IDEA_READY.value, RunStage.SCRIPT_GENERATING.value})
 
 
 class _StageGuardError(ValueError):
@@ -149,29 +151,22 @@ def generate_script(
                 source_type="generated_by_model",
                 markdown_content=generated,
             )
-            # Conditional success transition: only advance if run is still in a
-            # generating-compatible stage. A competing task may have already
-            # advanced the run past generation.
-            current_run = await _run_service.storage.get_run(run_id)
-            if current_run is not None:
-                try:
-                    cur_stage = RunStage(current_run["current_stage"])
-                except ValueError:
-                    cur_stage = None
-                if cur_stage in _FAIL_SAFE_STAGES:
-                    await _run_service.storage.update_run(
-                        run_id,
-                        {
-                            "current_stage": RunStage.SCRIPT_REVIEW.value,
-                            "status": "running",
-                        },
-                    )
-                else:
-                    logger.info(
-                        "Run %d is in stage %s after generation -- skipping SCRIPT_REVIEW transition",
-                        run_id,
-                        current_run["current_stage"],
-                    )
+            # Atomic success transition: only advance if run is still in a
+            # generating-compatible stage. Uses compare-and-set at the storage
+            # layer — no TOCTOU gap.
+            applied, _ = await _run_service.storage.conditional_update_run(
+                run_id,
+                {
+                    "current_stage": RunStage.SCRIPT_REVIEW.value,
+                    "status": "running",
+                },
+                expected_stages=_SAFE_STAGES,
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during generation -- skipping SCRIPT_REVIEW transition",
+                    run_id,
+                )
         finally:
             if lock_acquired:
                 try:
@@ -205,34 +200,24 @@ def generate_script(
         # A stale/duplicate task should not downgrade a run already past generation.
         raise
     except Exception:
-        # Only mark FAILED if the run is still in a generating-compatible stage.
-        # A competing task may have already advanced the run (e.g. to SCRIPT_REVIEW);
-        # unconditionally writing FAILED would downgrade it.
+        # Atomic conditional fail: only mark FAILED if run is still in a
+        # generating-compatible stage. Uses compare-and-set — no TOCTOU gap.
         try:
-            async def _conditional_fail() -> None:
-                run = await _run_service.storage.get_run(run_id)
-                if run is None:
-                    return
-                try:
-                    current = RunStage(run["current_stage"])
-                except ValueError:
-                    return  # Corrupted stage — don't make it worse
-                if current not in _FAIL_SAFE_STAGES:
-                    logger.info(
-                        "Run %d is in stage %s — skipping FAILED transition",
-                        run_id,
-                        current.value,
-                    )
-                    return
-                await _run_service.storage.update_run(
+            applied, _ = asyncio.run(
+                _run_service.storage.conditional_update_run(
                     run_id,
                     {
                         "current_stage": RunStage.FAILED.value,
                         "status": "failed",
                     },
+                    expected_stages=_SAFE_STAGES,
                 )
-
-            asyncio.run(_conditional_fail())
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during generation -- skipping FAILED transition",
+                    run_id,
+                )
         except Exception:
             logger.exception("Failed to mark run %d as FAILED after task error", run_id)
 

--- a/apps/worker-orchestrator/tasks/generate_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_subtitles.py
@@ -1,1 +1,258 @@
-"""Placeholder for generate_subtitles."""
+# pyright: reportMissingImports=false
+"""Celery task for run-level subtitle generation via subtitle providers.
+
+Consumes an approved script draft AND optionally audio artifact timing data
+and generates a single subtitle artifact for the run (SRT format).
+
+Key design decisions:
+- Subtitle generation is all-or-nothing for a run (no partial scene-level success).
+- GPU lock is held for the full generation window when required by provider.
+- Subtitles are saved to local filesystem: data/artifacts/{run_id}/subtitles/subtitles.srt
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
+
+try:
+    import redis
+except ImportError:
+    redis = None  # type: ignore[assignment]
+
+from celery_app import celery_app
+
+try:
+    from creator_domain.models.stage import RunStage
+except ImportError:
+    from models.stage import RunStage
+
+try:
+    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from creator_provider.registry import ProviderRegistry
+except ImportError:
+    from gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from registry import ProviderRegistry
+
+try:
+    from creator_service.run_service import run_service as _run_service
+except ImportError:
+    from run_service import run_service as _run_service
+
+try:
+    from creator_service.subtitle_service import subtitle_service as _subtitle_service
+except ImportError:
+    from subtitle_service import subtitle_service as _subtitle_service
+
+try:
+    from creator_service.script_service import script_service as _script_service
+except ImportError:
+    from script_service import script_service as _script_service
+
+try:
+    from creator_service.audio_service import audio_service as _audio_service
+except ImportError:
+    from audio_service import audio_service as _audio_service
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_STAGES = frozenset({RunStage.AUDIO_GENERATING, RunStage.SUBTITLE_GENERATING})
+
+# Stages where writing RENDER_GENERATING or FAILED is safe — the run
+# hasn't advanced past subtitle generation.
+_SAFE_STAGES = frozenset({RunStage.AUDIO_GENERATING.value, RunStage.SUBTITLE_GENERATING.value})
+
+
+class _StageGuardError(ValueError):
+    """Raised when a run is not in an acceptable stage for subtitle generation.
+
+    This is a validation/rejection error — the run state must NOT be mutated
+    to FAILED because the run may already be in a later stage.
+    """
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _get_redis_client() -> Any | None:
+    if redis is None:
+        return None
+    return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+@celery_app.task(bind=True, name="generate_subtitles")
+def generate_subtitles(
+    self,
+    run_id: int,
+    subtitle_model: str = "whisper-tiny",
+    subtitle_format: str = "srt",
+) -> dict[str, object]:
+    start_time = datetime.now(timezone.utc)
+    start_iso = start_time.isoformat()
+    task_id = str(getattr(getattr(self, "request", None), "id", None) or f"run-{run_id}")
+
+    provider_type: str | None = None
+    endpoint: str | None = None
+    gpu_lock_acquired_at: str | None = None
+    gpu_lock_released_at: str | None = None
+    redis_client: Any | None = None
+    lock_acquired = False
+
+    async def _run_task() -> dict[str, object]:
+        nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
+        nonlocal redis_client, lock_acquired
+
+        # 1. Stage guard — reject before any side effects.
+        run = await _run_service.storage.get_run(run_id)
+        if run is None:
+            raise _StageGuardError(f"Run {run_id} not found")
+
+        try:
+            current = RunStage(run["current_stage"])
+        except ValueError as exc:
+            raise _StageGuardError(
+                f"Run {run_id} has invalid stage {run['current_stage']!r}"
+            ) from exc
+        if current not in _ALLOWED_STAGES:
+            raise _StageGuardError(
+                f"Run {run_id} is in stage {current.value}, "
+                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+            )
+
+        # 2. Fetch approved script draft.
+        draft = await _script_service.get_active_draft(run_id)
+        if draft is None:
+            raise _StageGuardError(f"No script draft found for run {run_id}")
+
+        script_text = (draft.markdown_content or "").strip()
+        if not script_text and draft.structured_script:
+            script_text = "\n".join(
+                (section.display_text or section.text).strip()
+                for section in draft.structured_script
+                if (section.display_text or section.text).strip()
+            )
+
+        if not script_text:
+            raise _StageGuardError(f"Script draft for run {run_id} has no content")
+
+        # 3. Fetch latest audio artifact (optional timing context).
+        audio_artifact = await _audio_service.get_latest(run_id)
+        audio_path = audio_artifact.path if audio_artifact else None
+
+        # 4. Provider resolution (sync — blocks briefly, fine in Celery worker).
+        registry = ProviderRegistry.create_default()
+        entry = registry.resolve(subtitle_model)
+        provider = registry.get_provider(subtitle_model)
+
+        provider_type = entry.provider_type
+        endpoint = entry.endpoint
+
+        # 5. GPU lock acquisition (sync).
+        if entry.requires_gpu:
+            redis_client = _get_redis_client()
+            if redis_client is None:
+                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+            acquire_gpu_lock(redis_client, task_id)
+            lock_acquired = True
+            gpu_lock_acquired_at = _utc_now_iso()
+
+        subtitle_path = f"data/artifacts/{run_id}/subtitles/subtitles.{subtitle_format}"
+
+        try:
+            # 6. Generate subtitles via provider.
+            params = dict(entry.default_params or {})
+            params["format"] = subtitle_format
+            params["output_path"] = subtitle_path
+            if audio_path:
+                params["audio_path"] = audio_path
+            await provider.generate(script_text, params)
+
+            # 7. Save subtitle artifact via service.
+            artifact = await _subtitle_service.create_artifact(
+                run_id=run_id,
+                path=subtitle_path,
+                format=subtitle_format,
+                model_used=subtitle_model,
+                provider_type=entry.provider_type,
+            )
+
+            # 8. Atomic success transition.
+            applied, _ = await _run_service.storage.conditional_update_run(
+                run_id,
+                {
+                    "current_stage": RunStage.RENDER_GENERATING.value,
+                    "status": "running",
+                },
+                expected_stages=_SAFE_STAGES,
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during subtitle generation -- skipping transition",
+                    run_id,
+                )
+        finally:
+            if lock_acquired:
+                try:
+                    release_gpu_lock(redis_client, task_id)
+                    gpu_lock_released_at = _utc_now_iso()
+                except Exception:
+                    logger.exception("Failed to release GPU lock for task %s", task_id)
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "subtitle_model": subtitle_model,
+            "subtitle_format": subtitle_format,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+            "gpu_lock_released_at": gpu_lock_released_at,
+            "subtitle_artifact_id": artifact.id,
+            "subtitle_path": artifact.path,
+            "audio_path": audio_path,
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "success",
+        }
+
+    try:
+        return asyncio.run(_run_task())
+    except _StageGuardError:
+        # Validation rejection — do NOT mutate run state to FAILED.
+        raise
+    except Exception:
+        # Unexpected error — atomic conditional fail.
+        try:
+            applied, _ = asyncio.run(
+                _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.FAILED.value,
+                        "status": "failed",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during subtitle generation -- skipping FAILED transition",
+                    run_id,
+                )
+        except Exception:
+            logger.exception("Failed to mark run %d as FAILED after task error", run_id)
+
+        raise

--- a/apps/worker-orchestrator/tasks/generate_visual_plan.py
+++ b/apps/worker-orchestrator/tasks/generate_visual_plan.py
@@ -1,1 +1,337 @@
-"""Placeholder for generate_visual_plan."""
+# pyright: reportMissingImports=false
+"""Celery task for visual plan generation via LLM providers.
+
+Consumes an approved script draft and generates a visual plan — one scene
+per script section with image-generation prompts, style tags, and mood.
+Follows the same pattern as generate_script.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
+
+try:
+    import redis
+except ImportError:
+    redis = None  # type: ignore[assignment]
+
+from celery_app import celery_app
+
+try:
+    from creator_domain.models.stage import RunStage
+except ImportError:
+    from models.stage import RunStage
+
+try:
+    from creator_domain.models.visual_plan import VisualScene
+except ImportError:
+    from models.visual_plan import VisualScene
+
+try:
+    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from creator_provider.registry import ProviderRegistry
+except ImportError:
+    from gpu_lock import acquire_gpu_lock, release_gpu_lock
+    from registry import ProviderRegistry
+
+try:
+    from creator_service.run_service import run_service as _run_service
+except ImportError:
+    from run_service import run_service as _run_service
+
+try:
+    from creator_service.script_service import script_service as _script_service
+except ImportError:
+    from script_service import script_service as _script_service
+
+try:
+    from creator_service.visual_plan_service import visual_plan_service as _visual_plan_service
+except ImportError:
+    from visual_plan_service import visual_plan_service as _visual_plan_service
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_STAGES = frozenset({RunStage.SCRIPT_REVIEW, RunStage.VISUAL_PLAN_GENERATING})
+
+# Stages where writing VISUAL_PLAN_REVIEW or FAILED is safe — the run
+# hasn't advanced past visual plan generation.
+_SAFE_STAGES = frozenset({RunStage.SCRIPT_REVIEW.value, RunStage.VISUAL_PLAN_GENERATING.value})
+
+
+class _StageGuardError(ValueError):
+    """Raised when a run is not in an acceptable stage for visual plan generation.
+
+    This is a validation/rejection error — the run state must NOT be mutated
+    to FAILED because the run may already be in a later stage.
+    """
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _build_system_prompt(style_preset: str | None = None) -> str:
+    base = (
+        "You are a visual planning assistant for short-form video production. "
+        "Given a script with sections, generate one visual scene per section. "
+        "For each scene, produce:\n"
+        "- A detailed image-generation prompt (describe the visual, not the narration)\n"
+        "- Style tags (e.g., cinematic, cartoon, minimalist)\n"
+        "- Mood (e.g., tense, upbeat, mysterious)\n"
+        "- Composition notes (e.g., close-up, wide shot, overhead)\n\n"
+        "Return a JSON array of objects with keys: "
+        "section_id, prompt, style_tags (array), mood, composition.\n"
+        "Only return the JSON array, no markdown fencing or extra text."
+    )
+    if style_preset:
+        base += f"\n\nStyle preset: {style_preset}"
+    return base
+
+
+def _build_sections_prompt(sections: list[dict[str, Any]]) -> str:
+    """Format script sections into a prompt for the LLM."""
+    lines: list[str] = []
+    for section in sections:
+        section_id = section.get("section_id", "unknown")
+        section_type = section.get("type", "unknown")
+        text = section.get("text", "")
+        lines.append(f"[{section_id}] ({section_type}): {text}")
+    return "\n".join(lines)
+
+
+def _parse_llm_response(
+    raw: str,
+    sections: list[dict[str, Any]],
+) -> list[VisualScene]:
+    """Parse LLM response JSON into VisualScene domain objects.
+
+    Maps each LLM output to the corresponding script section by section_id.
+    Sections without a matching LLM output get a default scene.
+    """
+    # Try to parse JSON — strip markdown fencing if present
+    cleaned = raw.strip()
+    if cleaned.startswith("```"):
+        # Remove ```json ... ``` fencing
+        lines = cleaned.split("\n")
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        cleaned = "\n".join(lines)
+
+    try:
+        llm_scenes = json.loads(cleaned)
+    except json.JSONDecodeError:
+        # Fallback: generate default scenes for all sections
+        llm_scenes = []
+
+    if not isinstance(llm_scenes, list):
+        llm_scenes = []
+
+    # Build lookup by section_id
+    llm_map: dict[str, dict[str, Any]] = {}
+    for item in llm_scenes:
+        if isinstance(item, dict) and "section_id" in item:
+            llm_map[item["section_id"]] = item
+
+    scenes: list[VisualScene] = []
+    for idx, section in enumerate(sections):
+        section_id = section.get("section_id", f"sec-{idx}")
+        section_type = section.get("type", "body")
+        text = section.get("text", "")
+
+        llm_data = llm_map.get(section_id, {})
+
+        scene = VisualScene(
+            scene_id=f"scene-{section_id}",
+            section_id=section_id,
+            scene_index=idx,
+            section_type=section_type,
+            original_text=text,
+            prompt=llm_data.get("prompt", f"Visual representation of: {text[:200]}"),
+            prompt_edited=False,
+            prompt_source="auto_generated",
+            style_tags=llm_data.get("style_tags", []),
+            mood=llm_data.get("mood"),
+            composition=llm_data.get("composition"),
+            generation_status="pending",
+            latest_asset_id=None,
+        )
+        scenes.append(scene)
+
+    return scenes
+
+
+def _get_redis_client() -> Any | None:
+    if redis is None:
+        return None
+    return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+@celery_app.task(bind=True, name="generate_visual_plan")
+def generate_visual_plan(
+    self,
+    run_id: int,
+    model_key: str = "qwen3-4b",
+    style_preset: str | None = None,
+) -> dict[str, object]:
+    start_time = datetime.now(timezone.utc)
+    start_iso = start_time.isoformat()
+    task_id = str(getattr(getattr(self, "request", None), "id", None) or f"run-{run_id}")
+
+    provider_type: str | None = None
+    endpoint: str | None = None
+    gpu_lock_acquired_at: str | None = None
+    gpu_lock_released_at: str | None = None
+    redis_client: Any | None = None
+    lock_acquired = False
+
+    async def _run_task() -> dict[str, object]:
+        nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
+        nonlocal redis_client, lock_acquired
+
+        # 1. Stage guard — reject before any side effects.
+        run = await _run_service.storage.get_run(run_id)
+        if run is None:
+            raise _StageGuardError(f"Run {run_id} not found")
+
+        try:
+            current = RunStage(run["current_stage"])
+        except ValueError as exc:
+            raise _StageGuardError(
+                f"Run {run_id} has invalid stage {run['current_stage']!r}"
+            ) from exc
+        if current not in _ALLOWED_STAGES:
+            raise _StageGuardError(
+                f"Run {run_id} is in stage {current.value}, "
+                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+            )
+
+        # 2. Fetch approved script draft.
+        draft = await _script_service.get_active_draft(run_id)
+        if draft is None:
+            raise _StageGuardError(f"No script draft found for run {run_id}")
+
+        # Extract sections from the draft
+        sections: list[dict[str, Any]] = []
+        if draft.structured_script:
+            sections = [s.model_dump(mode="json") for s in draft.structured_script]
+        elif draft.markdown_content:
+            # Minimal fallback: single section from raw markdown
+            sections = [{"section_id": "sec-0", "type": "body", "text": draft.markdown_content}]
+
+        if not sections:
+            raise _StageGuardError(f"Script draft for run {run_id} has no content")
+
+        # 3. Provider resolution (sync — blocks briefly, fine in Celery worker).
+        registry = ProviderRegistry.create_default()
+        entry = registry.resolve(model_key)
+        provider = registry.get_provider(model_key)
+
+        provider_type = entry.provider_type
+        endpoint = entry.endpoint
+
+        # 4. GPU lock acquisition (sync).
+        if entry.requires_gpu:
+            redis_client = _get_redis_client()
+            if redis_client is None:
+                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+            acquire_gpu_lock(redis_client, task_id)
+            lock_acquired = True
+            gpu_lock_acquired_at = _utc_now_iso()
+
+        try:
+            # 5. Generation: send script sections to LLM for visual planning.
+            system_prompt = _build_system_prompt(style_preset)
+            sections_prompt = _build_sections_prompt(sections)
+            full_prompt = f"{system_prompt}\n\n---\nScript sections:\n{sections_prompt}"
+
+            params = dict(entry.default_params or {})
+            raw_response = await provider.generate(full_prompt, params)
+
+            # 6. Parse LLM response into VisualScene objects.
+            visual_scenes = _parse_llm_response(raw_response, sections)
+
+            # 7. Save visual plan via service.
+            await _visual_plan_service.save_plan(
+                run_id=run_id,
+                scenes=visual_scenes,
+            )
+
+            # 8. Atomic success transition: only advance if run is still in a
+            # generating-compatible stage.
+            applied, _ = await _run_service.storage.conditional_update_run(
+                run_id,
+                {
+                    "current_stage": RunStage.VISUAL_PLAN_REVIEW.value,
+                    "status": "running",
+                },
+                expected_stages=_SAFE_STAGES,
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during visual plan generation -- skipping transition",
+                    run_id,
+                )
+        finally:
+            if lock_acquired:
+                try:
+                    release_gpu_lock(redis_client, task_id)
+                    gpu_lock_released_at = _utc_now_iso()
+                except Exception:
+                    logger.exception("Failed to release GPU lock for task %s", task_id)
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "model_key": model_key,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+            "gpu_lock_released_at": gpu_lock_released_at,
+            "scene_count": len(visual_scenes),
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "success",
+            "error": None,
+        }
+
+    try:
+        return asyncio.run(_run_task())
+    except _StageGuardError:
+        # Validation rejection — do NOT mutate run state to FAILED.
+        raise
+    except Exception:
+        # Atomic conditional fail: only mark FAILED if run is still in a
+        # generating-compatible stage.
+        try:
+            applied, _ = asyncio.run(
+                _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.FAILED.value,
+                        "status": "failed",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during visual plan generation -- skipping FAILED transition",
+                    run_id,
+                )
+        except Exception:
+            logger.exception("Failed to mark run %d as FAILED after task error", run_id)
+
+        raise

--- a/apps/worker-orchestrator/tasks/render_video.py
+++ b/apps/worker-orchestrator/tasks/render_video.py
@@ -1,1 +1,189 @@
-"""Placeholder for render_video."""
+# pyright: reportMissingImports=false
+"""Celery task for run-level video rendering via FFmpeg.
+
+Consumes active visual assets and optional audio/subtitle artifacts,
+renders a single MP4 output for the run, and stores it as a video artifact.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
+
+from celery_app import celery_app
+
+try:
+    from creator_domain.models.stage import RunStage
+except ImportError:
+    from models.stage import RunStage
+
+try:
+    from creator_service.run_service import run_service as _run_service
+except ImportError:
+    from run_service import run_service as _run_service
+
+try:
+    from creator_service.render_service import render_service as _render_service
+except ImportError:
+    from render_service import render_service as _render_service
+
+try:
+    from creator_service.visual_asset_service import visual_asset_service as _visual_asset_service
+except ImportError:
+    from visual_asset_service import visual_asset_service as _visual_asset_service
+
+try:
+    from creator_service.audio_service import audio_service as _audio_service
+except ImportError:
+    from audio_service import audio_service as _audio_service
+
+try:
+    from creator_service.subtitle_service import subtitle_service as _subtitle_service
+except ImportError:
+    from subtitle_service import subtitle_service as _subtitle_service
+
+try:
+    from creator_service.ffmpeg_service import FFmpegService, RenderInput
+except ImportError:
+    from ffmpeg_service import FFmpegService, RenderInput
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_STAGES = frozenset({RunStage.RENDER_GENERATING})
+_SAFE_STAGES = frozenset({RunStage.RENDER_GENERATING.value})
+
+
+class _StageGuardError(ValueError):
+    pass
+
+
+@celery_app.task(bind=True, name="render_video")
+def render_video(
+    self,
+    run_id: int,
+    render_profile: str = "shorts_default",
+) -> dict[str, object]:
+    start_time = datetime.now(timezone.utc)
+    start_iso = start_time.isoformat()
+    task_id = str(getattr(getattr(self, "request", None), "id", None) or f"run-{run_id}")
+
+    async def _run_task() -> dict[str, object]:
+        run = await _run_service.storage.get_run(run_id)
+        if run is None:
+            raise _StageGuardError(f"Run {run_id} not found")
+
+        try:
+            current = RunStage(run["current_stage"])
+        except ValueError as exc:
+            raise _StageGuardError(
+                f"Run {run_id} has invalid stage {run['current_stage']!r}"
+            ) from exc
+        if current not in _ALLOWED_STAGES:
+            raise _StageGuardError(
+                f"Run {run_id} is in stage {current.value}, "
+                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+            )
+
+        manifest = await _render_service.build_render_manifest(
+            run_id,
+            _visual_asset_service,
+            _audio_service,
+            _subtitle_service,
+            render_profile_name=render_profile,
+        )
+
+        if not manifest["scenes"]:
+            raise RuntimeError("No scenes found for render")
+
+        profile_data = manifest["render_profile"]
+        scene_count = len(manifest["scenes"])
+        image_paths = [Path(scene["asset_path"]) for scene in manifest["scenes"]]
+        audio_path = Path(manifest["audio_path"]) if manifest["audio_path"] else None
+        subtitle_path = Path(manifest["subtitle_path"]) if manifest["subtitle_path"] else None
+        scene_duration = profile_data["max_duration_seconds"] / scene_count
+        scene_durations = [scene_duration] * scene_count
+
+        render_input = RenderInput(
+            image_paths=image_paths,
+            audio_path=audio_path,
+            subtitle_path=subtitle_path,
+            scene_durations=scene_durations,
+        )
+
+        output_path = f"data/artifacts/{run_id}/render/output.mp4"
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        ffmpeg = FFmpegService()
+        ffmpeg.render(render_input, Path(output_path))
+
+        artifact = await _render_service.create_artifact(
+            run_id=run_id,
+            path=output_path,
+            render_profile=render_profile,
+        )
+
+        applied, _ = await _run_service.storage.conditional_update_run(
+            run_id,
+            {
+                "current_stage": RunStage.FINAL_REVIEW.value,
+                "status": "running",
+            },
+            expected_stages=_SAFE_STAGES,
+        )
+        if not applied:
+            logger.info(
+                "Run %d stage changed during video render -- skipping transition",
+                run_id,
+            )
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "render_profile": render_profile,
+            "video_artifact_id": artifact.id,
+            "video_path": artifact.path,
+            "scene_count": len(manifest["scenes"]),
+            "audio_path": manifest["audio_path"],
+            "subtitle_path": manifest["subtitle_path"],
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "success",
+        }
+
+    try:
+        return asyncio.run(_run_task())
+    except _StageGuardError:
+        raise
+    except Exception:
+        try:
+            applied, _ = asyncio.run(
+                _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.FAILED.value,
+                        "status": "failed",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during video render -- skipping FAILED transition",
+                    run_id,
+                )
+        except Exception:
+            logger.exception("Failed to mark run %d as FAILED after task error", run_id)
+
+        raise

--- a/apps/worker-orchestrator/tasks/render_video.py
+++ b/apps/worker-orchestrator/tasks/render_video.py
@@ -53,8 +53,10 @@ except ImportError:
 
 try:
     from creator_service.ffmpeg_service import FFmpegService, RenderInput
+    from creator_service.render_profile import RenderProfile
 except ImportError:
     from ffmpeg_service import FFmpegService, RenderInput
+    from render_profile import RenderProfile
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +67,20 @@ _SAFE_STAGES = frozenset({RunStage.RENDER_GENERATING.value})
 class _StageGuardError(ValueError):
     pass
 
+# Map profile name → RenderProfile constructor
+_PROFILE_REGISTRY: dict[str, object] = {
+    "shorts_default": RenderProfile.default,
+    "high_quality": RenderProfile.high_quality,
+    "fast_preview": RenderProfile.fast_preview,
+}
+
+
+def _resolve_profile(name: str) -> RenderProfile:
+    factory = _PROFILE_REGISTRY.get(name)
+    if factory is None:
+        logger.warning("Unknown render profile %r, falling back to default", name)
+        return RenderProfile.default()
+    return factory()
 
 @celery_app.task(bind=True, name="render_video")
 def render_video(
@@ -121,7 +137,8 @@ def render_video(
 
         output_path = f"data/artifacts/{run_id}/render/output.mp4"
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-        ffmpeg = FFmpegService()
+        resolved_profile = _resolve_profile(render_profile)
+        ffmpeg = FFmpegService(profile=resolved_profile)
         ffmpeg.render(render_input, Path(output_path))
 
         artifact = await _render_service.create_artifact(

--- a/apps/worker-orchestrator/tests/__init__.py
+++ b/apps/worker-orchestrator/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test module for worker-orchestrator."""

--- a/apps/worker-orchestrator/tests/conftest.py
+++ b/apps/worker-orchestrator/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest fixtures for Celery app tests."""
+import pytest
+from celery_app import celery_app
+
+
+@pytest.fixture
+def celery_config():
+    """Celery configuration for testing."""
+    return {
+        "broker_url": "memory://",
+        "result_backend": "cache+memory://",
+    }
+
+
+@pytest.fixture
+def app(celery_config):
+    """Celery app fixture with test configuration."""
+    celery_app.conf.update(celery_config)
+    return celery_app

--- a/apps/worker-orchestrator/tests/test_celery_app.py
+++ b/apps/worker-orchestrator/tests/test_celery_app.py
@@ -1,0 +1,11 @@
+"""Tests for Celery app configuration."""
+
+
+def test_celery_app_loads(app):
+    """Test that Celery app loads correctly."""
+    assert app.main == "worker-orchestrator"
+
+
+def test_default_queue_is_creator(app):
+    """Test that default queue is set to 'creator'."""
+    assert app.conf.task_default_queue == "creator"

--- a/apps/worker-orchestrator/tests/test_generate_scene_image.py
+++ b/apps/worker-orchestrator/tests/test_generate_scene_image.py
@@ -457,6 +457,31 @@ def test_all_scenes_fail_marks_run_failed(monkeypatch: pytest.MonkeyPatch) -> No
     assert len(va_service.calls) == 0
 
 
+def test_all_scenes_fail_and_cas_raises_propagates_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If ALL scenes fail AND the CAS to FAILED itself errors, the exception must propagate.
+
+    Regression: previously the except-block swallowed the storage error and returned
+    a 'failed' payload, making Celery mark the task as SUCCESS while the run stayed
+    stuck in its original stage.
+    """
+    provider = FakeImageProvider(error=RuntimeError("GPU crashed"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    scenes = [
+        FakeVisualScene(scene_id="scene-sec-0", prompt="Hook"),
+    ]
+    plan = FakeVisualPlan(run_id=203, scenes=scenes)
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=203, stage="VISUAL_PLAN_REVIEW")
+    storage.error = ConnectionError("Redis down")  # CAS itself fails
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    with pytest.raises(ConnectionError, match="Redis down"):
+        _invoke_task(run_id=203)
+
 # ──────────────────────────────────────────────────────────────────────
 # Stage guard tests
 # ──────────────────────────────────────────────────────────────────────

--- a/apps/worker-orchestrator/tests/test_generate_scene_image.py
+++ b/apps/worker-orchestrator/tests/test_generate_scene_image.py
@@ -1,0 +1,831 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from tasks import generate_scene_image as generate_scene_image_module
+
+
+@dataclass
+class FakeEntry:
+    provider_type: str = "sd_local"
+    endpoint: str = "http://stable-diffusion:7860"
+    requires_gpu: bool = True
+    default_params: dict[str, object] | None = None
+
+
+@dataclass
+class FakeImageResult:
+    """Mimics base.ImageResult returned by ImageProvider.generate()."""
+    image_path: str = ""
+    width: int = 512
+    height: int = 512
+    model_key: str = "sd15"
+    metadata: dict[str, Any] | None = None
+
+
+class FakeImageProvider:
+    def __init__(
+        self,
+        result: FakeImageResult | None = None,
+        error: Exception | None = None,
+        per_scene_errors: dict[str, Exception] | None = None,
+    ) -> None:
+        self.result = result or FakeImageResult()
+        self.error = error
+        self.per_scene_errors = per_scene_errors or {}
+        self.calls: list[tuple[str, dict[str, object] | None]] = []
+
+    async def generate(self, prompt: str, params: dict[str, object] | None = None) -> FakeImageResult:
+        self.calls.append((prompt, params))
+        # Check per-scene errors based on prompt content
+        for scene_key, exc in self.per_scene_errors.items():
+            if scene_key in prompt:
+                raise exc
+        if self.error is not None:
+            raise self.error
+        return FakeImageResult(
+            image_path=f"/tmp/generated_{len(self.calls)}.png",
+            model_key="sd15",
+        )
+
+
+class FakeStorage:
+    def __init__(
+        self,
+        error: Exception | None = None,
+        runs: dict[int, dict[str, object]] | None = None,
+    ) -> None:
+        self.error = error
+        self.calls: list[tuple[int, dict[str, object]]] = []
+        self._runs: dict[int, dict[str, object]] = runs or {}
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        return self._runs.get(run_id)
+
+    async def update_run(self, run_id: int, updates: dict[str, object]) -> dict[str, object]:
+        self.calls.append((run_id, updates))
+        if self.error is not None:
+            raise self.error
+        return {"id": run_id, **updates}
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        if self.error is not None:
+            raise self.error
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
+
+
+def _make_storage(run_id: int = 101, stage: str = "VISUAL_PLAN_REVIEW", **extra: Any) -> FakeStorage:
+    run_row: dict[str, object] = {"id": run_id, "current_stage": stage, **extra}
+    return FakeStorage(runs={run_id: run_row})
+
+
+@dataclass
+class FakeVisualScene:
+    scene_id: str = "scene-sec-0"
+    section_id: str = "sec-0"
+    scene_index: int = 0
+    section_type: str = "hook"
+    original_text: str = "Hook text"
+    prompt: str = "A dramatic opening shot"
+    prompt_edited: bool = False
+    prompt_source: str = "auto_generated"
+    style_tags: list[str] = field(default_factory=list)
+    mood: str | None = None
+    composition: str | None = None
+    generation_status: str = "pending"
+    latest_asset_id: int | None = None
+
+
+@dataclass
+class FakeVisualPlan:
+    id: int = 1
+    run_id: int = 101
+    version: int = 1
+    scenes: list[FakeVisualScene] = field(default_factory=lambda: [FakeVisualScene()])
+    created_at: str = "2026-01-01T00:00:00Z"
+
+
+class FakeVisualPlanService:
+    def __init__(
+        self,
+        plan: FakeVisualPlan | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.plan = plan
+        self.error = error
+
+    async def get_active_plan(self, run_id: int) -> FakeVisualPlan | None:
+        if self.error is not None:
+            raise self.error
+        return self.plan
+
+
+@dataclass
+class FakeVisualAsset:
+    id: int = 1
+    run_id: int = 101
+    scene_id: str = "scene-sec-0"
+    version: int = 1
+    asset_path: str = "/tmp/test.png"
+    prompt_snapshot: str | None = None
+    model_used: str | None = None
+    provider_type: str | None = None
+    is_active: bool = True
+    created_at: str = "2026-01-01T00:00:00Z"
+
+
+class FakeVisualAssetService:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+        self._next_id = 1
+        self._next_version: dict[str, int] = {}
+
+    async def create_asset(
+        self,
+        run_id: int,
+        scene_id: str,
+        asset_path: str,
+        *,
+        prompt_snapshot: str | None = None,
+        model_used: str | None = None,
+        provider_type: str | None = None,
+        is_active: bool = True,
+    ) -> FakeVisualAsset:
+        call_data = {
+            "run_id": run_id,
+            "scene_id": scene_id,
+            "asset_path": asset_path,
+            "prompt_snapshot": prompt_snapshot,
+            "model_used": model_used,
+            "provider_type": provider_type,
+            "is_active": is_active,
+        }
+        self.calls.append(call_data)
+        if self.error is not None:
+            raise self.error
+        version_key = f"{run_id}:{scene_id}"
+        version = self._next_version.get(version_key, 0) + 1
+        self._next_version[version_key] = version
+        asset = FakeVisualAsset(
+            id=self._next_id,
+            run_id=run_id,
+            scene_id=scene_id,
+            version=version,
+            asset_path=asset_path,
+            prompt_snapshot=prompt_snapshot,
+            model_used=model_used,
+            provider_type=provider_type,
+            is_active=is_active,
+        )
+        self._next_id += 1
+        return asset
+
+
+class FakeRegistry:
+    def __init__(
+        self,
+        entry: FakeEntry,
+        provider: FakeImageProvider,
+        resolve_error: Exception | None = None,
+    ) -> None:
+        self.entry = entry
+        self.provider = provider
+        self.resolve_error = resolve_error
+
+    def resolve(self, _model_key: str) -> FakeEntry:
+        if self.resolve_error is not None:
+            raise self.resolve_error
+        return self.entry
+
+    def get_provider(self, _model_key: str) -> FakeImageProvider:
+        return self.provider
+
+
+def _patch_registry(monkeypatch: pytest.MonkeyPatch, registry: FakeRegistry) -> None:
+    class _ProviderRegistry:
+        @staticmethod
+        def create_default() -> FakeRegistry:
+            return registry
+
+    monkeypatch.setattr(generate_scene_image_module, "ProviderRegistry", _ProviderRegistry)
+
+
+def _patch_redis(monkeypatch: pytest.MonkeyPatch, redis_client: object) -> None:
+    redis_stub = SimpleNamespace(Redis=SimpleNamespace(from_url=lambda _: redis_client))
+    monkeypatch.setattr(generate_scene_image_module, "redis", redis_stub)
+
+
+def _patch_services(
+    monkeypatch: pytest.MonkeyPatch,
+    visual_plan_service: FakeVisualPlanService,
+    visual_asset_service: FakeVisualAssetService,
+    storage: FakeStorage,
+) -> None:
+    monkeypatch.setattr(generate_scene_image_module, "_visual_plan_service", visual_plan_service)
+    monkeypatch.setattr(generate_scene_image_module, "_visual_asset_service", visual_asset_service)
+    monkeypatch.setattr(generate_scene_image_module, "_run_service", SimpleNamespace(storage=storage))
+
+
+def _invoke_task(**kwargs: Any) -> dict[str, object]:
+    task = generate_scene_image_module.generate_scene_image
+    run_callable = getattr(task, "run", task)
+    return run_callable(**kwargs)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Happy-path tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_happy_path_single_scene_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=True, default_params={"steps": 20})
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    lock_calls: list[str] = []
+    release_calls: list[str] = []
+    monkeypatch.setattr(generate_scene_image_module, "acquire_gpu_lock", lambda client, task_id: lock_calls.append(task_id))
+    monkeypatch.setattr(generate_scene_image_module, "release_gpu_lock", lambda client, task_id: release_calls.append(task_id))
+
+    plan = FakeVisualPlan(run_id=101, scenes=[FakeVisualScene(scene_id="scene-sec-0", prompt="A hook shot")])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=101, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=101, scene_id="scene-sec-0")
+
+    assert result["status"] == "success"
+    assert result["total_scenes"] == 1
+    assert result["succeeded"] == 1
+    assert result["failed"] == 0
+    assert len(lock_calls) == 1
+    assert len(release_calls) == 1
+    assert va_service.calls[0]["scene_id"] == "scene-sec-0"
+    assert va_service.calls[0]["prompt_snapshot"] == "A hook shot"
+    assert storage.calls == [(101, {"current_stage": "VISUAL_ASSET_REVIEW", "status": "running"})]
+
+
+def test_happy_path_all_scenes(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    scenes = [
+        FakeVisualScene(scene_id="scene-sec-0", prompt="Hook shot"),
+        FakeVisualScene(scene_id="scene-sec-1", scene_index=1, prompt="Body shot"),
+        FakeVisualScene(scene_id="scene-sec-2", scene_index=2, prompt="CTA shot"),
+    ]
+    plan = FakeVisualPlan(run_id=102, scenes=scenes)
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=102, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=102)
+
+    assert result["status"] == "success"
+    assert result["total_scenes"] == 3
+    assert result["succeeded"] == 3
+    assert result["failed"] == 0
+    assert result["scene_id"] is None  # All scenes mode
+    assert len(va_service.calls) == 3
+    assert len(provider.calls) == 3
+    assert storage.calls == [(102, {"current_stage": "VISUAL_ASSET_REVIEW", "status": "running"})]
+
+
+def test_happy_path_without_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(provider_type="external_image", endpoint="https://api.example.com", requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    # GPU lock should NOT be called
+    monkeypatch.setattr(generate_scene_image_module, "acquire_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+    monkeypatch.setattr(generate_scene_image_module, "release_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+
+    plan = FakeVisualPlan(run_id=103, scenes=[FakeVisualScene()])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=103, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=103)
+
+    assert result["status"] == "success"
+    assert result["provider_type"] == "external_image"
+
+
+def test_prompt_override_single_scene(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=104, scenes=[FakeVisualScene(scene_id="scene-sec-0", prompt="Original prompt")])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=104, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=104, scene_id="scene-sec-0", prompt_override="Custom override prompt")
+
+    assert result["status"] == "success"
+    assert provider.calls[0][0] == "Custom override prompt"
+    assert va_service.calls[0]["prompt_snapshot"] == "Custom override prompt"
+
+
+def test_prompt_override_ignored_in_all_scene_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """prompt_override is only used when scene_id is specified."""
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=105, scenes=[FakeVisualScene(scene_id="scene-sec-0", prompt="Original prompt")])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=105, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=105, prompt_override="Should be ignored")
+
+    assert result["status"] == "success"
+    # Should use the scene prompt, not the override
+    assert provider.calls[0][0] == "Original prompt"
+
+
+def test_inactive_asset_creation(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=106, scenes=[FakeVisualScene()])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=106, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=106, is_active=False)
+
+    assert result["status"] == "success"
+    assert va_service.calls[0]["is_active"] is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Partial failure tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_partial_failure_advances_to_review(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If some scenes succeed and some fail, still advance to VISUAL_ASSET_REVIEW."""
+    provider = FakeImageProvider(
+        per_scene_errors={"Body shot": RuntimeError("GPU OOM")}
+    )
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    scenes = [
+        FakeVisualScene(scene_id="scene-sec-0", prompt="Hook shot"),
+        FakeVisualScene(scene_id="scene-sec-1", scene_index=1, prompt="Body shot"),
+        FakeVisualScene(scene_id="scene-sec-2", scene_index=2, prompt="CTA shot"),
+    ]
+    plan = FakeVisualPlan(run_id=201, scenes=scenes)
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=201, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=201)
+
+    assert result["status"] == "partial"
+    assert result["succeeded"] == 2
+    assert result["failed"] == 1
+    # Should still advance to review
+    assert storage.calls == [(201, {"current_stage": "VISUAL_ASSET_REVIEW", "status": "running"})]
+    # Only 2 assets saved (the successful ones)
+    assert len(va_service.calls) == 2
+
+
+def test_all_scenes_fail_marks_run_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If ALL scenes fail, mark run as FAILED."""
+    provider = FakeImageProvider(error=RuntimeError("GPU crashed"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    scenes = [
+        FakeVisualScene(scene_id="scene-sec-0", prompt="Hook"),
+        FakeVisualScene(scene_id="scene-sec-1", scene_index=1, prompt="Body"),
+    ]
+    plan = FakeVisualPlan(run_id=202, scenes=scenes)
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=202, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=202)
+
+    assert result["status"] == "failed"
+    assert result["succeeded"] == 0
+    assert result["failed"] == 2
+    assert storage.calls == [(202, {"current_stage": "FAILED", "status": "failed"})]
+    assert len(va_service.calls) == 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Stage guard tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_stage_guard_rejects_wrong_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    vp_service = FakeVisualPlanService(plan=FakeVisualPlan())
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=301, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=301)
+
+    assert provider.calls == []
+    assert va_service.calls == []
+    assert storage.calls == []
+
+
+def test_stage_guard_accepts_visual_asset_generating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """VISUAL_ASSET_GENERATING stage is accepted (retry scenario)."""
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=302)
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=302, stage="VISUAL_ASSET_GENERATING")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=302)
+
+    assert result["status"] == "success"
+    assert len(va_service.calls) == 1
+
+
+def test_stage_guard_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    vp_service = FakeVisualPlanService()
+    va_service = FakeVisualAssetService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    with pytest.raises(ValueError, match="Run 999 not found"):
+        _invoke_task(run_id=999)
+
+    assert provider.calls == []
+    assert storage.calls == []
+
+
+def test_stage_guard_no_visual_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    vp_service = FakeVisualPlanService(plan=None)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=303, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    with pytest.raises(ValueError, match="No active visual plan"):
+        _invoke_task(run_id=303)
+
+    assert provider.calls == []
+    assert storage.calls == []
+
+
+def test_stage_guard_scene_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=304, scenes=[FakeVisualScene(scene_id="scene-sec-0")])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=304, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    with pytest.raises(ValueError, match="Scene 'nonexistent' not found"):
+        _invoke_task(run_id=304, scene_id="nonexistent")
+
+    assert provider.calls == []
+    assert storage.calls == []
+
+
+def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stage guard must reject BEFORE provider resolution."""
+    registry = FakeRegistry(
+        entry=FakeEntry(),
+        provider=FakeImageProvider(),
+        resolve_error=KeyError("Model not found"),
+    )
+    _patch_registry(monkeypatch, registry)
+
+    vp_service = FakeVisualPlanService(plan=FakeVisualPlan())
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=305, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=305, model_key="bad-model")
+
+    assert storage.calls == []
+    assert storage._runs[305]["current_stage"] == "SCRIPT_REVIEW"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Provider resolution failure
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_provider_resolution_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = FakeRegistry(
+        entry=FakeEntry(),
+        provider=FakeImageProvider(),
+        resolve_error=KeyError("Model not found"),
+    )
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=401)
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=401, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    with pytest.raises(KeyError, match="Model not found"):
+        _invoke_task(run_id=401, model_key="missing")
+
+    assert va_service.calls == []
+    assert storage.calls == [(401, {"current_stage": "FAILED", "status": "failed"})]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# GPU lock and error propagation tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_gpu_lock_timeout_single_scene(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GPU lock timeout for a single scene still creates scene_results."""
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    monkeypatch.setattr(
+        generate_scene_image_module,
+        "acquire_gpu_lock",
+        lambda *_: (_ for _ in ()).throw(TimeoutError("lock timeout")),
+    )
+    monkeypatch.setattr(generate_scene_image_module, "release_gpu_lock", lambda *_: None)
+
+    plan = FakeVisualPlan(run_id=501, scenes=[FakeVisualScene()])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=501, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    # All scenes fail → task returns with failed status (doesn't raise)
+    result = _invoke_task(run_id=501)
+
+    assert result["status"] == "failed"
+    assert result["failed"] == 1
+    assert storage.calls == [(501, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_releases_gpu_lock_when_provider_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider(error=RuntimeError("provider exploded"))
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    released: list[str] = []
+    monkeypatch.setattr(generate_scene_image_module, "acquire_gpu_lock", lambda *_: True)
+    monkeypatch.setattr(generate_scene_image_module, "release_gpu_lock", lambda _, task_id: released.append(task_id))
+
+    plan = FakeVisualPlan(run_id=502, scenes=[FakeVisualScene()])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=502, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=502)
+
+    assert result["status"] == "failed"
+    assert len(released) == 1  # GPU lock released even on failure
+
+
+def test_release_gpu_lock_failure_does_not_mask_scene_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If release_gpu_lock raises, the scene is still recorded as failed."""
+    provider = FakeImageProvider(error=RuntimeError("generation boom"))
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    monkeypatch.setattr(generate_scene_image_module, "acquire_gpu_lock", lambda *_: True)
+    monkeypatch.setattr(
+        generate_scene_image_module,
+        "release_gpu_lock",
+        lambda *_: (_ for _ in ()).throw(ConnectionError("redis gone")),
+    )
+
+    plan = FakeVisualPlan(run_id=503, scenes=[FakeVisualScene()])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=503, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=503)
+
+    assert result["status"] == "failed"
+    assert result["failed"] == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Race condition / CAS tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+class RaceConditionStorage(FakeStorage):
+    """Storage that simulates a competing task advancing the run between operations."""
+
+    def __init__(self, run_id: int, initial_stage: str, advanced_stage: str, advance_after: int = 1) -> None:
+        super().__init__(runs={run_id: {"id": run_id, "current_stage": initial_stage}})
+        self._target_id = run_id
+        self._advanced_stage = advanced_stage
+        self._advance_after = advance_after
+        self._op_count = 0
+
+    def _maybe_advance(self, run_id: int) -> None:
+        if run_id == self._target_id:
+            self._op_count += 1
+            if self._op_count > self._advance_after:
+                self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        self._maybe_advance(run_id)
+        return self._runs.get(run_id)
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self._maybe_advance(run_id)
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
+
+
+def test_success_transition_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If run has advanced past image generation, skip the VISUAL_ASSET_REVIEW write."""
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=601)
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = RaceConditionStorage(
+        run_id=601, initial_stage="VISUAL_PLAN_REVIEW", advanced_stage="AUDIO_GENERATING"
+    )
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=601)
+
+    assert result["status"] == "success"
+    assert storage.calls == []  # CAS rejected — run already advanced
+    assert storage._runs[601]["current_stage"] == "AUDIO_GENERATING"
+
+
+def test_failure_transition_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If run has advanced and all scenes fail, FAILED write must be skipped."""
+    provider = FakeImageProvider(error=RuntimeError("fail"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=602)
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = RaceConditionStorage(
+        run_id=602, initial_stage="VISUAL_PLAN_REVIEW", advanced_stage="VISUAL_ASSET_REVIEW"
+    )
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=602)
+
+    assert result["status"] == "failed"
+    assert storage.calls == []  # CAS rejected
+    assert storage._runs[602]["current_stage"] == "VISUAL_ASSET_REVIEW"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Metadata / audit tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_asset_metadata_persisted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that model_used and provider_type are passed to asset service."""
+    provider = FakeImageProvider()
+    entry = FakeEntry(provider_type="sd_local", requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=701, scenes=[FakeVisualScene(prompt="Test prompt")])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=701, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=701, model_key="sd15")
+
+    assert result["status"] == "success"
+    call = va_service.calls[0]
+    assert call["model_used"] == "sd15"
+    assert call["provider_type"] == "sd_local"
+    assert call["prompt_snapshot"] == "Test prompt"
+
+
+def test_scene_results_contain_asset_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify scene_results contain asset_id, version, and asset_path."""
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=702, scenes=[FakeVisualScene()])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=702, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    result = _invoke_task(run_id=702)
+
+    assert result["status"] == "success"
+    scene_results = result["scene_results"]
+    assert len(scene_results) == 1
+    sr = scene_results[0]
+    assert sr["status"] == "success"
+    assert sr["asset_id"] == 1
+    assert sr["version"] == 1
+    assert "asset_path" in sr

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -470,3 +470,29 @@ def test_stage_guard_invalid_stage_value(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert provider.calls == []
     assert storage.calls == []
+
+
+def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stage guard must reject BEFORE provider resolution, so a bad model_key
+    with a wrong-stage run does NOT mark the run as FAILED."""
+    # Registry that will raise on resolve — simulates bad model_key
+    registry = FakeRegistry(
+        entry=FakeEntry(),
+        provider=FakeProvider(),
+        resolve_error=KeyError("Model not found"),
+    )
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    # Run is already in SCRIPT_REVIEW — stale/duplicate task scenario
+    storage = _make_storage(run_id=800, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, storage)
+
+    # Stage guard fires first, KeyError from resolve never reached
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=800, idea_brief="Stale task with bad model")
+
+    # Run state must NOT be mutated — stage guard rejected before provider setup
+    assert storage.calls == []
+    run = storage._runs[800]
+    assert run["current_stage"] == "SCRIPT_REVIEW"

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -322,8 +322,8 @@ def test_stage_guard_rejects_wrong_stage(monkeypatch: pytest.MonkeyPatch) -> Non
     # Provider should never have been called
     assert provider.calls == []
     assert script_service.calls == []
-    # Should still mark run as FAILED
-    assert storage.calls == [(200, {"current_stage": "FAILED", "status": "failed"})]
+    # Run state must NOT be mutated — this is a validation rejection, not a failure
+    assert storage.calls == []
 
 
 def test_stage_guard_accepts_script_generating(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -358,7 +358,8 @@ def test_stage_guard_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
         _invoke_task(run_id=999, idea_brief="Ghost run")
 
     assert provider.calls == []
-
+    # Run state must NOT be mutated for a non-existent run
+    assert storage.calls == []
 
 # ──────────────────────────────────────────────────────────────────────
 # Oracle-requested: re-raise propagation
@@ -427,3 +428,45 @@ def test_update_run_failure_in_error_path_still_re_raises_original(monkeypatch: 
     # Original error must still propagate even if FAILED-stage update fails
     with pytest.raises(RuntimeError, match="original error"):
         _invoke_task(run_id=500, idea_brief="Double failure")
+
+
+def test_stage_guard_wrong_stage_preserves_run_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run in SCRIPT_REVIEW must stay in SCRIPT_REVIEW after stage guard rejection."""
+    provider = FakeProvider(result="Should not run")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=600, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=600, idea_brief="Stale duplicate task")
+
+    # The run must NOT have been mutated at all
+    assert storage.calls == []
+    assert provider.calls == []
+    # Verify the run still has its original stage
+    run = storage._runs[600]
+    assert run["current_stage"] == "SCRIPT_REVIEW"
+
+
+def test_stage_guard_invalid_stage_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed current_stage value in storage should raise without marking FAILED."""
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    # Simulate corrupted stage value in storage
+    storage = _make_storage(run_id=700, stage="BOGUS_STAGE")
+    _patch_services(monkeypatch, script_service, storage)
+
+    # RunStage("BOGUS_STAGE") will raise ValueError — should NOT mark run FAILED
+    with pytest.raises(ValueError):
+        _invoke_task(run_id=700, idea_brief="Corrupted stage")
+
+    assert provider.calls == []
+    assert storage.calls == []

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -496,3 +496,68 @@ def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.Monke
     assert storage.calls == []
     run = storage._runs[800]
     assert run["current_stage"] == "SCRIPT_REVIEW"
+
+
+class RaceConditionStorage(FakeStorage):
+    """Storage that simulates a competing task advancing the run between guard and error handler."""
+
+    def __init__(self, run_id: int, initial_stage: str, advanced_stage: str) -> None:
+        super().__init__(runs={run_id: {"id": run_id, "current_stage": initial_stage}})
+        self._target_id = run_id
+        self._advanced_stage = advanced_stage
+        self._get_count = 0
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        self._get_count += 1
+        if run_id == self._target_id and self._get_count > 1:
+            # Second get_run call (from _conditional_fail) sees the advanced stage
+            self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
+        return self._runs.get(run_id)
+
+
+def test_conditional_fail_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a competing task advances the run to SCRIPT_REVIEW before the error handler
+    runs, the error handler must NOT overwrite it to FAILED.
+
+    Scenario: two duplicate tasks both pass the stage guard. Task A succeeds and
+    advances the run to SCRIPT_REVIEW. Task B then fails during generation. Task B's
+    error handler re-checks the stage and sees SCRIPT_REVIEW -> skips FAILED write.
+    """
+    provider = FakeProvider(error=RuntimeError("task B generation failed"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    # First get_run (stage guard) returns IDEA_READY -> task passes guard.
+    # Second get_run (_conditional_fail) returns SCRIPT_REVIEW -> competing task advanced it.
+    storage = RaceConditionStorage(
+        run_id=900, initial_stage="IDEA_READY", advanced_stage="SCRIPT_REVIEW"
+    )
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(RuntimeError, match="task B generation failed"):
+        _invoke_task(run_id=900, idea_brief="Duplicate task scenario")
+
+    # Error handler must NOT have written FAILED -- run was already advanced
+    assert storage.calls == []
+    assert storage._runs[900]["current_stage"] == "SCRIPT_REVIEW"
+
+
+def test_conditional_fail_marks_failed_when_still_in_generating_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the run is still in IDEA_READY at error time, the error handler should
+    mark it as FAILED (normal failure path)."""
+    provider = FakeProvider(error=RuntimeError("generation error"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=901, stage="IDEA_READY")
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(RuntimeError, match="generation error"):
+        _invoke_task(run_id=901, idea_brief="Normal failure")
+
+    # Run was still in IDEA_READY -> FAILED write should happen
+    assert storage.calls == [(901, {"current_stage": "FAILED", "status": "failed"})]

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-
 from tasks import generate_script as generate_script_module
 
 
@@ -31,15 +30,29 @@ class FakeProvider:
 
 
 class FakeStorage:
-    def __init__(self, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        error: Exception | None = None,
+        runs: dict[int, dict[str, object]] | None = None,
+    ) -> None:
         self.error = error
         self.calls: list[tuple[int, dict[str, object]]] = []
+        self._runs: dict[int, dict[str, object]] = runs or {}
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        return self._runs.get(run_id)
 
     async def update_run(self, run_id: int, updates: dict[str, object]) -> dict[str, object]:
         self.calls.append((run_id, updates))
         if self.error is not None:
             raise self.error
         return {"id": run_id, **updates}
+
+
+def _make_storage(run_id: int = 101, stage: str = "IDEA_READY", **extra: Any) -> FakeStorage:
+    """Create a FakeStorage pre-populated with a single run in the given stage."""
+    run_row: dict[str, object] = {"id": run_id, "current_stage": stage, **extra}
+    return FakeStorage(runs={run_id: run_row})
 
 
 class FakeScriptService:
@@ -98,6 +111,10 @@ def _invoke_task(**kwargs: Any) -> dict[str, object]:
     return run_callable(**kwargs)
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Happy-path tests
+# ──────────────────────────────────────────────────────────────────────
+
 def test_generate_script_happy_path_local_model_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = FakeProvider(result="# Draft")
     entry = FakeEntry(requires_gpu=True, default_params={"temperature": 0.2})
@@ -114,7 +131,7 @@ def test_generate_script_happy_path_local_model_with_gpu_lock(monkeypatch: pytes
     monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda client, task_id: release_calls.append(task_id))
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=101, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
     result = _invoke_task(run_id=101, idea_brief="A city mystery", model_key="qwen3-4b")
@@ -127,6 +144,7 @@ def test_generate_script_happy_path_local_model_with_gpu_lock(monkeypatch: pytes
     assert lock_calls == ["run-101"]
     assert release_calls == ["run-101"]
     assert script_service.calls == [(101, "generated_by_model", "# Draft")]
+    # get_run (stage guard) + update_run (advance to SCRIPT_REVIEW)
     assert storage.calls == [(101, {"current_stage": "SCRIPT_REVIEW", "status": "running"})]
     assert provider.calls[0][1] == {"temperature": 0.2}
 
@@ -141,7 +159,7 @@ def test_generate_script_happy_path_external_model_without_gpu_lock(monkeypatch:
     monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=102, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
     result = _invoke_task(run_id=102, idea_brief="Ocean documentary", model_key="gpt-4.1")
@@ -153,6 +171,33 @@ def test_generate_script_happy_path_external_model_without_gpu_lock(monkeypatch:
     assert storage.calls == [(102, {"current_stage": "SCRIPT_REVIEW", "status": "running"})]
 
 
+def test_generate_script_appends_custom_instructions_to_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="Draft")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=108, stage="IDEA_READY")
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(
+        run_id=108,
+        idea_brief="Base idea",
+        instructions="Use energetic narration",
+    )
+
+    assert result["status"] == "success"
+    used_prompt = provider.calls[0][0]
+    assert "Base idea" in used_prompt
+    assert "Additional instructions:" in used_prompt
+    assert "Use energetic narration" in used_prompt
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Failure tests — task now re-raises, so pytest.raises is required
+# ──────────────────────────────────────────────────────────────────────
+
 def test_generate_script_provider_resolution_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     registry = FakeRegistry(
         entry=FakeEntry(),
@@ -162,13 +207,12 @@ def test_generate_script_provider_resolution_failure(monkeypatch: pytest.MonkeyP
     _patch_registry(monkeypatch, registry)
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=103, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=103, idea_brief="Unknown model", model_key="missing")
+    with pytest.raises(KeyError, match="Model not found"):
+        _invoke_task(run_id=103, idea_brief="Unknown model", model_key="missing")
 
-    assert result["status"] == "failed"
-    assert "Model not found" in str(result["error"])
     assert script_service.calls == []
     assert storage.calls == [(103, {"current_stage": "FAILED", "status": "failed"})]
 
@@ -180,13 +224,12 @@ def test_generate_script_llm_generation_failure_sets_failed_stage(monkeypatch: p
     _patch_registry(monkeypatch, registry)
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=104, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=104, idea_brief="Failing generation")
+    with pytest.raises(RuntimeError, match="generation failed"):
+        _invoke_task(run_id=104, idea_brief="Failing generation")
 
-    assert result["status"] == "failed"
-    assert result["error"] == "generation failed"
     assert script_service.calls == []
     assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
 
@@ -208,15 +251,12 @@ def test_generate_script_gpu_lock_timeout(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda *_: None)
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=105, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=105, idea_brief="Lock timeout")
+    with pytest.raises(TimeoutError, match="lock timeout"):
+        _invoke_task(run_id=105, idea_brief="Lock timeout")
 
-    assert result["status"] == "failed"
-    assert result["error"] == "lock timeout"
-    assert result["gpu_lock_acquired_at"] is None
-    assert result["gpu_lock_released_at"] is None
     assert script_service.calls == []
     assert storage.calls == [(105, {"current_stage": "FAILED", "status": "failed"})]
 
@@ -235,14 +275,13 @@ def test_generate_script_releases_gpu_lock_when_llm_fails(monkeypatch: pytest.Mo
     monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda _, task_id: released.append(task_id))
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=106, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=106, idea_brief="Failure with GPU")
+    with pytest.raises(RuntimeError, match="provider exploded"):
+        _invoke_task(run_id=106, idea_brief="Failure with GPU")
 
-    assert result["status"] == "failed"
     assert released == ["run-106"]
-    assert result["gpu_lock_released_at"] is not None
     assert storage.calls == [(106, {"current_stage": "FAILED", "status": "failed"})]
 
 
@@ -253,34 +292,138 @@ def test_generate_script_script_save_failure(monkeypatch: pytest.MonkeyPatch) ->
     _patch_registry(monkeypatch, registry)
 
     script_service = FakeScriptService(error=RuntimeError("save failed"))
-    storage = FakeStorage()
+    storage = _make_storage(run_id=107, stage="IDEA_READY")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(run_id=107, idea_brief="Save failure")
+    with pytest.raises(RuntimeError, match="save failed"):
+        _invoke_task(run_id=107, idea_brief="Save failure")
 
-    assert result["status"] == "failed"
-    assert result["error"] == "save failed"
     assert storage.calls == [(107, {"current_stage": "FAILED", "status": "failed"})]
 
 
-def test_generate_script_appends_custom_instructions_to_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
-    provider = FakeProvider(result="Draft")
+# ──────────────────────────────────────────────────────────────────────
+# Oracle-requested: stage guard
+# ──────────────────────────────────────────────────────────────────────
+
+def test_stage_guard_rejects_wrong_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must refuse to run when the run is NOT in IDEA_READY or SCRIPT_GENERATING."""
+    provider = FakeProvider(result="Should not be called")
     entry = FakeEntry(requires_gpu=False)
     registry = FakeRegistry(entry=entry, provider=provider)
     _patch_registry(monkeypatch, registry)
 
     script_service = FakeScriptService()
-    storage = FakeStorage()
+    storage = _make_storage(run_id=200, stage="SCRIPT_REVIEW")
     _patch_services(monkeypatch, script_service, storage)
 
-    result = _invoke_task(
-        run_id=108,
-        idea_brief="Base idea",
-        instructions="Use energetic narration",
-    )
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=200, idea_brief="Should be blocked")
+
+    # Provider should never have been called
+    assert provider.calls == []
+    assert script_service.calls == []
+    # Should still mark run as FAILED
+    assert storage.calls == [(200, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_stage_guard_accepts_script_generating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task should accept SCRIPT_GENERATING stage (retry / re-entry scenario)."""
+    provider = FakeProvider(result="Retry draft")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=201, stage="SCRIPT_GENERATING")
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=201, idea_brief="Retry generation")
 
     assert result["status"] == "success"
-    used_prompt = provider.calls[0][0]
-    assert "Base idea" in used_prompt
-    assert "Additional instructions:" in used_prompt
-    assert "Use energetic narration" in used_prompt
+    assert script_service.calls == [(201, "generated_by_model", "Retry draft")]
+
+
+def test_stage_guard_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must fail when run_id does not exist."""
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()  # No runs at all
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(ValueError, match="Run 999 not found"):
+        _invoke_task(run_id=999, idea_brief="Ghost run")
+
+    assert provider.calls == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Oracle-requested: re-raise propagation
+# ──────────────────────────────────────────────────────────────────────
+
+def test_failure_propagates_to_celery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must re-raise exceptions so Celery marks the task as FAILURE."""
+    provider = FakeProvider(error=RuntimeError("LLM exploded"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=300, stage="IDEA_READY")
+    _patch_services(monkeypatch, script_service, storage)
+
+    with pytest.raises(RuntimeError, match="LLM exploded"):
+        _invoke_task(run_id=300, idea_brief="Propagation test")
+
+    # The FAILED stage update must still have happened before re-raise
+    assert storage.calls == [(300, {"current_stage": "FAILED", "status": "failed"})]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Oracle-requested: release_gpu_lock failure resilience
+# ──────────────────────────────────────────────────────────────────────
+
+def test_release_gpu_lock_failure_still_propagates_original_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If release_gpu_lock raises, the original generation error still propagates."""
+    provider = FakeProvider(error=RuntimeError("generation boom"))
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    monkeypatch.setattr(generate_script_module, "acquire_gpu_lock", lambda *_: True)
+    monkeypatch.setattr(
+        generate_script_module,
+        "release_gpu_lock",
+        lambda *_: (_ for _ in ()).throw(ConnectionError("redis gone")),
+    )
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=400, stage="IDEA_READY")
+    _patch_services(monkeypatch, script_service, storage)
+
+    # The original error should propagate (not the release_gpu_lock ConnectionError)
+    with pytest.raises(RuntimeError, match="generation boom"):
+        _invoke_task(run_id=400, idea_brief="Lock release failure")
+
+
+def test_update_run_failure_in_error_path_still_re_raises_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If update_run fails in the error handler, the original exception still propagates."""
+    provider = FakeProvider(error=RuntimeError("original error"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = _make_storage(run_id=500, stage="IDEA_READY")
+    storage.error = ConnectionError("DB down")  # update_run will fail too
+    _patch_services(monkeypatch, script_service, storage)
+
+    # Original error must still propagate even if FAILED-stage update fails
+    with pytest.raises(RuntimeError, match="original error"):
+        _invoke_task(run_id=500, idea_brief="Double failure")

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tasks import generate_script as generate_script_module
+
+
+@dataclass
+class FakeEntry:
+    provider_type: str = "ollama"
+    endpoint: str = "http://ollama:11434"
+    requires_gpu: bool = True
+    default_params: dict[str, object] | None = None
+
+
+class FakeProvider:
+    def __init__(self, result: str = "Generated script", error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[tuple[str, dict[str, object] | None]] = []
+
+    async def generate(self, prompt: str, params: dict[str, object] | None = None) -> str:
+        self.calls.append((prompt, params))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class FakeStorage:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[int, dict[str, object]]] = []
+
+    async def update_run(self, run_id: int, updates: dict[str, object]) -> dict[str, object]:
+        self.calls.append((run_id, updates))
+        if self.error is not None:
+            raise self.error
+        return {"id": run_id, **updates}
+
+
+class FakeScriptService:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[int, str, str | None]] = []
+
+    async def save_draft(self, run_id: int, source_type: str, markdown_content: str | None) -> dict[str, object]:
+        self.calls.append((run_id, source_type, markdown_content))
+        if self.error is not None:
+            raise self.error
+        return {"run_id": run_id, "source_type": source_type, "markdown_content": markdown_content}
+
+
+class FakeRegistry:
+    def __init__(self, entry: FakeEntry, provider: FakeProvider, resolve_error: Exception | None = None) -> None:
+        self.entry = entry
+        self.provider = provider
+        self.resolve_error = resolve_error
+
+    def resolve(self, _model_key: str) -> FakeEntry:
+        if self.resolve_error is not None:
+            raise self.resolve_error
+        return self.entry
+
+    def get_provider(self, _model_key: str) -> FakeProvider:
+        return self.provider
+
+
+def _patch_registry(monkeypatch: pytest.MonkeyPatch, registry: FakeRegistry) -> None:
+    class _ProviderRegistry:
+        @staticmethod
+        def create_default() -> FakeRegistry:
+            return registry
+
+    monkeypatch.setattr(generate_script_module, "ProviderRegistry", _ProviderRegistry)
+
+
+def _patch_redis(monkeypatch: pytest.MonkeyPatch, redis_client: object) -> None:
+    redis_stub = SimpleNamespace(Redis=SimpleNamespace(from_url=lambda _: redis_client))
+    monkeypatch.setattr(generate_script_module, "redis", redis_stub)
+
+
+def _patch_services(
+    monkeypatch: pytest.MonkeyPatch,
+    script_service: FakeScriptService,
+    storage: FakeStorage,
+) -> None:
+    monkeypatch.setattr(generate_script_module, "_script_service", script_service)
+    monkeypatch.setattr(generate_script_module, "_run_service", SimpleNamespace(storage=storage))
+
+
+def _invoke_task(**kwargs: Any) -> dict[str, object]:
+    task = generate_script_module.generate_script
+    run_callable = getattr(task, "run", task)
+    return run_callable(**kwargs)
+
+
+def test_generate_script_happy_path_local_model_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="# Draft")
+    entry = FakeEntry(requires_gpu=True, default_params={"temperature": 0.2})
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    lock_calls: list[str] = []
+    release_calls: list[str] = []
+
+    monkeypatch.setattr(generate_script_module, "acquire_gpu_lock", lambda client, task_id: lock_calls.append(task_id))
+    monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda client, task_id: release_calls.append(task_id))
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=101, idea_brief="A city mystery", model_key="qwen3-4b")
+
+    assert result["status"] == "success"
+    assert result["provider_type"] == "ollama"
+    assert result["endpoint"] == "http://ollama:11434"
+    assert result["gpu_lock_acquired_at"] is not None
+    assert result["gpu_lock_released_at"] is not None
+    assert lock_calls == ["run-101"]
+    assert release_calls == ["run-101"]
+    assert script_service.calls == [(101, "generated_by_model", "# Draft")]
+    assert storage.calls == [(101, {"current_stage": "SCRIPT_REVIEW", "status": "running"})]
+    assert provider.calls[0][1] == {"temperature": 0.2}
+
+
+def test_generate_script_happy_path_external_model_without_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="Script from external")
+    entry = FakeEntry(provider_type="openai", endpoint="https://api.openai.com", requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    monkeypatch.setattr(generate_script_module, "acquire_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+    monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=102, idea_brief="Ocean documentary", model_key="gpt-4.1")
+
+    assert result["status"] == "success"
+    assert result["provider_type"] == "openai"
+    assert result["gpu_lock_acquired_at"] is None
+    assert result["gpu_lock_released_at"] is None
+    assert storage.calls == [(102, {"current_stage": "SCRIPT_REVIEW", "status": "running"})]
+
+
+def test_generate_script_provider_resolution_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = FakeRegistry(
+        entry=FakeEntry(),
+        provider=FakeProvider(),
+        resolve_error=KeyError("Model not found"),
+    )
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=103, idea_brief="Unknown model", model_key="missing")
+
+    assert result["status"] == "failed"
+    assert "Model not found" in str(result["error"])
+    assert script_service.calls == []
+    assert storage.calls == [(103, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_llm_generation_failure_sets_failed_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(error=RuntimeError("generation failed"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=104, idea_brief="Failing generation")
+
+    assert result["status"] == "failed"
+    assert result["error"] == "generation failed"
+    assert script_service.calls == []
+    assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_gpu_lock_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    monkeypatch.setattr(
+        generate_script_module,
+        "acquire_gpu_lock",
+        lambda *_: (_ for _ in ()).throw(TimeoutError("lock timeout")),
+    )
+    monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda *_: None)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=105, idea_brief="Lock timeout")
+
+    assert result["status"] == "failed"
+    assert result["error"] == "lock timeout"
+    assert result["gpu_lock_acquired_at"] is None
+    assert result["gpu_lock_released_at"] is None
+    assert script_service.calls == []
+    assert storage.calls == [(105, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_releases_gpu_lock_when_llm_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(error=RuntimeError("provider exploded"))
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    released: list[str] = []
+    monkeypatch.setattr(generate_script_module, "acquire_gpu_lock", lambda *_: True)
+    monkeypatch.setattr(generate_script_module, "release_gpu_lock", lambda _, task_id: released.append(task_id))
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=106, idea_brief="Failure with GPU")
+
+    assert result["status"] == "failed"
+    assert released == ["run-106"]
+    assert result["gpu_lock_released_at"] is not None
+    assert storage.calls == [(106, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_script_save_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="Draft text")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(error=RuntimeError("save failed"))
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=107, idea_brief="Save failure")
+
+    assert result["status"] == "failed"
+    assert result["error"] == "save failed"
+    assert storage.calls == [(107, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_generate_script_appends_custom_instructions_to_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(result="Draft")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(
+        run_id=108,
+        idea_brief="Base idea",
+        instructions="Use energetic narration",
+    )
+
+    assert result["status"] == "success"
+    used_prompt = provider.calls[0][0]
+    assert "Base idea" in used_prompt
+    assert "Additional instructions:" in used_prompt
+    assert "Use energetic narration" in used_prompt

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -48,6 +48,23 @@ class FakeStorage:
             raise self.error
         return {"id": run_id, **updates}
 
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        if self.error is not None:
+            raise self.error
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
 
 def _make_storage(run_id: int = 101, stage: str = "IDEA_READY", **extra: Any) -> FakeStorage:
     """Create a FakeStorage pre-populated with a single run in the given stage."""
@@ -499,12 +516,13 @@ def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.Monke
 
 
 class RaceConditionStorage(FakeStorage):
-    """Storage that simulates a competing task advancing the run between calls.
+    """Storage that simulates a competing task advancing the run between operations.
 
-    After `advance_after` calls to get_run for the target run_id, the run's
-    stage is changed to `advanced_stage`. This allows testing both:
-    - Success path race: advance_after=1 (guard sees IDEA_READY, success check sees advanced)
-    - Failure path race: advance_after=1 (guard sees IDEA_READY, error handler sees advanced)
+    After `advance_after` read/CAS operations on the target run_id, the run's
+    stage is changed to `advanced_stage` before the operation reads it. This
+    allows testing both:
+    - Success path race: advance_after=1 (guard sees IDEA_READY, CAS sees advanced)
+    - Failure path race: advance_after=1 (guard sees IDEA_READY, CAS sees advanced)
     """
 
     def __init__(self, run_id: int, initial_stage: str, advanced_stage: str, advance_after: int = 1) -> None:
@@ -512,14 +530,36 @@ class RaceConditionStorage(FakeStorage):
         self._target_id = run_id
         self._advanced_stage = advanced_stage
         self._advance_after = advance_after
-        self._get_count = 0
+        self._op_count = 0
+
+    def _maybe_advance(self, run_id: int) -> None:
+        """Simulate a competing task advancing the run after N operations."""
+        if run_id == self._target_id:
+            self._op_count += 1
+            if self._op_count > self._advance_after:
+                self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
 
     async def get_run(self, run_id: int) -> dict[str, object] | None:
-        self._get_count += 1
-        if run_id == self._target_id and self._get_count > self._advance_after:
-            self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
+        self._maybe_advance(run_id)
         return self._runs.get(run_id)
 
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        """Atomic CAS — advance happens before the check, simulating a race."""
+        self._maybe_advance(run_id)
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
 
 def test_conditional_fail_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
     """If a competing task advances the run to SCRIPT_REVIEW before the error handler

--- a/apps/worker-orchestrator/tests/test_generate_script.py
+++ b/apps/worker-orchestrator/tests/test_generate_script.py
@@ -499,18 +499,24 @@ def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.Monke
 
 
 class RaceConditionStorage(FakeStorage):
-    """Storage that simulates a competing task advancing the run between guard and error handler."""
+    """Storage that simulates a competing task advancing the run between calls.
 
-    def __init__(self, run_id: int, initial_stage: str, advanced_stage: str) -> None:
+    After `advance_after` calls to get_run for the target run_id, the run's
+    stage is changed to `advanced_stage`. This allows testing both:
+    - Success path race: advance_after=1 (guard sees IDEA_READY, success check sees advanced)
+    - Failure path race: advance_after=1 (guard sees IDEA_READY, error handler sees advanced)
+    """
+
+    def __init__(self, run_id: int, initial_stage: str, advanced_stage: str, advance_after: int = 1) -> None:
         super().__init__(runs={run_id: {"id": run_id, "current_stage": initial_stage}})
         self._target_id = run_id
         self._advanced_stage = advanced_stage
+        self._advance_after = advance_after
         self._get_count = 0
 
     async def get_run(self, run_id: int) -> dict[str, object] | None:
         self._get_count += 1
-        if run_id == self._target_id and self._get_count > 1:
-            # Second get_run call (from _conditional_fail) sees the advanced stage
+        if run_id == self._target_id and self._get_count > self._advance_after:
             self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
         return self._runs.get(run_id)
 
@@ -561,3 +567,38 @@ def test_conditional_fail_marks_failed_when_still_in_generating_stage(monkeypatc
 
     # Run was still in IDEA_READY -> FAILED write should happen
     assert storage.calls == [(901, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_success_transition_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a competing task advances the run past generation before this task's
+    success transition, the SCRIPT_REVIEW write must be skipped.
+
+    Scenario: two duplicate tasks both pass the stage guard (both see IDEA_READY).
+    Task A completes and moves the run to VISUAL_PLAN_GENERATING. Task B then
+    completes generation -- its success transition re-checks and sees the run is
+    no longer in a generating stage, so it skips the SCRIPT_REVIEW write.
+    """
+    provider = FakeProvider(result="Duplicate draft")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    # First get_run (stage guard) returns IDEA_READY -> passes guard.
+    # Second get_run (success transition check) returns VISUAL_PLAN_GENERATING
+    # -> competing task already advanced the run further.
+    storage = RaceConditionStorage(
+        run_id=950, initial_stage="IDEA_READY", advanced_stage="VISUAL_PLAN_GENERATING"
+    )
+    _patch_services(monkeypatch, script_service, storage)
+
+    result = _invoke_task(run_id=950, idea_brief="Duplicate success scenario")
+
+    # Task still reports success (it generated and saved the draft)
+    assert result["status"] == "success"
+    # But the SCRIPT_REVIEW update_run must NOT have happened
+    assert storage.calls == []
+    # Draft was still saved (that is fine -- it will not be the active one)
+    assert script_service.calls == [(950, "generated_by_model", "Duplicate draft")]
+    # Run stays at the advanced stage, not overwritten to SCRIPT_REVIEW
+    assert storage._runs[950]["current_stage"] == "VISUAL_PLAN_GENERATING"

--- a/apps/worker-orchestrator/tests/test_generate_subtitles.py
+++ b/apps/worker-orchestrator/tests/test_generate_subtitles.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from tasks import generate_subtitles as generate_subtitles_module
+
+
+@dataclass
+class FakeEntry:
+    provider_type: str = "faster-whisper"
+    endpoint: str = "http://whisper:9000"
+    requires_gpu: bool = True
+    default_params: dict[str, object] | None = None
+
+
+class FakeProvider:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[str, dict[str, object] | None]] = []
+
+    async def generate(self, script_text: str, params: dict[str, object] | None = None) -> None:
+        self.calls.append((script_text, params))
+        if self.error is not None:
+            raise self.error
+
+
+class FakeStorage:
+    def __init__(self, runs: dict[int, dict[str, object]] | None = None) -> None:
+        self._runs: dict[int, dict[str, object]] = runs or {}
+        self.calls: list[tuple[int, dict[str, object]]] = []
+        self.cas_calls: list[tuple[int, dict[str, object], frozenset[str]]] = []
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        return self._runs.get(run_id)
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self.cas_calls.append((run_id, updates, expected_stages))
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
+
+
+def _make_storage(run_id: int = 101, stage: str = "AUDIO_GENERATING") -> FakeStorage:
+    run_row: dict[str, object] = {"id": run_id, "current_stage": stage}
+    return FakeStorage(runs={run_id: run_row})
+
+
+@dataclass
+class FakeSection:
+    text: str = "Section text"
+    display_text: str | None = None
+
+
+@dataclass
+class FakeScriptDraft:
+    markdown_content: str | None = None
+    structured_script: list[FakeSection] | None = None
+
+
+class FakeScriptService:
+    def __init__(self, draft: FakeScriptDraft | None = None) -> None:
+        self.draft = draft
+
+    async def get_active_draft(self, _run_id: int) -> FakeScriptDraft | None:
+        return self.draft
+
+
+@dataclass
+class FakeAudioArtifact:
+    path: str
+
+
+class FakeAudioService:
+    def __init__(self, artifact: FakeAudioArtifact | None = None) -> None:
+        self.artifact = artifact
+
+    async def get_latest(self, _run_id: int) -> FakeAudioArtifact | None:
+        return self.artifact
+
+
+@dataclass
+class FakeSubtitleArtifact:
+    id: int
+    path: str
+
+
+class FakeSubtitleService:
+    def __init__(self, artifact_id: int = 1) -> None:
+        self.artifact_id = artifact_id
+        self.calls: list[dict[str, object]] = []
+
+    async def create_artifact(
+        self,
+        run_id: int,
+        path: str,
+        *,
+        format: str = "srt",
+        model_used: str | None = None,
+        provider_type: str | None = None,
+    ) -> FakeSubtitleArtifact:
+        call_data = {
+            "run_id": run_id,
+            "path": path,
+            "format": format,
+            "model_used": model_used,
+            "provider_type": provider_type,
+        }
+        self.calls.append(call_data)
+        return FakeSubtitleArtifact(id=self.artifact_id, path=path)
+
+
+class FakeRegistry:
+    def __init__(self, entry: FakeEntry, provider: FakeProvider) -> None:
+        self.entry = entry
+        self.provider = provider
+
+    def resolve(self, _model_key: str) -> FakeEntry:
+        return self.entry
+
+    def get_provider(self, _model_key: str) -> FakeProvider:
+        return self.provider
+
+
+def _patch_registry(monkeypatch: pytest.MonkeyPatch, registry: FakeRegistry) -> None:
+    class _ProviderRegistry:
+        @staticmethod
+        def create_default() -> FakeRegistry:
+            return registry
+
+    monkeypatch.setattr(generate_subtitles_module, "ProviderRegistry", _ProviderRegistry)
+
+
+def _patch_redis(monkeypatch: pytest.MonkeyPatch, redis_client: object) -> None:
+    redis_stub = SimpleNamespace(Redis=SimpleNamespace(from_url=lambda _: redis_client))
+    monkeypatch.setattr(generate_subtitles_module, "redis", redis_stub)
+
+
+def _patch_services(
+    monkeypatch: pytest.MonkeyPatch,
+    script_service: FakeScriptService,
+    audio_service: FakeAudioService,
+    subtitle_service: FakeSubtitleService,
+    storage: FakeStorage,
+) -> None:
+    monkeypatch.setattr(generate_subtitles_module, "_script_service", script_service)
+    monkeypatch.setattr(generate_subtitles_module, "_audio_service", audio_service)
+    monkeypatch.setattr(generate_subtitles_module, "_subtitle_service", subtitle_service)
+    monkeypatch.setattr(generate_subtitles_module, "_run_service", SimpleNamespace(storage=storage))
+
+
+def _invoke_task(**kwargs: Any) -> dict[str, object]:
+    task = generate_subtitles_module.generate_subtitles
+    run_callable = getattr(task, "run", task)
+    return run_callable(**kwargs)
+
+
+def test_generate_subtitles_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=True, default_params={"temperature": 0.1})
+    _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    lock_calls: list[str] = []
+    release_calls: list[str] = []
+    monkeypatch.setattr(generate_subtitles_module, "acquire_gpu_lock", lambda _, task_id: lock_calls.append(task_id))
+    monkeypatch.setattr(generate_subtitles_module, "release_gpu_lock", lambda _, task_id: release_calls.append(task_id))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Hello world script"))
+    audio_service = FakeAudioService(artifact=None)
+    subtitle_service = FakeSubtitleService(artifact_id=33)
+    storage = _make_storage(run_id=101, stage="AUDIO_GENERATING")
+    _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
+
+    result = _invoke_task(run_id=101, subtitle_model="whisper-large", subtitle_format="srt")
+
+    assert result["status"] == "success"
+    assert result["subtitle_artifact_id"] == 33
+    assert result["provider_type"] == "faster-whisper"
+    assert result["endpoint"] == "http://whisper:9000"
+    assert result["gpu_lock_acquired_at"] is not None
+    assert result["gpu_lock_released_at"] is not None
+    assert result["subtitle_path"] == "data/artifacts/101/subtitles/subtitles.srt"
+    assert result["audio_path"] is None
+
+    assert lock_calls == ["run-101"]
+    assert release_calls == ["run-101"]
+
+    assert provider.calls == [
+        (
+            "Hello world script",
+            {
+                "temperature": 0.1,
+                "format": "srt",
+                "output_path": "data/artifacts/101/subtitles/subtitles.srt",
+            },
+        )
+    ]
+    assert subtitle_service.calls == [
+        {
+            "run_id": 101,
+            "path": "data/artifacts/101/subtitles/subtitles.srt",
+            "format": "srt",
+            "model_used": "whisper-large",
+            "provider_type": "faster-whisper",
+        }
+    ]
+    assert storage.calls == [(101, {"current_stage": "RENDER_GENERATING", "status": "running"})]
+    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING", "SUBTITLE_GENERATING"})
+
+
+def test_generate_subtitles_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Any"))
+    audio_service = FakeAudioService(artifact=None)
+    subtitle_service = FakeSubtitleService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
+
+    with pytest.raises(ValueError, match="Run 999 not found"):
+        _invoke_task(run_id=999)
+
+    assert provider.calls == []
+    assert storage.calls == []
+    assert subtitle_service.calls == []
+
+
+def test_generate_subtitles_wrong_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Any"))
+    audio_service = FakeAudioService(artifact=None)
+    subtitle_service = FakeSubtitleService()
+    storage = _make_storage(run_id=102, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
+
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=102)
+
+    assert provider.calls == []
+    assert storage.calls == []
+    assert subtitle_service.calls == []
+
+
+def test_generate_subtitles_no_script(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=None)
+    audio_service = FakeAudioService(artifact=None)
+    subtitle_service = FakeSubtitleService()
+    storage = _make_storage(run_id=103, stage="AUDIO_GENERATING")
+    _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
+
+    with pytest.raises(ValueError, match="No script draft found"):
+        _invoke_task(run_id=103)
+
+    assert provider.calls == []
+    assert storage.calls == []
+    assert subtitle_service.calls == []
+
+
+def test_generate_subtitles_provider_failure_marks_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(error=RuntimeError("subtitle provider failed"))
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Some script"))
+    audio_service = FakeAudioService(artifact=None)
+    subtitle_service = FakeSubtitleService()
+    storage = _make_storage(run_id=104, stage="AUDIO_GENERATING")
+    _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
+
+    with pytest.raises(RuntimeError, match="subtitle provider failed"):
+        _invoke_task(run_id=104)
+
+    assert subtitle_service.calls == []
+    assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
+    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING", "SUBTITLE_GENERATING"})
+
+
+def test_generate_subtitles_with_audio_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Narration text"))
+    audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="data/artifacts/105/audio/audio.wav"))
+    subtitle_service = FakeSubtitleService()
+    storage = _make_storage(run_id=105, stage="AUDIO_GENERATING")
+    _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
+
+    result = _invoke_task(run_id=105, subtitle_format="vtt")
+
+    assert result["status"] == "success"
+    assert result["audio_path"] == "data/artifacts/105/audio/audio.wav"
+    params = provider.calls[0][1]
+    assert params is not None
+    assert params["audio_path"] == "data/artifacts/105/audio/audio.wav"
+    assert params["format"] == "vtt"
+    assert params["output_path"] == "data/artifacts/105/subtitles/subtitles.vtt"
+
+
+def test_generate_subtitles_without_audio(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Narration text"))
+    audio_service = FakeAudioService(artifact=None)
+    subtitle_service = FakeSubtitleService()
+    storage = _make_storage(run_id=106, stage="SUBTITLE_GENERATING")
+    _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
+
+    result = _invoke_task(run_id=106)
+
+    assert result["status"] == "success"
+    assert result["audio_path"] is None
+    params = provider.calls[0][1]
+    assert params is not None
+    assert "audio_path" not in params
+    assert params["format"] == "srt"
+    assert params["output_path"] == "data/artifacts/106/subtitles/subtitles.srt"

--- a/apps/worker-orchestrator/tests/test_generate_subtitles.py
+++ b/apps/worker-orchestrator/tests/test_generate_subtitles.py
@@ -336,3 +336,57 @@ def test_generate_subtitles_without_audio(monkeypatch: pytest.MonkeyPatch) -> No
     assert "audio_path" not in params
     assert params["format"] == "srt"
     assert params["output_path"] == "data/artifacts/106/subtitles/subtitles.srt"
+
+
+class _CASSkipStorage(FakeStorage):
+    """FakeStorage variant where conditional_update_run always returns (False, row).
+
+    Simulates a concurrent stage change between the provider call and
+    the atomic success/failure transition.
+    """
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self.cas_calls.append((run_id, updates, expected_stages))
+        row = self._runs.get(run_id)
+        # Always reject — stage was moved by another worker.
+        return False, dict(row) if row else None
+
+
+def test_generate_subtitles_cas_skip_on_stage_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When another worker advances the stage during subtitle generation,
+    the CAS success transition is skipped gracefully (no error, no stage mutation).
+    """
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Narration text"))
+    audio_service = FakeAudioService(artifact=None)
+    subtitle_service = FakeSubtitleService(artifact_id=50)
+
+    # Storage starts at AUDIO_GENERATING (passes stage guard) but CAS always rejects.
+    run_row: dict[str, object] = {"id": 107, "current_stage": "AUDIO_GENERATING"}
+    storage = _CASSkipStorage(runs={107: run_row})
+    _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
+
+    result = _invoke_task(run_id=107)
+
+    # Task still succeeds — subtitles were generated and artifact created.
+    assert result["status"] == "success"
+    assert result["subtitle_artifact_id"] == 50
+
+    # Provider was called normally.
+    assert len(provider.calls) == 1
+
+    # Subtitle artifact was saved.
+    assert len(subtitle_service.calls) == 1
+
+    # CAS was attempted but the transition was NOT applied.
+    assert len(storage.cas_calls) == 1
+    assert storage.cas_calls[0][1] == {"current_stage": "RENDER_GENERATING", "status": "running"}
+    # No actual updates were applied (calls stays empty).
+    assert storage.calls == []

--- a/apps/worker-orchestrator/tests/test_generate_visual_plan.py
+++ b/apps/worker-orchestrator/tests/test_generate_visual_plan.py
@@ -1,0 +1,793 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from tasks import generate_visual_plan as generate_visual_plan_module
+
+
+@dataclass
+class FakeEntry:
+    provider_type: str = "ollama"
+    endpoint: str = "http://ollama:11434"
+    requires_gpu: bool = True
+    default_params: dict[str, object] | None = None
+
+
+class FakeProvider:
+    def __init__(self, result: str = "[]", error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[tuple[str, dict[str, object] | None]] = []
+
+    async def generate(self, prompt: str, params: dict[str, object] | None = None) -> str:
+        self.calls.append((prompt, params))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class FakeStorage:
+    def __init__(
+        self,
+        error: Exception | None = None,
+        runs: dict[int, dict[str, object]] | None = None,
+    ) -> None:
+        self.error = error
+        self.calls: list[tuple[int, dict[str, object]]] = []
+        self._runs: dict[int, dict[str, object]] = runs or {}
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        return self._runs.get(run_id)
+
+    async def update_run(self, run_id: int, updates: dict[str, object]) -> dict[str, object]:
+        self.calls.append((run_id, updates))
+        if self.error is not None:
+            raise self.error
+        return {"id": run_id, **updates}
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        if self.error is not None:
+            raise self.error
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
+
+
+def _make_storage(run_id: int = 101, stage: str = "SCRIPT_REVIEW", **extra: Any) -> FakeStorage:
+    """Create a FakeStorage pre-populated with a single run in the given stage."""
+    run_row: dict[str, object] = {"id": run_id, "current_stage": stage, **extra}
+    return FakeStorage(runs={run_id: run_row})
+
+
+@dataclass
+class FakeScriptDraft:
+    """Minimal fake for the ScriptDraft domain model returned by script_service."""
+    markdown_content: str | None = None
+    structured_script: list[Any] | None = None
+
+
+class FakeScriptService:
+    def __init__(
+        self,
+        draft: FakeScriptDraft | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.draft = draft
+        self.error = error
+
+    async def get_active_draft(self, run_id: int) -> FakeScriptDraft | None:
+        if self.error is not None:
+            raise self.error
+        return self.draft
+
+
+@dataclass
+class FakeSection:
+    """Minimal structured script section with model_dump support."""
+    section_id: str = "sec-0"
+    type: str = "hook"
+    text: str = "Hook text"
+
+    def model_dump(self, mode: str = "python") -> dict[str, str]:
+        return {"section_id": self.section_id, "type": self.type, "text": self.text}
+
+
+class FakeVisualPlanService:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[int, int]] = []  # (run_id, num_scenes)
+
+    async def save_plan(self, run_id: int, scenes: list[Any]) -> SimpleNamespace:
+        self.calls.append((run_id, len(scenes)))
+        if self.error is not None:
+            raise self.error
+        return SimpleNamespace(run_id=run_id, scenes=scenes, version=1)
+
+
+class FakeRegistry:
+    def __init__(self, entry: FakeEntry, provider: FakeProvider, resolve_error: Exception | None = None) -> None:
+        self.entry = entry
+        self.provider = provider
+        self.resolve_error = resolve_error
+
+    def resolve(self, _model_key: str) -> FakeEntry:
+        if self.resolve_error is not None:
+            raise self.resolve_error
+        return self.entry
+
+    def get_provider(self, _model_key: str) -> FakeProvider:
+        return self.provider
+
+
+def _patch_registry(monkeypatch: pytest.MonkeyPatch, registry: FakeRegistry) -> None:
+    class _ProviderRegistry:
+        @staticmethod
+        def create_default() -> FakeRegistry:
+            return registry
+
+    monkeypatch.setattr(generate_visual_plan_module, "ProviderRegistry", _ProviderRegistry)
+
+
+def _patch_redis(monkeypatch: pytest.MonkeyPatch, redis_client: object) -> None:
+    redis_stub = SimpleNamespace(Redis=SimpleNamespace(from_url=lambda _: redis_client))
+    monkeypatch.setattr(generate_visual_plan_module, "redis", redis_stub)
+
+
+def _patch_services(
+    monkeypatch: pytest.MonkeyPatch,
+    script_service: FakeScriptService,
+    visual_plan_service: FakeVisualPlanService,
+    storage: FakeStorage,
+) -> None:
+    monkeypatch.setattr(generate_visual_plan_module, "_script_service", script_service)
+    monkeypatch.setattr(generate_visual_plan_module, "_visual_plan_service", visual_plan_service)
+    monkeypatch.setattr(generate_visual_plan_module, "_run_service", SimpleNamespace(storage=storage))
+
+
+def _invoke_task(**kwargs: Any) -> dict[str, object]:
+    task = generate_visual_plan_module.generate_visual_plan
+    run_callable = getattr(task, "run", task)
+    return run_callable(**kwargs)
+
+
+def _make_llm_response(sections: list[dict[str, str]]) -> str:
+    """Build a valid LLM JSON response matching the expected format."""
+    scenes = []
+    for sec in sections:
+        scenes.append({
+            "section_id": sec.get("section_id", "sec-0"),
+            "prompt": f"Visual for {sec.get('text', '')}",
+            "style_tags": ["cinematic"],
+            "mood": "dramatic",
+            "composition": "wide shot",
+        })
+    return json.dumps(scenes)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Happy-path tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_happy_path_local_model_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    sections = [FakeSection(section_id="sec-1", type="hook", text="Opening hook")]
+    llm_response = _make_llm_response([s.model_dump() for s in sections])
+    provider = FakeProvider(result=llm_response)
+    entry = FakeEntry(requires_gpu=True, default_params={"temperature": 0.3})
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    lock_calls: list[str] = []
+    release_calls: list[str] = []
+
+    monkeypatch.setattr(generate_visual_plan_module, "acquire_gpu_lock", lambda client, task_id: lock_calls.append(task_id))
+    monkeypatch.setattr(generate_visual_plan_module, "release_gpu_lock", lambda client, task_id: release_calls.append(task_id))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=101, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    result = _invoke_task(run_id=101, model_key="qwen3-4b")
+
+    assert result["status"] == "success"
+    assert result["provider_type"] == "ollama"
+    assert result["endpoint"] == "http://ollama:11434"
+    assert result["gpu_lock_acquired_at"] is not None
+    assert result["gpu_lock_released_at"] is not None
+    assert result["scene_count"] == 1
+    assert lock_calls == ["run-101"]
+    assert release_calls == ["run-101"]
+    assert visual_plan_service.calls == [(101, 1)]
+    assert storage.calls == [(101, {"current_stage": "VISUAL_PLAN_REVIEW", "status": "running"})]
+    assert provider.calls[0][1] == {"temperature": 0.3}
+
+
+def test_happy_path_external_model_without_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    sections = [FakeSection(section_id="sec-1", type="hook", text="Hook")]
+    llm_response = _make_llm_response([s.model_dump() for s in sections])
+    provider = FakeProvider(result=llm_response)
+    entry = FakeEntry(provider_type="openai", endpoint="https://api.openai.com", requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    monkeypatch.setattr(generate_visual_plan_module, "acquire_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+    monkeypatch.setattr(generate_visual_plan_module, "release_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=102, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    result = _invoke_task(run_id=102, model_key="gpt-4.1")
+
+    assert result["status"] == "success"
+    assert result["provider_type"] == "openai"
+    assert result["gpu_lock_acquired_at"] is None
+    assert result["gpu_lock_released_at"] is None
+    assert storage.calls == [(102, {"current_stage": "VISUAL_PLAN_REVIEW", "status": "running"})]
+
+
+def test_happy_path_multi_section_script(monkeypatch: pytest.MonkeyPatch) -> None:
+    sections = [
+        FakeSection(section_id="sec-1", type="hook", text="Opening"),
+        FakeSection(section_id="sec-2", type="body", text="Main content"),
+        FakeSection(section_id="sec-3", type="cta", text="Call to action"),
+    ]
+    llm_response = _make_llm_response([s.model_dump() for s in sections])
+    provider = FakeProvider(result=llm_response)
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=103, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    result = _invoke_task(run_id=103)
+
+    assert result["status"] == "success"
+    assert result["scene_count"] == 3
+    assert visual_plan_service.calls == [(103, 3)]
+
+
+def test_happy_path_markdown_fallback_single_section(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When draft has only markdown_content (no structured_script), produces a single scene."""
+    llm_response = json.dumps([{
+        "section_id": "sec-0",
+        "prompt": "Visual for markdown",
+        "style_tags": ["minimalist"],
+        "mood": "calm",
+        "composition": "medium shot",
+    }])
+    provider = FakeProvider(result=llm_response)
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="# My Script\nSome content"))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=104, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    result = _invoke_task(run_id=104)
+
+    assert result["status"] == "success"
+    assert result["scene_count"] == 1
+    assert visual_plan_service.calls == [(104, 1)]
+
+
+def test_style_preset_passed_to_system_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    sections = [FakeSection()]
+    llm_response = _make_llm_response([s.model_dump() for s in sections])
+    provider = FakeProvider(result=llm_response)
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=105, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    result = _invoke_task(run_id=105, style_preset="anime")
+
+    assert result["status"] == "success"
+    used_prompt = provider.calls[0][0]
+    assert "anime" in used_prompt
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Failure tests — task re-raises, pytest.raises required
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_provider_resolution_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = FakeRegistry(
+        entry=FakeEntry(),
+        provider=FakeProvider(),
+        resolve_error=KeyError("Model not found"),
+    )
+    _patch_registry(monkeypatch, registry)
+
+    sections = [FakeSection()]
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=201, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(KeyError, match="Model not found"):
+        _invoke_task(run_id=201, model_key="missing")
+
+    assert visual_plan_service.calls == []
+    assert storage.calls == [(201, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_llm_generation_failure_sets_failed_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(error=RuntimeError("generation failed"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    sections = [FakeSection()]
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=202, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(RuntimeError, match="generation failed"):
+        _invoke_task(run_id=202)
+
+    assert visual_plan_service.calls == []
+    assert storage.calls == [(202, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_gpu_lock_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    monkeypatch.setattr(
+        generate_visual_plan_module,
+        "acquire_gpu_lock",
+        lambda *_: (_ for _ in ()).throw(TimeoutError("lock timeout")),
+    )
+    monkeypatch.setattr(generate_visual_plan_module, "release_gpu_lock", lambda *_: None)
+
+    sections = [FakeSection()]
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=203, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(TimeoutError, match="lock timeout"):
+        _invoke_task(run_id=203)
+
+    assert visual_plan_service.calls == []
+    assert storage.calls == [(203, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_releases_gpu_lock_when_llm_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(error=RuntimeError("provider exploded"))
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    released: list[str] = []
+    monkeypatch.setattr(generate_visual_plan_module, "acquire_gpu_lock", lambda *_: True)
+    monkeypatch.setattr(generate_visual_plan_module, "release_gpu_lock", lambda _, task_id: released.append(task_id))
+
+    sections = [FakeSection()]
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=204, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(RuntimeError, match="provider exploded"):
+        _invoke_task(run_id=204)
+
+    assert released == ["run-204"]
+    assert storage.calls == [(204, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_visual_plan_save_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    sections = [FakeSection()]
+    llm_response = _make_llm_response([s.model_dump() for s in sections])
+    provider = FakeProvider(result=llm_response)
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService(error=RuntimeError("save failed"))
+    storage = _make_storage(run_id=205, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(RuntimeError, match="save failed"):
+        _invoke_task(run_id=205)
+
+    assert storage.calls == [(205, {"current_stage": "FAILED", "status": "failed"})]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Stage guard tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_stage_guard_rejects_wrong_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must refuse to run when the run is NOT in SCRIPT_REVIEW or VISUAL_PLAN_GENERATING."""
+    provider = FakeProvider(result="Should not be called")
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=[FakeSection()]))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=301, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=301)
+
+    assert provider.calls == []
+    assert visual_plan_service.calls == []
+    assert storage.calls == []
+
+
+def test_stage_guard_accepts_visual_plan_generating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task should accept VISUAL_PLAN_GENERATING stage (retry / re-entry scenario)."""
+    sections = [FakeSection()]
+    llm_response = _make_llm_response([s.model_dump() for s in sections])
+    provider = FakeProvider(result=llm_response)
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=302, stage="VISUAL_PLAN_GENERATING")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    result = _invoke_task(run_id=302)
+
+    assert result["status"] == "success"
+    assert visual_plan_service.calls == [(302, 1)]
+
+
+def test_stage_guard_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must fail when run_id does not exist."""
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    visual_plan_service = FakeVisualPlanService()
+    storage = FakeStorage()  # No runs at all
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(ValueError, match="Run 999 not found"):
+        _invoke_task(run_id=999)
+
+    assert provider.calls == []
+    assert storage.calls == []
+
+
+def test_stage_guard_no_script_draft(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must fail when no script draft exists for the run."""
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=None)
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=303, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(ValueError, match="No script draft found"):
+        _invoke_task(run_id=303)
+
+    assert provider.calls == []
+    assert storage.calls == []
+
+
+def test_stage_guard_empty_script_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must fail when script draft has no content (no sections, no markdown)."""
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft())  # no structured_script, no markdown
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=304, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(ValueError, match="has no content"):
+        _invoke_task(run_id=304)
+
+    assert provider.calls == []
+    assert storage.calls == []
+
+
+def test_stage_guard_invalid_stage_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed current_stage in storage should raise without marking FAILED."""
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService()
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=305, stage="BOGUS_STAGE")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(ValueError):
+        _invoke_task(run_id=305)
+
+    assert provider.calls == []
+    assert storage.calls == []
+
+
+def test_stage_guard_blocks_before_provider_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stage guard must reject BEFORE provider resolution, so a bad model_key
+    with a wrong-stage run does NOT mark the run as FAILED."""
+    registry = FakeRegistry(
+        entry=FakeEntry(),
+        provider=FakeProvider(),
+        resolve_error=KeyError("Model not found"),
+    )
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=[FakeSection()]))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=306, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=306, model_key="bad-model")
+
+    assert storage.calls == []
+    run = storage._runs[306]
+    assert run["current_stage"] == "VISUAL_PLAN_REVIEW"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Re-raise propagation and lock resilience
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_failure_propagates_to_celery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task must re-raise exceptions so Celery marks the task as FAILURE."""
+    sections = [FakeSection()]
+    provider = FakeProvider(error=RuntimeError("LLM exploded"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=401, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(RuntimeError, match="LLM exploded"):
+        _invoke_task(run_id=401)
+
+    assert storage.calls == [(401, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_release_gpu_lock_failure_still_propagates_original_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If release_gpu_lock raises, the original generation error still propagates."""
+    sections = [FakeSection()]
+    provider = FakeProvider(error=RuntimeError("generation boom"))
+    entry = FakeEntry(requires_gpu=True)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    monkeypatch.setattr(generate_visual_plan_module, "acquire_gpu_lock", lambda *_: True)
+    monkeypatch.setattr(
+        generate_visual_plan_module,
+        "release_gpu_lock",
+        lambda *_: (_ for _ in ()).throw(ConnectionError("redis gone")),
+    )
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=402, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(RuntimeError, match="generation boom"):
+        _invoke_task(run_id=402)
+
+
+def test_update_run_failure_in_error_path_still_re_raises_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If conditional_update_run fails in error handler, original exception still propagates."""
+    sections = [FakeSection()]
+    provider = FakeProvider(error=RuntimeError("original error"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = _make_storage(run_id=403, stage="SCRIPT_REVIEW")
+    storage.error = ConnectionError("DB down")
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(RuntimeError, match="original error"):
+        _invoke_task(run_id=403)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Race condition / CAS tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+class RaceConditionStorage(FakeStorage):
+    """Storage that simulates a competing task advancing the run between operations."""
+
+    def __init__(self, run_id: int, initial_stage: str, advanced_stage: str, advance_after: int = 1) -> None:
+        super().__init__(runs={run_id: {"id": run_id, "current_stage": initial_stage}})
+        self._target_id = run_id
+        self._advanced_stage = advanced_stage
+        self._advance_after = advance_after
+        self._op_count = 0
+
+    def _maybe_advance(self, run_id: int) -> None:
+        if run_id == self._target_id:
+            self._op_count += 1
+            if self._op_count > self._advance_after:
+                self._runs[run_id] = {"id": run_id, "current_stage": self._advanced_stage}
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        self._maybe_advance(run_id)
+        return self._runs.get(run_id)
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self._maybe_advance(run_id)
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
+
+
+def test_conditional_fail_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a competing task advances the run before this task's error handler,
+    the FAILED write must be skipped."""
+    sections = [FakeSection()]
+    provider = FakeProvider(error=RuntimeError("task B failed"))
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = RaceConditionStorage(
+        run_id=501, initial_stage="SCRIPT_REVIEW", advanced_stage="VISUAL_PLAN_REVIEW"
+    )
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    with pytest.raises(RuntimeError, match="task B failed"):
+        _invoke_task(run_id=501)
+
+    assert storage.calls == []
+    assert storage._runs[501]["current_stage"] == "VISUAL_PLAN_REVIEW"
+
+
+def test_success_transition_skips_when_run_already_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a competing task advances the run past visual plan generation,
+    the VISUAL_PLAN_REVIEW write must be skipped."""
+    sections = [FakeSection()]
+    llm_response = _make_llm_response([s.model_dump() for s in sections])
+    provider = FakeProvider(result=llm_response)
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(structured_script=sections))
+    visual_plan_service = FakeVisualPlanService()
+    storage = RaceConditionStorage(
+        run_id=502, initial_stage="SCRIPT_REVIEW", advanced_stage="VISUAL_ASSET_GENERATING"
+    )
+    _patch_services(monkeypatch, script_service, visual_plan_service, storage)
+
+    result = _invoke_task(run_id=502)
+
+    assert result["status"] == "success"
+    assert storage.calls == []
+    assert visual_plan_service.calls == [(502, 1)]
+    assert storage._runs[502]["current_stage"] == "VISUAL_ASSET_GENERATING"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# LLM response parsing tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_parse_llm_response_handles_markdown_fenced_json() -> None:
+    """LLM response wrapped in ```json fencing should still parse."""
+    sections = [{"section_id": "sec-1", "type": "hook", "text": "Hook"}]
+    fenced = '```json\n[{"section_id": "sec-1", "prompt": "test", "style_tags": [], "mood": "calm", "composition": "wide"}]\n```'
+
+    result = generate_visual_plan_module._parse_llm_response(fenced, sections)
+
+    assert len(result) == 1
+    assert result[0].prompt == "test"
+    assert result[0].mood == "calm"
+
+
+def test_parse_llm_response_invalid_json_produces_default_scenes() -> None:
+    """Invalid JSON should produce fallback scenes with default prompts."""
+    sections = [
+        {"section_id": "sec-1", "type": "hook", "text": "Hook text here"},
+        {"section_id": "sec-2", "type": "body", "text": "Body text here"},
+    ]
+    result = generate_visual_plan_module._parse_llm_response("this is not json", sections)
+
+    assert len(result) == 2
+    assert result[0].scene_id == "scene-sec-1"
+    assert "Hook text here" in result[0].prompt
+    assert result[1].scene_id == "scene-sec-2"
+
+
+def test_parse_llm_response_missing_section_gets_default() -> None:
+    """Sections not matched by LLM output get a default scene."""
+    sections = [
+        {"section_id": "sec-1", "type": "hook", "text": "Hook"},
+        {"section_id": "sec-2", "type": "body", "text": "Body"},
+    ]
+    llm_json = json.dumps([{
+        "section_id": "sec-1",
+        "prompt": "LLM prompt for hook",
+        "style_tags": ["anime"],
+        "mood": "energetic",
+        "composition": "close-up",
+    }])
+
+    result = generate_visual_plan_module._parse_llm_response(llm_json, sections)
+
+    assert len(result) == 2
+    assert result[0].prompt == "LLM prompt for hook"
+    assert result[0].style_tags == ["anime"]
+    assert "Body" in result[1].prompt  # Default prompt with section text
+    assert result[1].style_tags == []  # Default empty

--- a/apps/worker-orchestrator/tests/test_render_video.py
+++ b/apps/worker-orchestrator/tests/test_render_video.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from tasks import render_video as render_video_module
+
+
+class FakeStorage:
+    def __init__(self, runs: dict[int, dict[str, object]] | None = None) -> None:
+        self._runs: dict[int, dict[str, object]] = runs or {}
+        self.calls: list[tuple[int, dict[str, object]]] = []
+        self.cas_calls: list[tuple[int, dict[str, object], frozenset[str]]] = []
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        return self._runs.get(run_id)
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self.cas_calls.append((run_id, updates, expected_stages))
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
+
+
+def _make_storage(run_id: int = 201, stage: str = "RENDER_GENERATING") -> FakeStorage:
+    run_row: dict[str, object] = {"id": run_id, "current_stage": stage}
+    return FakeStorage(runs={run_id: run_row})
+
+
+@dataclass
+class FakeVisualAsset:
+    scene_id: str
+    asset_path: str
+    prompt_snapshot: str
+    is_active: bool
+
+
+class FakeVisualAssetService:
+    def __init__(self, grouped_assets: dict[str, list[FakeVisualAsset]] | None = None) -> None:
+        self.grouped_assets = grouped_assets or {}
+
+    async def list_by_run(self, _run_id: int) -> dict[str, list[FakeVisualAsset]]:
+        return self.grouped_assets
+
+
+@dataclass
+class FakeAudioArtifact:
+    path: str
+
+
+class FakeAudioService:
+    def __init__(self, artifact: FakeAudioArtifact | None = None) -> None:
+        self.artifact = artifact
+
+    async def get_latest(self, _run_id: int) -> FakeAudioArtifact | None:
+        return self.artifact
+
+
+@dataclass
+class FakeSubtitleArtifact:
+    path: str
+
+
+class FakeSubtitleService:
+    def __init__(self, artifact: FakeSubtitleArtifact | None = None) -> None:
+        self.artifact = artifact
+
+    async def get_latest(self, _run_id: int) -> FakeSubtitleArtifact | None:
+        return self.artifact
+
+
+@dataclass
+class FakeVideoArtifact:
+    id: int
+    path: str
+
+
+class FakeRenderService:
+    def __init__(
+        self,
+        manifest: dict[str, Any],
+        artifact_id: int = 1,
+        artifact_path: str = "data/artifacts/201/render/output.mp4",
+    ) -> None:
+        self.manifest = manifest
+        self.artifact = FakeVideoArtifact(id=artifact_id, path=artifact_path)
+        self.manifest_calls: list[dict[str, object]] = []
+        self.create_calls: list[dict[str, object]] = []
+
+    async def build_render_manifest(
+        self,
+        run_id: int,
+        visual_asset_service: Any,
+        audio_service: Any,
+        subtitle_service: Any,
+        render_profile_name: str = "shorts_default",
+    ) -> dict[str, Any]:
+        self.manifest_calls.append(
+            {
+                "run_id": run_id,
+                "visual_asset_service": visual_asset_service,
+                "audio_service": audio_service,
+                "subtitle_service": subtitle_service,
+                "render_profile_name": render_profile_name,
+            }
+        )
+        return self.manifest
+
+    async def create_artifact(
+        self,
+        run_id: int,
+        path: str,
+        *,
+        render_profile: str | None = None,
+    ) -> FakeVideoArtifact:
+        self.create_calls.append(
+            {
+                "run_id": run_id,
+                "path": path,
+                "render_profile": render_profile,
+            }
+        )
+        return self.artifact
+
+
+class FakeFFmpegService:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[Any, Path]] = []
+
+    def render(self, render_input: Any, output_path: Path) -> Path:
+        self.calls.append((render_input, output_path))
+        if self.error is not None:
+            raise self.error
+        return output_path
+
+
+def _manifest(
+    run_id: int,
+    scenes: list[dict[str, object]] | None = None,
+    audio_path: str | None = "data/artifacts/201/audio/audio.wav",
+    subtitle_path: str | None = "data/artifacts/201/subtitles/subtitles.srt",
+    max_duration_seconds: float = 30.0,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "scenes": scenes
+        if scenes is not None
+        else [
+            {"scene_id": "scene-1", "asset_path": "data/artifacts/201/visual/scene-1.png"},
+            {"scene_id": "scene-2", "asset_path": "data/artifacts/201/visual/scene-2.png"},
+        ],
+        "audio_path": audio_path,
+        "subtitle_path": subtitle_path,
+        "render_profile": {
+            "name": "shorts_default",
+            "width": 1080,
+            "height": 1920,
+            "fps": 30,
+            "video_codec": "libx264",
+            "audio_codec": "aac",
+            "transition_style": "none",
+            "min_duration_seconds": 10.0,
+            "max_duration_seconds": max_duration_seconds,
+            "crf": 23,
+            "preset": "medium",
+            "burn_subtitles": True,
+            "subtitle_font_size": 48,
+        },
+    }
+
+
+def _patch_services(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    storage: FakeStorage,
+    fake_render_service: FakeRenderService,
+    fake_vas: FakeVisualAssetService,
+    fake_audio: FakeAudioService,
+    fake_subtitle: FakeSubtitleService,
+    fake_ffmpeg: FakeFFmpegService,
+) -> None:
+    monkeypatch.setattr(render_video_module, "_run_service", SimpleNamespace(storage=storage))
+    monkeypatch.setattr(render_video_module, "_render_service", fake_render_service)
+    monkeypatch.setattr(render_video_module, "_visual_asset_service", fake_vas)
+    monkeypatch.setattr(render_video_module, "_audio_service", fake_audio)
+    monkeypatch.setattr(render_video_module, "_subtitle_service", fake_subtitle)
+    monkeypatch.setattr(render_video_module, "FFmpegService", lambda: fake_ffmpeg)
+
+
+def _invoke_task(**kwargs: Any) -> dict[str, object]:
+    task = render_video_module.render_video
+    run_callable = getattr(task, "run", task)
+    return run_callable(**kwargs)
+
+
+def test_render_video_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = 201
+    storage = _make_storage(run_id=run_id, stage="RENDER_GENERATING")
+    fake_render_service = FakeRenderService(manifest=_manifest(run_id=run_id), artifact_id=77)
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService()
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+    )
+
+    result = _invoke_task(run_id=run_id, render_profile="high_quality")
+
+    assert result["status"] == "success"
+    assert result["run_id"] == run_id
+    assert result["render_profile"] == "high_quality"
+    assert result["video_artifact_id"] == 77
+    assert result["video_path"] == "data/artifacts/201/render/output.mp4"
+    assert result["scene_count"] == 2
+    assert result["audio_path"] == "data/artifacts/201/audio/audio.wav"
+    assert result["subtitle_path"] == "data/artifacts/201/subtitles/subtitles.srt"
+
+    assert fake_render_service.manifest_calls[0]["render_profile_name"] == "high_quality"
+    assert fake_render_service.create_calls == [
+        {
+            "run_id": 201,
+            "path": "data/artifacts/201/render/output.mp4",
+            "render_profile": "high_quality",
+        }
+    ]
+
+    render_input, output = fake_ffmpeg.calls[0]
+    assert output == Path("data/artifacts/201/render/output.mp4")
+    assert render_input.image_paths == [
+        Path("data/artifacts/201/visual/scene-1.png"),
+        Path("data/artifacts/201/visual/scene-2.png"),
+    ]
+    assert render_input.audio_path == Path("data/artifacts/201/audio/audio.wav")
+    assert render_input.subtitle_path == Path("data/artifacts/201/subtitles/subtitles.srt")
+    assert render_input.scene_durations == [15.0, 15.0]
+
+    assert storage.calls == [(201, {"current_stage": "FINAL_REVIEW", "status": "running"})]
+    assert storage.cas_calls[0][2] == frozenset({"RENDER_GENERATING"})
+
+
+def test_render_video_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = FakeStorage()
+    fake_render_service = FakeRenderService(manifest=_manifest(run_id=999))
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService()
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+    )
+
+    with pytest.raises(ValueError, match="Run 999 not found"):
+        _invoke_task(run_id=999)
+
+    assert fake_render_service.manifest_calls == []
+    assert fake_ffmpeg.calls == []
+    assert storage.calls == []
+
+
+def test_render_video_wrong_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = _make_storage(run_id=202, stage="SCRIPT_REVIEW")
+    fake_render_service = FakeRenderService(manifest=_manifest(run_id=202))
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService()
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+    )
+
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=202)
+
+    assert fake_render_service.manifest_calls == []
+    assert fake_ffmpeg.calls == []
+    assert storage.calls == []
+
+
+def test_render_video_no_scenes(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = _make_storage(run_id=203, stage="RENDER_GENERATING")
+    fake_render_service = FakeRenderService(
+        manifest=_manifest(run_id=203, scenes=[]),
+        artifact_path="data/artifacts/203/render/output.mp4",
+    )
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService()
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+    )
+
+    with pytest.raises(RuntimeError, match="No scenes found for render"):
+        _invoke_task(run_id=203)
+
+    assert fake_ffmpeg.calls == []
+    assert fake_render_service.create_calls == []
+    assert storage.calls == [(203, {"current_stage": "FAILED", "status": "failed"})]
+
+
+def test_render_video_ffmpeg_failure_marks_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = _make_storage(run_id=204, stage="RENDER_GENERATING")
+    fake_render_service = FakeRenderService(
+        manifest=_manifest(run_id=204),
+        artifact_path="data/artifacts/204/render/output.mp4",
+    )
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService(error=RuntimeError("ffmpeg crashed"))
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+    )
+
+    with pytest.raises(RuntimeError, match="ffmpeg crashed"):
+        _invoke_task(run_id=204)
+
+    assert len(fake_ffmpeg.calls) == 1
+    assert fake_render_service.create_calls == []
+    assert storage.calls == [(204, {"current_stage": "FAILED", "status": "failed"})]
+    assert storage.cas_calls[0][2] == frozenset({"RENDER_GENERATING"})
+
+
+def test_render_video_without_audio_subtitles(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = _make_storage(run_id=205, stage="RENDER_GENERATING")
+    fake_render_service = FakeRenderService(
+        manifest=_manifest(run_id=205, audio_path=None, subtitle_path=None),
+        artifact_path="data/artifacts/205/render/output.mp4",
+    )
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService()
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+    )
+
+    result = _invoke_task(run_id=205, render_profile="fast_preview")
+
+    assert result["status"] == "success"
+    assert result["audio_path"] is None
+    assert result["subtitle_path"] is None
+    render_input, _ = fake_ffmpeg.calls[0]
+    assert render_input.audio_path is None
+    assert render_input.subtitle_path is None
+
+
+class _CASSkipStorage(FakeStorage):
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self.cas_calls.append((run_id, updates, expected_stages))
+        row = self._runs.get(run_id)
+        return False, dict(row) if row else None
+
+
+def test_render_video_cas_skip_on_stage_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_row: dict[str, object] = {"id": 206, "current_stage": "RENDER_GENERATING"}
+    storage = _CASSkipStorage(runs={206: run_row})
+    fake_render_service = FakeRenderService(
+        manifest=_manifest(run_id=206),
+        artifact_id=90,
+        artifact_path="data/artifacts/206/render/output.mp4",
+    )
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService()
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+    )
+
+    result = _invoke_task(run_id=206)
+
+    assert result["status"] == "success"
+    assert result["video_artifact_id"] == 90
+    assert len(fake_ffmpeg.calls) == 1
+    assert len(fake_render_service.create_calls) == 1
+    assert len(storage.cas_calls) == 1
+    assert storage.cas_calls[0][1] == {"current_stage": "FINAL_REVIEW", "status": "running"}
+    assert storage.calls == []
+
+
+def test_render_video_default_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = _make_storage(run_id=207, stage="RENDER_GENERATING")
+    fake_render_service = FakeRenderService(
+        manifest=_manifest(run_id=207),
+        artifact_path="data/artifacts/207/render/output.mp4",
+    )
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService()
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+    )
+
+    result = _invoke_task(run_id=207)
+
+    assert result["status"] == "success"
+    assert result["render_profile"] == "shorts_default"
+    assert fake_render_service.manifest_calls[0]["render_profile_name"] == "shorts_default"
+    assert fake_render_service.create_calls[0]["render_profile"] == "shorts_default"

--- a/apps/worker-orchestrator/tests/test_render_video.py
+++ b/apps/worker-orchestrator/tests/test_render_video.py
@@ -199,7 +199,7 @@ def _patch_services(
     monkeypatch.setattr(render_video_module, "_visual_asset_service", fake_vas)
     monkeypatch.setattr(render_video_module, "_audio_service", fake_audio)
     monkeypatch.setattr(render_video_module, "_subtitle_service", fake_subtitle)
-    monkeypatch.setattr(render_video_module, "FFmpegService", lambda: fake_ffmpeg)
+    monkeypatch.setattr(render_video_module, "FFmpegService", lambda profile=None: fake_ffmpeg)
 
 
 def _invoke_task(**kwargs: Any) -> dict[str, object]:
@@ -468,3 +468,41 @@ def test_render_video_default_profile(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result["render_profile"] == "shorts_default"
     assert fake_render_service.manifest_calls[0]["render_profile_name"] == "shorts_default"
     assert fake_render_service.create_calls[0]["render_profile"] == "shorts_default"
+
+
+def test_render_video_profile_propagated_to_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify non-default render_profile is actually passed to FFmpegService."""
+    run_id = 208
+    storage = _make_storage(run_id=run_id, stage="RENDER_GENERATING")
+    fake_render_service = FakeRenderService(
+        manifest=_manifest(run_id=run_id),
+        artifact_path="data/artifacts/208/render/output.mp4",
+    )
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService()
+
+    # Capture the profile argument passed to FFmpegService constructor
+    captured_profiles: list[Any] = []
+
+    def ffmpeg_factory(profile: Any = None) -> FakeFFmpegService:
+        captured_profiles.append(profile)
+        return fake_ffmpeg
+
+    monkeypatch.setattr(render_video_module, "_run_service", SimpleNamespace(storage=storage))
+    monkeypatch.setattr(render_video_module, "_render_service", fake_render_service)
+    monkeypatch.setattr(render_video_module, "_visual_asset_service", fake_vas)
+    monkeypatch.setattr(render_video_module, "_audio_service", fake_audio)
+    monkeypatch.setattr(render_video_module, "_subtitle_service", fake_subtitle)
+    monkeypatch.setattr(render_video_module, "FFmpegService", ffmpeg_factory)
+
+    result = _invoke_task(run_id=run_id, render_profile="high_quality")
+
+    assert result["status"] == "success"
+    assert result["render_profile"] == "high_quality"
+    assert len(captured_profiles) == 1
+    profile = captured_profiles[0]
+    assert profile.name == "high_quality"
+    assert profile.crf == 18
+    assert profile.preset == "slow"

--- a/packages/creator-domain/creator-domain
+++ b/packages/creator-domain/creator-domain
@@ -1,1 +1,0 @@
-creator-domain

--- a/packages/creator-domain/creator-domain
+++ b/packages/creator-domain/creator-domain
@@ -1,0 +1,1 @@
+creator-domain

--- a/packages/creator-domain/models/__init__.py
+++ b/packages/creator-domain/models/__init__.py
@@ -3,6 +3,15 @@ from .model_selection import ModelSelection
 from .pipeline_run import PipelineRun
 from .project import Project
 from .script_draft import ScriptDraft, ScriptSection, VisualOverride
+from .stage import (
+    GENERATING_STAGES,
+    REVIEW_STAGES,
+    TRANSITIONS,
+    RunStage,
+    advance,
+    can_transition,
+    next_stages,
+)
 from .subtitle_artifact import SubtitleArtifact
 from .video_artifact import VideoArtifact
 from .visual_asset import VisualAsset
@@ -15,6 +24,13 @@ __all__ = [
     "ScriptDraft",
     "ScriptSection",
     "VisualOverride",
+    "RunStage",
+    "TRANSITIONS",
+    "REVIEW_STAGES",
+    "GENERATING_STAGES",
+    "can_transition",
+    "next_stages",
+    "advance",
     "VisualPlan",
     "VisualScene",
     "VisualAsset",

--- a/packages/creator-domain/models/__init__.py
+++ b/packages/creator-domain/models/__init__.py
@@ -1,1 +1,24 @@
-"""Placeholder for creator_domain.models."""
+from .audio_artifact import AudioArtifact
+from .model_selection import ModelSelection
+from .pipeline_run import PipelineRun
+from .project import Project
+from .script_draft import ScriptDraft, ScriptSection, VisualOverride
+from .subtitle_artifact import SubtitleArtifact
+from .video_artifact import VideoArtifact
+from .visual_asset import VisualAsset
+from .visual_plan import VisualPlan, VisualScene
+
+__all__ = [
+    "Project",
+    "PipelineRun",
+    "ModelSelection",
+    "ScriptDraft",
+    "ScriptSection",
+    "VisualOverride",
+    "VisualPlan",
+    "VisualScene",
+    "VisualAsset",
+    "AudioArtifact",
+    "SubtitleArtifact",
+    "VideoArtifact",
+]

--- a/packages/creator-domain/models/audio_artifact.py
+++ b/packages/creator-domain/models/audio_artifact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -20,25 +21,25 @@ class AudioArtifact(BaseModel):
 
     @classmethod
     def from_row(cls, row: dict) -> AudioArtifact:
-        """Construct from a DB row dict, mapping column names to domain fields.
+        """Construct from a creator_artifacts DB row.
 
-        Handles:
-        - file_path (TEXT) -> path (str)
-        - metadata_json (TEXT) -> ignored (not on this model)
-        - provider (VARCHAR, if present) -> provider_type (str)
+        The creator_artifacts table stores artifact-specific fields in
+        metadata_json.  This method extracts model_used, provider_type,
+        and voice from that JSON column and maps file_path -> path.
         """
         mapped = dict(row)
         if "file_path" in mapped and "path" not in mapped:
             mapped["path"] = mapped.pop("file_path")
-        if "provider" in mapped and "provider_type" not in mapped:
-            mapped["provider_type"] = mapped.pop("provider")
+        # Extract domain fields from metadata_json
+        raw_meta = mapped.pop("metadata_json", None)
+        if raw_meta is not None:
+            meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+            mapped.setdefault("model_used", meta.get("model_used"))
+            mapped.setdefault("provider_type", meta.get("provider_type"))
+            mapped.setdefault("voice", meta.get("voice"))
         # Discard DB-only columns not in this domain model
-        mapped.pop("metadata_json", None)
-        mapped.pop("artifact_type", None)
-        mapped.pop("scene_id", None)
-        mapped.pop("file_size_bytes", None)
-        mapped.pop("mime_type", None)
-        mapped.pop("updated_at", None)
+        for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
+            mapped.pop(key, None)
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/models/audio_artifact.py
+++ b/packages/creator-domain/models/audio_artifact.py
@@ -3,20 +3,17 @@ from datetime import datetime
 from pydantic import BaseModel
 
 
-class VisualAsset(BaseModel):
+class AudioArtifact(BaseModel):
     id: int
     run_id: int
-    scene_id: str
-    version: int = 1
-    asset_path: str
-    prompt_snapshot: str | None = None
+    path: str
     model_used: str | None = None
     provider_type: str | None = None
-    is_active: bool = True
+    voice: str | None = None
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "VisualAsset":
+    def from_dict(cls, data: dict) -> "AudioArtifact":
         return cls.model_validate(data)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/models/audio_artifact.py
+++ b/packages/creator-domain/models/audio_artifact.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -13,8 +15,31 @@ class AudioArtifact(BaseModel):
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "AudioArtifact":
+    def from_dict(cls, data: dict) -> AudioArtifact:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> AudioArtifact:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - file_path (TEXT) -> path (str)
+        - metadata_json (TEXT) -> ignored (not on this model)
+        - provider (VARCHAR, if present) -> provider_type (str)
+        """
+        mapped = dict(row)
+        if "file_path" in mapped and "path" not in mapped:
+            mapped["path"] = mapped.pop("file_path")
+        if "provider" in mapped and "provider_type" not in mapped:
+            mapped["provider_type"] = mapped.pop("provider")
+        # Discard DB-only columns not in this domain model
+        mapped.pop("metadata_json", None)
+        mapped.pop("artifact_type", None)
+        mapped.pop("scene_id", None)
+        mapped.pop("file_size_bytes", None)
+        mapped.pop("mime_type", None)
+        mapped.pop("updated_at", None)
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/model_selection.py
+++ b/packages/creator-domain/models/model_selection.py
@@ -1,1 +1,16 @@
-"""Placeholder for model_selection."""
+from pydantic import BaseModel
+
+
+class ModelSelection(BaseModel):
+    script_model: str | None = None
+    image_model: str | None = None
+    tts_model: str | None = None
+    subtitle_model: str | None = None
+    render_profile: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ModelSelection":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/pipeline_run.py
+++ b/packages/creator-domain/models/pipeline_run.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import json
 from datetime import datetime
 from typing import Literal
 
@@ -22,8 +25,25 @@ class PipelineRun(BaseModel):
     updated_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "PipelineRun":
+    def from_dict(cls, data: dict) -> PipelineRun:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> PipelineRun:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - model_defaults_json (TEXT) -> model_defaults (ModelSelection | None)
+        - metadata_json (TEXT) -> metadata (dict | None)
+        """
+        mapped = dict(row)
+        raw_defaults = mapped.pop("model_defaults_json", None)
+        if raw_defaults is not None:
+            mapped["model_defaults"] = json.loads(raw_defaults)
+        raw_meta = mapped.pop("metadata_json", None)
+        if raw_meta is not None:
+            mapped["metadata"] = json.loads(raw_meta)
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/pipeline_run.py
+++ b/packages/creator-domain/models/pipeline_run.py
@@ -1,1 +1,29 @@
-"""Placeholder for pipeline_run."""
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+from .model_selection import ModelSelection
+
+
+class PipelineRun(BaseModel):
+    id: int
+    project_id: int
+    current_stage: str | None = None
+    status: Literal["pending", "running", "paused", "completed", "failed", "cancelled"] = "pending"
+    review_stage: str | None = None
+    restart_from: str | None = None
+    model_defaults: ModelSelection | None = None
+    metadata: dict | None = None
+    style_preset: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PipelineRun":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/project.py
+++ b/packages/creator-domain/models/project.py
@@ -1,1 +1,23 @@
-"""Placeholder for project."""
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class Project(BaseModel):
+    id: int
+    title: str | None = None
+    source_type: Literal["idea", "markdown", "url"] = "idea"
+    idea_brief: str | None = None
+    markdown_source: str | None = None
+    url_source: str | None = None
+    status: Literal["draft", "active", "completed", "archived"] = "draft"
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Project":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/script_draft.py
+++ b/packages/creator-domain/models/script_draft.py
@@ -10,7 +10,7 @@ class VisualOverride(BaseModel):
 
 
 class ScriptSection(BaseModel):
-    id: str
+    section_id: str
     type: str
     text: str
     display_text: str | None = None

--- a/packages/creator-domain/models/script_draft.py
+++ b/packages/creator-domain/models/script_draft.py
@@ -1,1 +1,42 @@
-"""Placeholder for script_draft."""
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class VisualOverride(BaseModel):
+    type: Literal["prompt", "image_url", "none"]
+    value: str | None = None
+
+
+class ScriptSection(BaseModel):
+    id: str
+    type: str
+    text: str
+    display_text: str | None = None
+    speaker: str | None = "host"
+    duration: float | None = None
+    turn_kind: str | None = None
+    visual_override: VisualOverride | None = None
+
+
+class ScriptDraft(BaseModel):
+    id: int
+    run_id: int
+    source_type: Literal[
+        "generated_by_model",
+        "pasted_markdown",
+        "uploaded_markdown",
+        "edited_manually",
+    ]
+    markdown_content: str | None = None
+    structured_script: list[ScriptSection] | None = None
+    version: int = 1
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ScriptDraft":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/stage.py
+++ b/packages/creator-domain/models/stage.py
@@ -1,15 +1,11 @@
-from enum import Enum
-from typing import TYPE_CHECKING
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
 
-if TYPE_CHECKING:
-    class StrEnum(Enum):
-        ...
-else:
-    try:
-        from enum import StrEnum
-    except ImportError:
-        StrEnum = Enum("StrEnum", {}, type=str)
-
+    class StrEnum(str, Enum):  # noqa: UP042
+        def __str__(self) -> str:
+            return self.value
 
 class RunStage(StrEnum):
     IDEA_READY = "IDEA_READY"

--- a/packages/creator-domain/models/stage.py
+++ b/packages/creator-domain/models/stage.py
@@ -1,0 +1,80 @@
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    class StrEnum(Enum):
+        ...
+else:
+    try:
+        from enum import StrEnum
+    except ImportError:
+        StrEnum = Enum("StrEnum", {}, type=str)
+
+
+class RunStage(StrEnum):
+    IDEA_READY = "IDEA_READY"
+    SCRIPT_GENERATING = "SCRIPT_GENERATING"
+    SCRIPT_REVIEW = "SCRIPT_REVIEW"
+    VISUAL_PLAN_GENERATING = "VISUAL_PLAN_GENERATING"
+    VISUAL_PLAN_REVIEW = "VISUAL_PLAN_REVIEW"
+    VISUAL_ASSET_GENERATING = "VISUAL_ASSET_GENERATING"
+    VISUAL_ASSET_REVIEW = "VISUAL_ASSET_REVIEW"
+    AUDIO_GENERATING = "AUDIO_GENERATING"
+    SUBTITLE_GENERATING = "SUBTITLE_GENERATING"
+    RENDER_GENERATING = "RENDER_GENERATING"
+    FINAL_REVIEW = "FINAL_REVIEW"
+    PUBLISHED = "PUBLISHED"
+    FAILED = "FAILED"
+
+
+TRANSITIONS: dict[RunStage, tuple[RunStage, ...]] = {
+    RunStage.IDEA_READY: (RunStage.SCRIPT_GENERATING,),
+    RunStage.SCRIPT_GENERATING: (RunStage.SCRIPT_REVIEW, RunStage.FAILED),
+    RunStage.SCRIPT_REVIEW: (RunStage.VISUAL_PLAN_GENERATING, RunStage.SCRIPT_GENERATING),
+    RunStage.VISUAL_PLAN_GENERATING: (RunStage.VISUAL_PLAN_REVIEW, RunStage.FAILED),
+    RunStage.VISUAL_PLAN_REVIEW: (RunStage.VISUAL_ASSET_GENERATING, RunStage.VISUAL_PLAN_GENERATING),
+    RunStage.VISUAL_ASSET_GENERATING: (RunStage.VISUAL_ASSET_REVIEW, RunStage.FAILED),
+    RunStage.VISUAL_ASSET_REVIEW: (RunStage.AUDIO_GENERATING, RunStage.VISUAL_ASSET_GENERATING),
+    RunStage.AUDIO_GENERATING: (RunStage.SUBTITLE_GENERATING, RunStage.FAILED),
+    RunStage.SUBTITLE_GENERATING: (RunStage.RENDER_GENERATING, RunStage.FAILED),
+    RunStage.RENDER_GENERATING: (RunStage.FINAL_REVIEW, RunStage.FAILED),
+    RunStage.FINAL_REVIEW: (RunStage.PUBLISHED, RunStage.RENDER_GENERATING),
+    RunStage.PUBLISHED: (),
+    RunStage.FAILED: (),
+}
+
+
+REVIEW_STAGES: frozenset[RunStage] = frozenset(
+    {
+        RunStage.SCRIPT_REVIEW,
+        RunStage.VISUAL_PLAN_REVIEW,
+        RunStage.VISUAL_ASSET_REVIEW,
+        RunStage.FINAL_REVIEW,
+    }
+)
+
+GENERATING_STAGES: frozenset[RunStage] = frozenset(
+    {
+        RunStage.SCRIPT_GENERATING,
+        RunStage.VISUAL_PLAN_GENERATING,
+        RunStage.VISUAL_ASSET_GENERATING,
+        RunStage.AUDIO_GENERATING,
+        RunStage.SUBTITLE_GENERATING,
+        RunStage.RENDER_GENERATING,
+    }
+)
+
+
+def can_transition(current: RunStage, target: RunStage) -> bool:
+    return target in TRANSITIONS[current]
+
+
+def next_stages(current: RunStage) -> list[RunStage]:
+    return list(TRANSITIONS[current])
+
+
+def advance(current: RunStage) -> RunStage:
+    candidates = [stage for stage in TRANSITIONS[current] if stage is not RunStage.FAILED]
+    if len(candidates) != 1:
+        raise ValueError(f"Stage {current} does not have exactly one non-failed transition")
+    return candidates[0]

--- a/packages/creator-domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/models/subtitle_artifact.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Literal
 
@@ -12,8 +14,27 @@ class SubtitleArtifact(BaseModel):
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "SubtitleArtifact":
+    def from_dict(cls, data: dict) -> SubtitleArtifact:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> SubtitleArtifact:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - file_path (TEXT) -> path (str)
+        """
+        mapped = dict(row)
+        if "file_path" in mapped and "path" not in mapped:
+            mapped["path"] = mapped.pop("file_path")
+        # Discard DB-only columns not in this domain model
+        mapped.pop("metadata_json", None)
+        mapped.pop("artifact_type", None)
+        mapped.pop("scene_id", None)
+        mapped.pop("file_size_bytes", None)
+        mapped.pop("mime_type", None)
+        mapped.pop("updated_at", None)
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/models/subtitle_artifact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Literal
 
@@ -19,21 +20,23 @@ class SubtitleArtifact(BaseModel):
 
     @classmethod
     def from_row(cls, row: dict) -> SubtitleArtifact:
-        """Construct from a DB row dict, mapping column names to domain fields.
+        """Construct from a creator_artifacts DB row.
 
-        Handles:
-        - file_path (TEXT) -> path (str)
+        The creator_artifacts table stores artifact-specific fields in
+        metadata_json.  This method extracts format from that JSON column
+        and maps file_path -> path.
         """
         mapped = dict(row)
         if "file_path" in mapped and "path" not in mapped:
             mapped["path"] = mapped.pop("file_path")
+        # Extract domain fields from metadata_json
+        raw_meta = mapped.pop("metadata_json", None)
+        if raw_meta is not None:
+            meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+            mapped.setdefault("format", meta.get("format"))
         # Discard DB-only columns not in this domain model
-        mapped.pop("metadata_json", None)
-        mapped.pop("artifact_type", None)
-        mapped.pop("scene_id", None)
-        mapped.pop("file_size_bytes", None)
-        mapped.pop("mime_type", None)
-        mapped.pop("updated_at", None)
+        for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
+            mapped.pop(key, None)
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/models/subtitle_artifact.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class SubtitleArtifact(BaseModel):
+    id: int
+    run_id: int
+    path: str
+    format: Literal["srt", "vtt"] = "srt"
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SubtitleArtifact":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/video_artifact.py
+++ b/packages/creator-domain/models/video_artifact.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -11,8 +13,27 @@ class VideoArtifact(BaseModel):
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "VideoArtifact":
+    def from_dict(cls, data: dict) -> VideoArtifact:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> VideoArtifact:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - file_path (TEXT) -> path (str)
+        """
+        mapped = dict(row)
+        if "file_path" in mapped and "path" not in mapped:
+            mapped["path"] = mapped.pop("file_path")
+        # Discard DB-only columns not in this domain model
+        mapped.pop("metadata_json", None)
+        mapped.pop("artifact_type", None)
+        mapped.pop("scene_id", None)
+        mapped.pop("file_size_bytes", None)
+        mapped.pop("mime_type", None)
+        mapped.pop("updated_at", None)
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/video_artifact.py
+++ b/packages/creator-domain/models/video_artifact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -18,21 +19,23 @@ class VideoArtifact(BaseModel):
 
     @classmethod
     def from_row(cls, row: dict) -> VideoArtifact:
-        """Construct from a DB row dict, mapping column names to domain fields.
+        """Construct from a creator_artifacts DB row.
 
-        Handles:
-        - file_path (TEXT) -> path (str)
+        The creator_artifacts table stores artifact-specific fields in
+        metadata_json.  This method extracts render_profile from that JSON
+        column and maps file_path -> path.
         """
         mapped = dict(row)
         if "file_path" in mapped and "path" not in mapped:
             mapped["path"] = mapped.pop("file_path")
+        # Extract domain fields from metadata_json
+        raw_meta = mapped.pop("metadata_json", None)
+        if raw_meta is not None:
+            meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+            mapped.setdefault("render_profile", meta.get("render_profile"))
         # Discard DB-only columns not in this domain model
-        mapped.pop("metadata_json", None)
-        mapped.pop("artifact_type", None)
-        mapped.pop("scene_id", None)
-        mapped.pop("file_size_bytes", None)
-        mapped.pop("mime_type", None)
-        mapped.pop("updated_at", None)
+        for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
+            mapped.pop(key, None)
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/models/video_artifact.py
+++ b/packages/creator-domain/models/video_artifact.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class VideoArtifact(BaseModel):
+    id: int
+    run_id: int
+    path: str
+    render_profile: str | None = None
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "VideoArtifact":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/models/visual_asset.py
+++ b/packages/creator-domain/models/visual_asset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -16,8 +18,20 @@ class VisualAsset(BaseModel):
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "VisualAsset":
+    def from_dict(cls, data: dict) -> VisualAsset:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_row(cls, row: dict) -> VisualAsset:
+        """Construct from a DB row dict, mapping column names to domain fields.
+
+        Handles:
+        - provider (VARCHAR) -> provider_type (str)
+        """
+        mapped = dict(row)
+        if "provider" in mapped and "provider_type" not in mapped:
+            mapped["provider_type"] = mapped.pop("provider")
+        return cls.model_validate(mapped)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/models/visual_plan.py
+++ b/packages/creator-domain/models/visual_plan.py
@@ -1,1 +1,35 @@
-"""Placeholder for visual_plan."""
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class VisualScene(BaseModel):
+    scene_id: str
+    section_id: str
+    scene_index: int
+    section_type: str
+    original_text: str
+    prompt: str
+    prompt_edited: bool = False
+    prompt_source: Literal["auto_generated", "user_edited", "model_suggested"] = "auto_generated"
+    style_tags: list[str] = Field(default_factory=list)
+    mood: str | None = None
+    composition: str | None = None
+    generation_status: Literal["pending", "generating", "completed", "failed"] = "pending"
+    latest_asset_id: int | None = None
+
+
+class VisualPlan(BaseModel):
+    id: int
+    run_id: int
+    version: int = 1
+    scenes: list[VisualScene]
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "VisualPlan":
+        return cls.model_validate(data)
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/packages/creator-domain/tests/test_stage.py
+++ b/packages/creator-domain/tests/test_stage.py
@@ -87,3 +87,9 @@ def test_stage_group_sets() -> None:
         RunStage.SUBTITLE_GENERATING,
         RunStage.RENDER_GENERATING,
     } == GENERATING_STAGES
+
+
+def test_run_stage_str_returns_value() -> None:
+    """Regression: str(RunStage.X) must return the raw value, not 'RunStage.X'."""
+    for stage in RunStage:
+        assert str(stage) == stage.value

--- a/packages/creator-domain/tests/test_stage.py
+++ b/packages/creator-domain/tests/test_stage.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models import (  # noqa: E402
+    GENERATING_STAGES,
+    REVIEW_STAGES,
+    TRANSITIONS,
+    RunStage,
+    advance,
+    can_transition,
+    next_stages,
+)
+
+
+def test_all_valid_transitions_are_allowed() -> None:
+    for current, targets in TRANSITIONS.items():
+        for target in targets:
+            assert can_transition(current, target)
+
+
+def test_invalid_transition_returns_false() -> None:
+    assert not can_transition(RunStage.IDEA_READY, RunStage.PUBLISHED)
+    assert not can_transition(RunStage.PUBLISHED, RunStage.FAILED)
+    assert not can_transition(RunStage.FAILED, RunStage.IDEA_READY)
+
+
+def test_advance_raises_for_stages_without_single_non_failed_path() -> None:
+    with pytest.raises(ValueError):
+        advance(RunStage.SCRIPT_REVIEW)
+
+    with pytest.raises(ValueError):
+        advance(RunStage.FINAL_REVIEW)
+
+    with pytest.raises(ValueError):
+        advance(RunStage.PUBLISHED)
+
+    with pytest.raises(ValueError):
+        advance(RunStage.FAILED)
+
+
+def test_happy_path_sequence_idea_ready_to_published() -> None:
+    happy_path = [
+        RunStage.IDEA_READY,
+        RunStage.SCRIPT_GENERATING,
+        RunStage.SCRIPT_REVIEW,
+        RunStage.VISUAL_PLAN_GENERATING,
+        RunStage.VISUAL_PLAN_REVIEW,
+        RunStage.VISUAL_ASSET_GENERATING,
+        RunStage.VISUAL_ASSET_REVIEW,
+        RunStage.AUDIO_GENERATING,
+        RunStage.SUBTITLE_GENERATING,
+        RunStage.RENDER_GENERATING,
+        RunStage.FINAL_REVIEW,
+        RunStage.PUBLISHED,
+    ]
+
+    for current, nxt in zip(happy_path, happy_path[1:], strict=False):
+        assert can_transition(current, nxt)
+
+
+def test_failed_is_reachable_from_all_generating_stages() -> None:
+    for stage in GENERATING_STAGES:
+        assert RunStage.FAILED in next_stages(stage)
+
+
+def test_next_stages_match_transition_map() -> None:
+    for stage in RunStage:
+        assert next_stages(stage) == list(TRANSITIONS[stage])
+
+
+def test_stage_group_sets() -> None:
+    assert {
+        RunStage.SCRIPT_REVIEW,
+        RunStage.VISUAL_PLAN_REVIEW,
+        RunStage.VISUAL_ASSET_REVIEW,
+        RunStage.FINAL_REVIEW,
+    } == REVIEW_STAGES
+    assert {
+        RunStage.SCRIPT_GENERATING,
+        RunStage.VISUAL_PLAN_GENERATING,
+        RunStage.VISUAL_ASSET_GENERATING,
+        RunStage.AUDIO_GENERATING,
+        RunStage.SUBTITLE_GENERATING,
+        RunStage.RENDER_GENERATING,
+    } == GENERATING_STAGES

--- a/packages/creator-provider/__init__.py
+++ b/packages/creator-provider/__init__.py
@@ -1,4 +1,5 @@
 from .base import AudioResult, ImageProvider, ImageResult, LLMProvider, STTProvider, SubtitleResult, TTSProvider
+from .gpu_lock import acquire_gpu_lock, gpu_lock_context, release_gpu_lock
 from .registry import ModelCatalogEntry, ProviderCategory, ProviderRegistry
 
 __all__ = [
@@ -9,6 +10,9 @@ __all__ = [
     "ImageResult",
     "AudioResult",
     "SubtitleResult",
+    "acquire_gpu_lock",
+    "release_gpu_lock",
+    "gpu_lock_context",
     "ProviderRegistry",
     "ProviderCategory",
     "ModelCatalogEntry",

--- a/packages/creator-provider/gpu_lock.py
+++ b/packages/creator-provider/gpu_lock.py
@@ -1,0 +1,70 @@
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+
+GPU_LOCK_KEY = os.getenv("GPU_LOCK_KEY", "gpu:lock")
+
+try:
+    GPU_LOCK_TIMEOUT_SECONDS = int(os.getenv("GPU_LOCK_TIMEOUT_SECONDS", "600"))
+except ValueError:
+    GPU_LOCK_TIMEOUT_SECONDS = 600
+
+
+RELEASE_LOCK_SCRIPT = """
+local current = redis.call('GET', KEYS[1])
+if not current then
+    return 0
+end
+
+if string.sub(current, 1, string.len(ARGV[1])) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+
+return 0
+"""
+
+
+def acquire_gpu_lock(
+    redis_client: Any,
+    task_id: str,
+    timeout: int = GPU_LOCK_TIMEOUT_SECONDS,
+    retry_interval: float = 2.0,
+    max_wait: float = 300.0,
+) -> bool:
+    start_time = time.monotonic()
+    backoff = retry_interval
+
+    while True:
+        lock_value = f"{task_id}:{int(time.time())}"
+        acquired = redis_client.set(GPU_LOCK_KEY, lock_value, nx=True, ex=timeout)
+        if acquired:
+            return True
+
+        elapsed = time.monotonic() - start_time
+        if elapsed >= max_wait:
+            raise TimeoutError(f"Timed out acquiring GPU lock for task '{task_id}'")
+
+        sleep_for = min(backoff, max_wait - elapsed)
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+        backoff = min(backoff * 2, 30.0)
+
+
+def release_gpu_lock(redis_client: Any, task_id: str) -> bool:
+    released = redis_client.eval(RELEASE_LOCK_SCRIPT, 1, GPU_LOCK_KEY, f"{task_id}:")
+    return bool(released)
+
+
+@asynccontextmanager
+async def gpu_lock_context(
+    redis_client: Any,
+    task_id: str,
+    timeout: int = GPU_LOCK_TIMEOUT_SECONDS,
+) -> AsyncIterator[None]:
+    acquire_gpu_lock(redis_client, task_id, timeout=timeout)
+    try:
+        yield
+    finally:
+        release_gpu_lock(redis_client, task_id)

--- a/packages/creator-provider/tests/test_gpu_lock.py
+++ b/packages/creator-provider/tests/test_gpu_lock.py
@@ -1,0 +1,88 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from gpu_lock import GPU_LOCK_KEY, RELEASE_LOCK_SCRIPT, acquire_gpu_lock, gpu_lock_context, release_gpu_lock
+
+
+class GpuLockTests(unittest.TestCase):
+    def test_acquire_succeeds_on_first_try(self) -> None:
+        redis_client = Mock()
+        redis_client.set.return_value = True
+
+        acquired = acquire_gpu_lock(redis_client, "task-1", timeout=42)
+
+        self.assertTrue(acquired)
+        redis_client.set.assert_called_once()
+        call_args = redis_client.set.call_args
+        self.assertEqual(call_args.kwargs["nx"], True)
+        self.assertEqual(call_args.kwargs["ex"], 42)
+        self.assertEqual(call_args.args[0], GPU_LOCK_KEY)
+        self.assertTrue(call_args.args[1].startswith("task-1:"))
+
+    def test_acquire_retries_when_lock_is_held(self) -> None:
+        redis_client = Mock()
+        redis_client.set.side_effect = [False, False, True]
+
+        with patch("gpu_lock.time.sleep") as sleep_mock:
+            acquired = acquire_gpu_lock(redis_client, "task-2", retry_interval=0.01, max_wait=1.0)
+
+        self.assertTrue(acquired)
+        self.assertEqual(redis_client.set.call_count, 3)
+        self.assertEqual(sleep_mock.call_count, 2)
+
+    def test_release_succeeds_for_holder(self) -> None:
+        redis_client = Mock()
+        redis_client.eval.return_value = 1
+
+        released = release_gpu_lock(redis_client, "task-3")
+
+        self.assertTrue(released)
+        redis_client.eval.assert_called_once_with(RELEASE_LOCK_SCRIPT, 1, GPU_LOCK_KEY, "task-3:")
+
+    def test_release_returns_false_when_not_holder(self) -> None:
+        redis_client = Mock()
+        redis_client.eval.return_value = 0
+
+        released = release_gpu_lock(redis_client, "task-4")
+
+        self.assertFalse(released)
+
+    def test_acquire_raises_timeout_after_max_wait(self) -> None:
+        redis_client = Mock()
+        redis_client.set.return_value = False
+
+        with patch("gpu_lock.time.monotonic", side_effect=[0.0, 0.5, 1.1]), patch("gpu_lock.time.sleep"):
+            with self.assertRaises(TimeoutError):
+                acquire_gpu_lock(redis_client, "task-timeout", retry_interval=0.01, max_wait=1.0)
+
+    def test_double_release_safety(self) -> None:
+        redis_client = Mock()
+        redis_client.eval.side_effect = [1, 0]
+
+        first_release = release_gpu_lock(redis_client, "task-5")
+        second_release = release_gpu_lock(redis_client, "task-5")
+
+        self.assertTrue(first_release)
+        self.assertFalse(second_release)
+
+    def test_context_manager_enters_and_exits_cleanly(self) -> None:
+        redis_client = Mock()
+        redis_client.set.return_value = True
+        redis_client.eval.return_value = 1
+
+        async def _run() -> None:
+            async with gpu_lock_context(redis_client, "task-ctx", timeout=30):
+                return
+
+        asyncio.run(_run())
+
+        redis_client.set.assert_called_once()
+        redis_client.eval.assert_called_once_with(RELEASE_LOCK_SCRIPT, 1, GPU_LOCK_KEY, "task-ctx:")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/creator-service/audio_service.py
+++ b/packages/creator-service/audio_service.py
@@ -1,1 +1,165 @@
-"""Placeholder for audio_service."""
+"""Audio service for artifact storage and retrieval.
+
+Manages audio artifacts generated for runs. Each run can have multiple audio
+artifacts. Audio artifacts are NOT scene-versioned; the latest artifact
+per run is the current one.
+
+Follows the same Protocol → InMemory → Service pattern as
+VisualAssetService and ScriptService.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+_DOMAIN_DIR = str(Path(__file__).resolve().parent.parent / "creator-domain")
+if _DOMAIN_DIR not in sys.path:
+    sys.path.insert(0, _DOMAIN_DIR)
+
+from models.audio_artifact import AudioArtifact  # type: ignore[reportMissingImports]  # noqa: E402, I001
+
+
+# ---------------------------------------------------------------------------
+# Storage Protocol
+# ---------------------------------------------------------------------------
+
+
+class AudioStorageBackend(Protocol):
+    async def save_artifact(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist an audio artifact row and return stored row with id assigned.
+
+        The storage backend allocates the next id and inserts the row.
+        Callers MUST NOT include ``id`` in *row*; the returned dict
+        MUST contain the allocated ``id``.
+        """
+        ...
+
+    async def get_artifact(self, artifact_id: int) -> dict[str, Any] | None:
+        """Fetch a single artifact by id."""
+        ...
+
+    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        """List all artifacts for a run, newest first."""
+        ...
+
+    async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
+        """Fetch the most recent artifact for a run."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-Memory Storage
+# ---------------------------------------------------------------------------
+
+
+class InMemoryAudioStorage:
+    """In-memory storage for audio artifacts."""
+
+    def __init__(self) -> None:
+        self._artifacts: list[dict[str, Any]] = []
+        self._next_id = 1
+
+    async def save_artifact(self, row: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        saved = {
+            "id": self._next_id,
+            "created_at": now,
+            **row,
+        }
+        self._next_id += 1
+        self._artifacts.append(saved)
+        return dict(saved)
+
+    async def get_artifact(self, artifact_id: int) -> dict[str, Any] | None:
+        for a in self._artifacts:
+            if a["id"] == artifact_id:
+                return dict(a)
+        return None
+
+    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        run_artifacts = [a for a in self._artifacts if a["run_id"] == run_id]
+        return [
+            dict(a)
+            for a in sorted(run_artifacts, key=lambda x: x["created_at"], reverse=True)
+        ]
+
+    async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
+        artifacts = await self.list_by_run(run_id)
+        return artifacts[0] if artifacts else None
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class AudioService:
+    def __init__(self, storage: AudioStorageBackend | None = None) -> None:
+        self.storage = storage if storage is not None else InMemoryAudioStorage()
+
+    # -- Create -------------------------------------------------------------
+
+    async def create_artifact(
+        self,
+        run_id: int,
+        path: str,
+        *,
+        model_used: str | None = None,
+        provider_type: str | None = None,
+        voice: str | None = None,
+    ) -> AudioArtifact:
+        """Create a new audio artifact for a run.
+
+        Audio artifacts are NOT versioned. The latest artifact per run
+        is the current one.
+        """
+        metadata = {}
+        if model_used is not None:
+            metadata["model_used"] = model_used
+        if provider_type is not None:
+            metadata["provider_type"] = provider_type
+        if voice is not None:
+            metadata["voice"] = voice
+
+        row = {
+            "run_id": run_id,
+            "file_path": path,
+            "metadata_json": metadata,
+        }
+        saved = await self.storage.save_artifact(row)
+
+        return self._row_to_artifact(saved)
+
+    # -- Reads --------------------------------------------------------------
+
+    async def get_latest(self, run_id: int) -> AudioArtifact | None:
+        """Get the most recent audio artifact for a run."""
+        row = await self.storage.get_latest_by_run(run_id)
+        if row is None:
+            return None
+        return self._row_to_artifact(row)
+
+    async def list_by_run(self, run_id: int) -> list[AudioArtifact]:
+        """List all audio artifacts for a run, newest first."""
+        rows = await self.storage.list_by_run(run_id)
+        return [self._row_to_artifact(r) for r in rows]
+
+    async def get_by_id(self, artifact_id: int) -> AudioArtifact | None:
+        """Get a single artifact by id."""
+        row = await self.storage.get_artifact(artifact_id)
+        if row is None:
+            return None
+        return self._row_to_artifact(row)
+
+    # -- Internal -----------------------------------------------------------
+
+    @staticmethod
+    def _row_to_artifact(row: dict[str, Any]) -> AudioArtifact:
+        """Convert a storage row to an AudioArtifact domain model."""
+        return AudioArtifact.from_row(row)
+
+
+audio_service = AudioService()

--- a/packages/creator-service/creator-service
+++ b/packages/creator-service/creator-service
@@ -1,1 +1,0 @@
-creator-service

--- a/packages/creator-service/creator-service
+++ b/packages/creator-service/creator-service
@@ -1,0 +1,1 @@
+creator-service

--- a/packages/creator-service/ffmpeg_service.py
+++ b/packages/creator-service/ffmpeg_service.py
@@ -1,0 +1,76 @@
+import subprocess
+from pathlib import Path
+from dataclasses import dataclass
+
+from .render_profile import RenderProfile
+
+
+@dataclass
+class RenderInput:
+    image_paths: list[Path]       # ordered scene images
+    audio_path: Path | None       # narration audio
+    subtitle_path: Path | None    # SRT subtitle file
+    scene_durations: list[float]  # duration per scene in seconds
+
+
+class FFmpegService:
+    def __init__(self, profile: RenderProfile | None = None):
+        self.profile = profile or RenderProfile.default()
+
+    def build_command(self, input_data: RenderInput, output_path: Path) -> list[str]:
+        """Build FFmpeg command for rendering video from scenes."""
+        # This builds the actual FFmpeg command
+        # Ken Burns effect: use zoompan filter
+        # Subtitle burn-in: use subtitles filter
+        cmd = ["ffmpeg", "-y"]  # overwrite output
+        
+        # Build filter complex for image sequence with ken burns
+        filter_parts = []
+        for i, (img, dur) in enumerate(zip(input_data.image_paths, input_data.scene_durations)):
+            cmd.extend(["-loop", "1", "-t", str(dur), "-i", str(img)])
+            # Scale + Ken Burns zoom
+            filter_parts.append(
+                f"[{i}:v]scale={self.profile.width}:{self.profile.height}:force_original_aspect_ratio=decrease,"
+                f"pad={self.profile.width}:{self.profile.height}:(ow-iw)/2:(oh-ih)/2,"
+                f"setsar=1[v{i}]"
+            )
+        
+        # Concat all scenes
+        concat_inputs = "".join(f"[v{i}]" for i in range(len(input_data.image_paths)))
+        filter_parts.append(f"{concat_inputs}concat=n={len(input_data.image_paths)}:v=1:a=0[vout]")
+        
+        cmd.extend(["-filter_complex", ";".join(filter_parts)])
+        
+        # Add audio if present
+        if input_data.audio_path:
+            cmd.extend(["-i", str(input_data.audio_path)])
+            cmd.extend(["-map", "[vout]", "-map", f"{len(input_data.image_paths)}:a"])
+        else:
+            cmd.extend(["-map", "[vout]"])
+        
+        # Codec settings
+        cmd.extend([
+            "-c:v", self.profile.video_codec.value,
+            "-crf", str(self.profile.crf),
+            "-preset", self.profile.preset,
+            "-r", str(self.profile.fps),
+        ])
+        
+        if input_data.audio_path:
+            cmd.extend(["-c:a", self.profile.audio_codec.value])
+        
+        # Subtitle burn-in
+        if self.profile.burn_subtitles and input_data.subtitle_path:
+            cmd.extend(["-vf", f"subtitles={input_data.subtitle_path}:force_style='FontSize={self.profile.subtitle_font_size}'"])
+        
+        cmd.append(str(output_path))
+        return cmd
+
+    def render(self, input_data: RenderInput, output_path: Path) -> Path:
+        """Execute FFmpeg render. Returns output path on success."""
+        cmd = self.build_command(input_data, output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        if result.returncode != 0:
+            raise RuntimeError(f"FFmpeg render failed: {result.stderr}")
+        return output_path

--- a/packages/creator-service/logging_config.py
+++ b/packages/creator-service/logging_config.py
@@ -1,0 +1,95 @@
+"""Shared structured JSON logging configuration."""
+
+import json
+import logging
+from typing import Any
+
+
+class JsonFormatter(logging.Formatter):
+    """JSON formatter for structured logging."""
+
+    def __init__(self, service_name: str) -> None:
+        """Initialize JSON formatter.
+        
+        Args:
+            service_name: Name of the service using this logger
+        """
+        super().__init__()
+        self.service_name = service_name
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format log record as JSON.
+        
+        Args:
+            record: Log record to format
+            
+        Returns:
+            JSON-formatted log string
+        """
+        log_obj: dict[str, Any] = {
+            "timestamp": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "service": self.service_name,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Add exception info if present
+        if record.exc_info:
+            log_obj["exc_info"] = self.formatException(record.exc_info)
+
+        # Add extra fields
+        if hasattr(record, "__dict__"):
+            for key, value in record.__dict__.items():
+                if key not in [
+                    "name",
+                    "msg",
+                    "args",
+                    "created",
+                    "filename",
+                    "funcName",
+                    "levelname",
+                    "levelno",
+                    "lineno",
+                    "module",
+                    "msecs",
+                    "message",
+                    "pathname",
+                    "process",
+                    "processName",
+                    "relativeCreated",
+                    "thread",
+                    "threadName",
+                    "exc_info",
+                    "exc_text",
+                    "stack_info",
+                ]:
+                    log_obj[key] = value
+
+        return json.dumps(log_obj, default=str)
+
+
+def setup_json_logging(service_name: str, level: str = "INFO") -> None:
+    """Configure root logger with JSON formatting.
+    
+    Args:
+        service_name: Name of the service
+        level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    """
+    # Remove existing handlers
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+
+    # Create console handler with JSON formatter
+    handler = logging.StreamHandler()
+    formatter = JsonFormatter(service_name=service_name)
+    handler.setFormatter(formatter)
+
+    # Configure root logger
+    root_logger.addHandler(handler)
+    root_logger.setLevel(getattr(logging, level))
+
+    # Suppress noisy loggers
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("asyncio").setLevel(logging.WARNING)

--- a/packages/creator-service/markdown_parser.py
+++ b/packages/creator-service/markdown_parser.py
@@ -1,0 +1,88 @@
+import re
+
+try:
+    from creator_domain.models import ScriptSection  # pyright: ignore[reportMissingImports]
+except ImportError:
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
+    from models import ScriptSection  # pyright: ignore[reportMissingImports]
+
+
+_LEVEL_TWO_HEADING_RE = re.compile(r"^\s{0,3}##(?!#)\s*(.*?)\s*$")
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _normalize_section_type(raw_heading: str) -> str:
+    normalized = _NON_ALNUM_RE.sub("-", raw_heading.strip().lower()).strip("-")
+    return normalized or "body"
+
+
+def _join_and_trim(lines: list[str]) -> str:
+    return "\n".join(lines).strip()
+
+
+def _extract_sections(markdown: str) -> list[tuple[str, str]]:
+    lines = markdown.splitlines()
+    extracted: list[tuple[str, str]] = []
+    pending_lines: list[str] = []
+    current_type: str | None = None
+
+    for line in lines:
+        heading_match = _LEVEL_TWO_HEADING_RE.match(line)
+        if heading_match:
+            if current_type is None:
+                prelude = _join_and_trim(pending_lines)
+                if prelude:
+                    extracted.append(("body", prelude))
+            else:
+                extracted.append((current_type, _join_and_trim(pending_lines)))
+
+            current_type = _normalize_section_type(heading_match.group(1))
+            pending_lines = []
+            continue
+
+        pending_lines.append(line)
+
+    if current_type is None:
+        body_text = _join_and_trim(pending_lines)
+        return [("body", body_text)] if body_text else []
+
+    extracted.append((current_type, _join_and_trim(pending_lines)))
+    return extracted
+
+
+def parse_markdown(
+    markdown: str, existing_sections: list[ScriptSection] | None = None
+) -> list[ScriptSection]:
+    if not markdown or not markdown.strip():
+        return []
+
+    extracted_sections = _extract_sections(markdown)
+    existing_id_by_key: dict[tuple[str, int], str] = {}
+
+    if existing_sections:
+        for position, section in enumerate(existing_sections, start=1):
+            key = (section.type, position)
+            if key not in existing_id_by_key:
+                existing_id_by_key[key] = section.section_id
+
+    parsed_sections: list[ScriptSection] = []
+    for position, (section_type, text) in enumerate(extracted_sections, start=1):
+        key = (section_type, position)
+        section_id = existing_id_by_key.get(key, f"{section_type}-{position}")
+        parsed_sections.append(
+            ScriptSection(
+                section_id=section_id,
+                type=section_type,
+                text=text,
+                display_text=text,
+                speaker="host",
+                duration=None,
+                turn_kind=None,
+                visual_override=None,
+            )
+        )
+
+    return parsed_sections

--- a/packages/creator-service/model_catalog_service.py
+++ b/packages/creator-service/model_catalog_service.py
@@ -34,6 +34,19 @@ class ModelCatalogService:
         ModelStatus.UNKNOWN: "unknown",
     }
 
+    # Explicit labels for known model keys.  New models that lack an entry
+    # fall through to the generic _format_label_fallback() formatter.
+    _KNOWN_LABELS: dict[str, str] = {
+        "qwen3-4b": "Qwen3 4B",
+        "qwen3-8b": "Qwen3 8B",
+        "sd15": "Stable Diffusion 1.5",
+        "sd-2.1": "Stable Diffusion 2.1",
+        "qwen-tts": "Qwen TTS",
+        "whisper-medium": "Whisper Medium",
+        "gpt-4o-mini": "GPT-4o Mini",
+        "llama-3.1-8b": "Llama 3.1 8B",
+    }
+
     def __init__(self, registry: Any, health_service: ModelHealthService):
         self.registry = registry
         self.health_service = health_service
@@ -79,7 +92,7 @@ class ModelCatalogService:
             health_result = await self.health_service.check_model(health_key)
             providers.append(
                 {
-                    "name": entry.provider_type,
+                    "name": self._health_key(entry),
                     "endpoint": entry.endpoint,
                     "healthy": health_result.status == ModelStatus.HEALTHY,
                     "loaded_model": None,
@@ -107,22 +120,25 @@ class ModelCatalogService:
             "status": self._HEALTH_TO_CATALOG_STATUS[health_result.status],
         }
 
-    @staticmethod
-    def _format_label(model_key: str, is_local: bool) -> str:
-        words = []
-        for token in model_key.replace("_", "-").split("-"):
-            if not token:
-                continue
-            if token[:-1].isdigit() and token[-1:].isalpha():
-                words.append(f"{token[:-1]}{token[-1:].upper()}")
-            else:
-                words.append(token[:1].upper() + token[1:])
-
+    def _format_label(self, model_key: str, is_local: bool) -> str:
+        known = self._KNOWN_LABELS.get(model_key)
+        base = known if known is not None else self._format_label_fallback(model_key)
         location = "Local" if is_local else "Remote"
-        return f"{' '.join(words)} ({location})"
+        return f"{base} ({location})"
+
+    @staticmethod
+    def _format_label_fallback(model_key: str) -> str:
+        """Best-effort title-case for unknown model keys."""
+        return model_key.replace("-", " ").replace("_", " ").title()
 
     @staticmethod
     def _health_key(entry: Any) -> str:
+        """Derive the ModelHealthService lookup key from a registry entry.
+
+        ModelHealthService is keyed by Docker service hostname (e.g.
+        "ollama", "stable-diffusion"), which matches the hostname portion
+        of the endpoint URL in the registry.
+        """
         parsed = urlparse(entry.endpoint)
         if parsed.hostname:
             return parsed.hostname

--- a/packages/creator-service/model_catalog_service.py
+++ b/packages/creator-service/model_catalog_service.py
@@ -1,1 +1,129 @@
-"""Placeholder for model_catalog_service."""
+"""Model catalog service backed by provider registry and health checks."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+try:
+    from .model_health_service import ModelHealthService, ModelStatus
+except ImportError:
+    from model_health_service import ModelHealthService, ModelStatus
+
+
+class ModelCatalogService:
+    """Expose registry-backed model catalog and provider status."""
+
+    _CATEGORY_TO_REGISTRY_VALUE = {
+        "script": "llm",
+        "image": "image",
+        "tts": "tts",
+        "stt": "stt",
+    }
+
+    _CATEGORY_TO_RESPONSE_KEY = {
+        "llm": "script_models",
+        "image": "image_models",
+        "tts": "tts_models",
+        "stt": "stt_models",
+    }
+
+    _HEALTH_TO_CATALOG_STATUS = {
+        ModelStatus.HEALTHY: "available",
+        ModelStatus.UNHEALTHY: "unavailable",
+        ModelStatus.UNKNOWN: "unknown",
+    }
+
+    def __init__(self, registry: Any, health_service: ModelHealthService):
+        self.registry = registry
+        self.health_service = health_service
+
+    async def list_models(self, category: str | None = None) -> dict[str, list[dict[str, object]]]:
+        """List catalog models grouped by API response category keys."""
+        response: dict[str, list[dict[str, object]]] = {
+            "script_models": [],
+            "image_models": [],
+            "tts_models": [],
+            "stt_models": [],
+        }
+
+        category_value = None
+        if category is not None:
+            category_value = self._CATEGORY_TO_REGISTRY_VALUE.get(category)
+            if category_value is None:
+                raise ValueError(f"Unsupported category '{category}'")
+
+        entries = self.registry.list_models()
+        for entry in entries:
+            entry_category = entry.category.value
+            if category_value is not None and entry_category != category_value:
+                continue
+
+            response_key = self._CATEGORY_TO_RESPONSE_KEY[entry_category]
+            response[response_key].append(await self._catalog_entry(entry))
+
+        return response
+
+    async def get_status(self) -> dict[str, object]:
+        """Return provider-level health and current GPU lock defaults."""
+        providers: list[dict[str, object]] = []
+        seen: set[tuple[str, str]] = set()
+
+        for entry in self.registry.list_models():
+            provider_id = (entry.provider_type, entry.endpoint)
+            if provider_id in seen:
+                continue
+            seen.add(provider_id)
+
+            health_key = self._health_key(entry)
+            health_result = await self.health_service.check_model(health_key)
+            providers.append(
+                {
+                    "name": entry.provider_type,
+                    "endpoint": entry.endpoint,
+                    "healthy": health_result.status == ModelStatus.HEALTHY,
+                    "loaded_model": None,
+                    "gpu_locked": False,
+                }
+            )
+
+        return {
+            "providers": providers,
+            "gpu_lock": {
+                "active": False,
+                "holder": None,
+                "ttl_remaining": None,
+            },
+        }
+
+    async def _catalog_entry(self, entry: Any) -> dict[str, object]:
+        health_result = await self.health_service.check_model(self._health_key(entry))
+        return {
+            "key": entry.model_key,
+            "label": self._format_label(entry.model_key, entry.is_local),
+            "provider_type": entry.provider_type,
+            "is_local": entry.is_local,
+            "requires_gpu": entry.requires_gpu,
+            "status": self._HEALTH_TO_CATALOG_STATUS[health_result.status],
+        }
+
+    @staticmethod
+    def _format_label(model_key: str, is_local: bool) -> str:
+        words = []
+        for token in model_key.replace("_", "-").split("-"):
+            if not token:
+                continue
+            if token[:-1].isdigit() and token[-1:].isalpha():
+                words.append(f"{token[:-1]}{token[-1:].upper()}")
+            else:
+                words.append(token[:1].upper() + token[1:])
+
+        location = "Local" if is_local else "Remote"
+        return f"{' '.join(words)} ({location})"
+
+    @staticmethod
+    def _health_key(entry: Any) -> str:
+        parsed = urlparse(entry.endpoint)
+        if parsed.hostname:
+            return parsed.hostname
+        return entry.provider_type

--- a/packages/creator-service/model_health_service.py
+++ b/packages/creator-service/model_health_service.py
@@ -1,0 +1,84 @@
+"""Model health check service for monitoring model serving containers."""
+
+from dataclasses import dataclass
+from enum import Enum
+import os
+
+
+class ModelStatus(Enum):
+    """Status of a model container."""
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ModelHealthResult:
+    """Result of a model health check."""
+    model_name: str
+    endpoint: str
+    status: ModelStatus
+    response_time_ms: float | None = None
+    error: str | None = None
+
+
+class ModelHealthService:
+    """Check health of model serving containers."""
+    
+    def __init__(self):
+        """Initialize health service with model endpoints from environment variables."""
+        self.endpoints = {
+            "ollama": os.getenv("OLLAMA_BASE_URL", "http://ollama:11434"),
+            "stable-diffusion": os.getenv("STABLE_DIFFUSION_BASE_URL", "http://stable-diffusion:7860"),
+            "tts-qwen3": os.getenv("TTS_QWEN_BASE_URL", "http://tts-qwen3:9880"),
+            "stt-whisper": os.getenv("STT_WHISPER_BASE_URL", "http://stt-whisper:9000"),
+        }
+        self.health_paths = {
+            "ollama": "/api/tags",
+            "stable-diffusion": "/sdapi/v1/options",
+            "tts-qwen3": "/",  # placeholder — update when TTS health endpoint is known
+            "stt-whisper": "/",  # placeholder — update when STT health endpoint is known
+        }
+
+    async def check_model(self, model_name: str) -> ModelHealthResult:
+        """Check health of a single model container.
+        
+        Args:
+            model_name: Name of the model to check
+            
+        Returns:
+            ModelHealthResult with health status and metadata
+        """
+        endpoint = self.endpoints.get(model_name)
+        if not endpoint:
+            return ModelHealthResult(
+                model_name=model_name,
+                endpoint="unknown",
+                status=ModelStatus.UNKNOWN,
+                error="Unknown model"
+            )
+        
+        health_path = self.health_paths.get(model_name, "/")
+        url = f"{endpoint}{health_path}"
+        
+        # TODO: Implement actual HTTP call using httpx
+        # In production: async with httpx.AsyncClient() as client: ...
+        # For now, return placeholder result
+        return ModelHealthResult(
+            model_name=model_name,
+            endpoint=endpoint,
+            status=ModelStatus.UNKNOWN,
+            error="Health check not yet implemented"
+        )
+
+    async def check_all(self) -> list[ModelHealthResult]:
+        """Check health of all model containers.
+        
+        Returns:
+            List of ModelHealthResult for each model container
+        """
+        results = []
+        for name in self.endpoints:
+            result = await self.check_model(name)
+            results.append(result)
+        return results

--- a/packages/creator-service/project_service.py
+++ b/packages/creator-service/project_service.py
@@ -7,41 +7,19 @@ the same async service-facing interface.
 
 from __future__ import annotations
 
-import importlib
-import sys
+try:
+    from creator_domain.models import Project
+except ImportError:
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
+    from models import Project
+
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import Any, Literal, Protocol
 
-
-def _load_project_model() -> Any:
-    try:
-        return importlib.import_module("models").Project
-    except ModuleNotFoundError:
-        domain_root = Path(__file__).resolve().parents[1] / "creator-domain"
-        if str(domain_root) not in sys.path:
-            sys.path.insert(0, str(domain_root))
-        return importlib.import_module("models").Project
-
-
-if TYPE_CHECKING:
-    from pydantic import BaseModel
-
-    class Project(BaseModel):
-        id: int
-        title: str | None
-        source_type: Literal["idea", "markdown", "url"]
-        idea_brief: str | None
-        markdown_source: str | None
-        url_source: str | None
-        status: Literal["draft", "active", "completed", "archived"]
-        created_at: datetime
-        updated_at: datetime
-else:
-    Project = _load_project_model()
-
-
-LatestRunSummary = dict[str, int | str]
+LatestRunSummary = dict[str, int | str | None]
 
 
 class ProjectStorageBackend(Protocol):
@@ -152,6 +130,14 @@ class ProjectService:
     ) -> Project:
         if source_type not in self._ALLOWED_SOURCE_TYPES:
             raise ValueError(f"Unsupported source_type '{source_type}'")
+
+        # Validate payload matches source_type
+        if source_type == "markdown" and markdown_source is None:
+            raise ValueError("source_type='markdown' requires markdown_source to be provided")
+        if source_type == "url" and url_source is None:
+            raise ValueError("source_type='url' requires url_source to be provided")
+        if source_type == "idea" and idea_brief is None:
+            raise ValueError("source_type='idea' requires idea_brief to be provided")
 
         row = await self.db.insert_project(
             {

--- a/packages/creator-service/project_service.py
+++ b/packages/creator-service/project_service.py
@@ -7,16 +7,16 @@ the same async service-facing interface.
 
 from __future__ import annotations
 
-try:
-    from creator_domain.models import Project
-except ImportError:
-    import sys
-    from pathlib import Path
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
-    from models import Project
+import sys
+from pathlib import Path
+
+_DOMAIN_DIR = str(Path(__file__).resolve().parent.parent / "creator-domain")
+if _DOMAIN_DIR not in sys.path:
+    sys.path.insert(0, _DOMAIN_DIR)
+
+from models.project import Project
 
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Literal, Protocol
 
 LatestRunSummary = dict[str, int | str | None]
@@ -138,6 +138,14 @@ class ProjectService:
             raise ValueError("source_type='url' requires url_source to be provided")
         if source_type == "idea" and idea_brief is None:
             raise ValueError("source_type='idea' requires idea_brief to be provided")
+
+        # Enforce field exclusivity: each source_type should only have its corresponding field
+        if source_type == "idea" and (markdown_source is not None or url_source is not None):
+            raise ValueError("source_type='idea' cannot have markdown_source or url_source set")
+        if source_type == "markdown" and (idea_brief is not None or url_source is not None):
+            raise ValueError("source_type='markdown' cannot have idea_brief or url_source set")
+        if source_type == "url" and (idea_brief is not None or markdown_source is not None):
+            raise ValueError("source_type='url' cannot have idea_brief or markdown_source set")
 
         row = await self.db.insert_project(
             {

--- a/packages/creator-service/project_service.py
+++ b/packages/creator-service/project_service.py
@@ -1,1 +1,190 @@
-"""Placeholder for project_service."""
+"""Project service with a pluggable async storage backend.
+
+The long-term target is an async DB connection/pool (for example, asyncpg).
+Until DB wiring is in place, this module uses an in-memory backend that exposes
+the same async service-facing interface.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+
+def _load_project_model() -> Any:
+    try:
+        return importlib.import_module("models").Project
+    except ModuleNotFoundError:
+        domain_root = Path(__file__).resolve().parents[1] / "creator-domain"
+        if str(domain_root) not in sys.path:
+            sys.path.insert(0, str(domain_root))
+        return importlib.import_module("models").Project
+
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+    class Project(BaseModel):
+        id: int
+        title: str | None
+        source_type: Literal["idea", "markdown", "url"]
+        idea_brief: str | None
+        markdown_source: str | None
+        url_source: str | None
+        status: Literal["draft", "active", "completed", "archived"]
+        created_at: datetime
+        updated_at: datetime
+else:
+    Project = _load_project_model()
+
+
+LatestRunSummary = dict[str, int | str]
+
+
+class ProjectStorageBackend(Protocol):
+    """Abstract async storage interface used by ProjectService."""
+
+    async def insert_project(self, payload: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+    async def fetch_project(self, project_id: int) -> dict[str, Any] | None:
+        ...
+
+    async def list_projects(self, limit: int, offset: int) -> list[dict[str, Any]]:
+        ...
+
+    async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
+        ...
+
+
+class InMemoryProjectStorage:
+    """Temporary async storage backend used before DB integration."""
+
+    def __init__(self) -> None:
+        self._projects: dict[int, dict[str, Any]] = {}
+        self._runs_by_project: dict[int, list[dict[str, Any]]] = {}
+        self._next_project_id = 1
+        self._next_run_id = 1
+
+    async def insert_project(self, payload: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        project_id = self._next_project_id
+        self._next_project_id += 1
+
+        row = {
+            "id": project_id,
+            "title": payload.get("title"),
+            "source_type": payload.get("source_type", "idea"),
+            "idea_brief": payload.get("idea_brief"),
+            "markdown_source": payload.get("markdown_source"),
+            "url_source": payload.get("url_source"),
+            "status": payload.get("status", "draft"),
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._projects[project_id] = row
+        return dict(row)
+
+    async def fetch_project(self, project_id: int) -> dict[str, Any] | None:
+        row = self._projects.get(project_id)
+        if row is None:
+            return None
+        return dict(row)
+
+    async def list_projects(self, limit: int, offset: int) -> list[dict[str, Any]]:
+        ordered = sorted(
+            self._projects.values(),
+            key=lambda row: (row["created_at"], row["id"]),
+            reverse=True,
+        )
+        return [dict(row) for row in ordered[offset : offset + limit]]
+
+    async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
+        runs = self._runs_by_project.get(project_id, [])
+        if not runs:
+            return None
+        latest = max(runs, key=lambda run: run["id"])
+        return {
+            "run_id": latest["id"],
+            "current_stage": latest["current_stage"],
+            "status": latest["status"],
+        }
+
+    async def insert_run(
+        self,
+        project_id: int,
+        current_stage: str | None,
+        status: str,
+    ) -> dict[str, Any]:
+        run_id = self._next_run_id
+        self._next_run_id += 1
+        row = {
+            "id": run_id,
+            "project_id": project_id,
+            "current_stage": current_stage,
+            "status": status,
+            "created_at": datetime.now(timezone.utc),
+        }
+        self._runs_by_project.setdefault(project_id, []).append(row)
+        return dict(row)
+
+
+class ProjectWithLatestRun(Project):
+    latest_run: LatestRunSummary | None = None
+
+
+class ProjectService:
+    _ALLOWED_SOURCE_TYPES = {"idea", "markdown", "url"}
+
+    def __init__(self, db: ProjectStorageBackend | None = None) -> None:
+        self.db = db if db is not None else InMemoryProjectStorage()
+
+    async def create_project(
+        self,
+        title: str,
+        source_type: Literal["idea", "markdown", "url"],
+        idea_brief: str | None = None,
+        markdown_source: str | None = None,
+        url_source: str | None = None,
+    ) -> Project:
+        if source_type not in self._ALLOWED_SOURCE_TYPES:
+            raise ValueError(f"Unsupported source_type '{source_type}'")
+
+        row = await self.db.insert_project(
+            {
+                "title": title,
+                "source_type": source_type,
+                "idea_brief": idea_brief,
+                "markdown_source": markdown_source,
+                "url_source": url_source,
+                "status": "draft",
+            }
+        )
+        return Project.model_validate(row)
+
+    async def get_project(self, project_id: int) -> Project | None:
+        row = await self.db.fetch_project(project_id)
+        if row is None:
+            return None
+
+        latest_run = await self.db.fetch_latest_run_summary(project_id)
+        return ProjectWithLatestRun.model_validate({**row, "latest_run": latest_run})
+
+    async def list_projects(self, limit: int = 20, offset: int = 0) -> list[Project]:
+        if limit < 0:
+            raise ValueError("limit must be >= 0")
+        if offset < 0:
+            raise ValueError("offset must be >= 0")
+
+        rows = await self.db.list_projects(limit=limit, offset=offset)
+        projects: list[Project] = []
+        for row in rows:
+            latest_run = await self.db.fetch_latest_run_summary(row["id"])
+            projects.append(ProjectWithLatestRun.model_validate({**row, "latest_run": latest_run}))
+        return projects
+
+
+project_service = ProjectService()

--- a/packages/creator-service/project_service.py
+++ b/packages/creator-service/project_service.py
@@ -37,6 +37,9 @@ class ProjectStorageBackend(Protocol):
     async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
         ...
 
+    async def count_projects(self) -> int:
+        ...
+
 
 class InMemoryProjectStorage:
     """Temporary async storage backend used before DB integration."""
@@ -79,6 +82,9 @@ class InMemoryProjectStorage:
             reverse=True,
         )
         return [dict(row) for row in ordered[offset : offset + limit]]
+
+    async def count_projects(self) -> int:
+        return len(self._projects)
 
     async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
         runs = self._runs_by_project.get(project_id, [])
@@ -179,6 +185,9 @@ class ProjectService:
             latest_run = await self.db.fetch_latest_run_summary(row["id"])
             projects.append(ProjectWithLatestRun.model_validate({**row, "latest_run": latest_run}))
         return projects
+
+    async def count_projects(self) -> int:
+        return await self.db.count_projects()
 
 
 project_service = ProjectService()

--- a/packages/creator-service/render_profile.py
+++ b/packages/creator-service/render_profile.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Codec(Enum):
+    H264 = "libx264"
+    H265 = "libx265"
+
+
+class AudioCodec(Enum):
+    AAC = "aac"
+    MP3 = "libmp3lame"
+
+
+class TransitionStyle(Enum):
+    CUT = "cut"
+    FADE = "fade"
+    KEN_BURNS = "ken_burns"
+
+
+@dataclass
+class RenderProfile:
+    name: str = "shorts_default"
+    width: int = 1080
+    height: int = 1920  # 9:16 vertical
+    fps: int = 30
+    video_codec: Codec = Codec.H264
+    audio_codec: AudioCodec = AudioCodec.AAC
+    transition_style: TransitionStyle = TransitionStyle.KEN_BURNS
+    min_duration_seconds: int = 15
+    max_duration_seconds: int = 60
+    crf: int = 23  # quality (lower = better, 18-28 typical)
+    preset: str = "medium"  # encoding speed
+    burn_subtitles: bool = True
+    subtitle_font_size: int = 24
+
+    @classmethod
+    def default(cls) -> "RenderProfile":
+        return cls()
+
+    @classmethod
+    def high_quality(cls) -> "RenderProfile":
+        return cls(name="high_quality", crf=18, preset="slow")
+
+    @classmethod
+    def fast_preview(cls) -> "RenderProfile":
+        return cls(name="fast_preview", width=540, height=960, fps=15, crf=28, preset="ultrafast")

--- a/packages/creator-service/render_service.py
+++ b/packages/creator-service/render_service.py
@@ -1,1 +1,247 @@
-"""Placeholder for render_service."""
+"""Render service for artifact storage and retrieval.
+
+Manages video render artifacts generated for runs. Each run can have multiple render
+artifacts. Render artifacts are NOT scene-versioned; the latest artifact per run
+is the current one.
+
+Follows the same Protocol → InMemory → Service pattern as
+VisualAssetService and ScriptService.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+import json
+
+_DOMAIN_DIR = str(Path(__file__).resolve().parent.parent / "creator-domain")
+if _DOMAIN_DIR not in sys.path:
+    sys.path.insert(0, _DOMAIN_DIR)
+
+from models.video_artifact import VideoArtifact  # type: ignore[reportMissingImports]  # noqa: E402, I001
+
+from render_profile import RenderProfile  # noqa: E402, I001
+
+
+# ---------------------------------------------------------------------------
+# Storage Protocol
+# ---------------------------------------------------------------------------
+
+
+class RenderStorageBackend(Protocol):
+    async def save_artifact(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist a render artifact row and return stored row with id assigned.
+
+        The storage backend allocates the next id and inserts the row.
+        Callers MUST NOT include ``id`` in *row*; the returned dict
+        MUST contain the allocated ``id``.
+        """
+        ...
+
+    async def get_artifact(self, artifact_id: int) -> dict[str, Any] | None:
+        """Fetch a single artifact by id."""
+        ...
+
+    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        """List all artifacts for a run, newest first."""
+        ...
+
+    async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
+        """Fetch the most recent artifact for a run."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-Memory Storage
+# ---------------------------------------------------------------------------
+
+
+class InMemoryRenderStorage:
+    """In-memory storage for render artifacts."""
+
+    def __init__(self) -> None:
+        self._artifacts: list[dict[str, Any]] = []
+        self._next_id = 1
+
+    async def save_artifact(self, row: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        saved = {
+            "id": self._next_id,
+            "created_at": now,
+            **row,
+        }
+        self._next_id += 1
+        self._artifacts.append(saved)
+        return dict(saved)
+
+    async def get_artifact(self, artifact_id: int) -> dict[str, Any] | None:
+        for a in self._artifacts:
+            if a["id"] == artifact_id:
+                return dict(a)
+        return None
+
+    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        run_artifacts = [a for a in self._artifacts if a["run_id"] == run_id]
+        return [
+            dict(a)
+            for a in sorted(run_artifacts, key=lambda x: x["created_at"], reverse=True)
+        ]
+
+    async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
+        artifacts = await self.list_by_run(run_id)
+        return artifacts[0] if artifacts else None
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class RenderService:
+    def __init__(self, storage: RenderStorageBackend | None = None) -> None:
+        self.storage = storage if storage is not None else InMemoryRenderStorage()
+
+    # -- Create -------------------------------------------------------------
+
+    async def create_artifact(
+        self,
+        run_id: int,
+        path: str,
+        *,
+        render_profile: str | None = None,
+    ) -> VideoArtifact:
+        """Create a new render artifact for a run.
+
+        Render artifacts are NOT versioned. The latest artifact per run
+        is the current one.
+        """
+        metadata = {}
+        if render_profile is not None:
+            metadata["render_profile"] = render_profile
+
+        row = {
+            "run_id": run_id,
+            "file_path": path,
+            "metadata_json": metadata,
+        }
+        saved = await self.storage.save_artifact(row)
+
+        return self._row_to_artifact(saved)
+
+    # -- Reads --------------------------------------------------------------
+
+    async def get_latest(self, run_id: int) -> VideoArtifact | None:
+        """Get the most recent render artifact for a run."""
+        row = await self.storage.get_latest_by_run(run_id)
+        if row is None:
+            return None
+        return self._row_to_artifact(row)
+
+    async def list_by_run(self, run_id: int) -> list[VideoArtifact]:
+        """List all render artifacts for a run, newest first."""
+        rows = await self.storage.list_by_run(run_id)
+        return [self._row_to_artifact(r) for r in rows]
+
+    async def get_by_id(self, artifact_id: int) -> VideoArtifact | None:
+        """Get a single artifact by id."""
+        row = await self.storage.get_artifact(artifact_id)
+        if row is None:
+            return None
+        return self._row_to_artifact(row)
+
+    async def build_render_manifest(
+        self,
+        run_id: int,
+        visual_asset_service: Any,
+        audio_service: Any,
+        subtitle_service: Any,
+        render_profile_name: str = "shorts_default",
+    ) -> dict[str, Any]:
+        """Build a render manifest for a run.
+
+        Assembles a manifest containing:
+        - scenes: list of active scene assets
+        - audio_path: latest audio artifact path or None
+        - subtitle_path: latest subtitle artifact path or None
+        - render_profile: render profile configuration
+
+        Args:
+            run_id: Run ID
+            visual_asset_service: Service to retrieve visual assets (grouped by scene)
+            audio_service: Service to retrieve latest audio
+            subtitle_service: Service to retrieve latest subtitles
+            render_profile_name: Name of render profile ("shorts_default", "high_quality", "fast_preview")
+
+        Returns:
+            dict with keys: run_id, scenes, audio_path, subtitle_path, render_profile
+        """
+        # Get grouped assets by scene
+        grouped_assets = await visual_asset_service.list_by_run(run_id)
+
+        # Build scenes list - pick first active asset from each scene
+        scenes = []
+        for scene_id in sorted(grouped_assets.keys()):
+            assets = grouped_assets[scene_id]
+            # Find first active asset
+            active_asset = None
+            for asset in assets:
+                if asset.is_active:
+                    active_asset = asset
+                    break
+            if active_asset:
+                scenes.append({
+                    "scene_id": scene_id,
+                    "asset_path": active_asset.asset_path,
+                    "prompt_snapshot": active_asset.prompt_snapshot,
+                })
+
+        # Get latest audio
+        audio_artifact = await audio_service.get_latest(run_id)
+        audio_path = audio_artifact.path if audio_artifact else None
+
+        # Get latest subtitle
+        subtitle_artifact = await subtitle_service.get_latest(run_id)
+        subtitle_path = subtitle_artifact.path if subtitle_artifact else None
+
+        # Resolve render profile
+        if render_profile_name == "high_quality":
+            profile = RenderProfile.high_quality()
+        elif render_profile_name == "fast_preview":
+            profile = RenderProfile.fast_preview()
+        else:  # default to shorts_default
+            profile = RenderProfile.default()
+
+        return {
+            "run_id": run_id,
+            "scenes": scenes,
+            "audio_path": audio_path,
+            "subtitle_path": subtitle_path,
+            "render_profile": {
+                "name": profile.name,
+                "width": profile.width,
+                "height": profile.height,
+                "fps": profile.fps,
+                "video_codec": profile.video_codec.value,
+                "audio_codec": profile.audio_codec.value,
+                "transition_style": profile.transition_style.value,
+                "min_duration_seconds": profile.min_duration_seconds,
+                "max_duration_seconds": profile.max_duration_seconds,
+                "crf": profile.crf,
+                "preset": profile.preset,
+                "burn_subtitles": profile.burn_subtitles,
+                "subtitle_font_size": profile.subtitle_font_size,
+            },
+        }
+
+    # -- Internal -----------------------------------------------------------
+
+    @staticmethod
+    def _row_to_artifact(row: dict[str, Any]) -> VideoArtifact:
+        """Convert a storage row to a VideoArtifact domain model."""
+        return VideoArtifact.from_row(row)
+
+
+render_service = RenderService()

--- a/packages/creator-service/run_service.py
+++ b/packages/creator-service/run_service.py
@@ -1,1 +1,143 @@
-"""Placeholder for run_service."""
+"""Run service with in-memory storage backend."""
+
+from __future__ import annotations
+
+import json
+import importlib
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
+domain_models = importlib.import_module("models")
+ModelSelection = domain_models.ModelSelection
+PipelineRun = domain_models.PipelineRun
+RunStage = domain_models.RunStage
+REVIEW_STAGES = domain_models.REVIEW_STAGES
+can_transition = domain_models.can_transition
+
+
+class RunStorageBackend(Protocol):
+    async def create_run(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist a run row and return stored row."""
+        ...
+
+    async def get_run(self, run_id: int) -> dict[str, Any] | None:
+        """Fetch run row by id."""
+        ...
+
+    async def update_run(self, run_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update and return run row by id."""
+        ...
+
+
+class InMemoryRunStorage:
+    def __init__(self) -> None:
+        self._rows: dict[int, dict[str, Any]] = {}
+        self._next_id = 1
+
+    async def create_run(self, row: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        saved = {
+            "id": self._next_id,
+            "created_at": now,
+            "updated_at": now,
+            **row,
+        }
+        self._rows[self._next_id] = saved
+        self._next_id += 1
+        return dict(saved)
+
+    async def get_run(self, run_id: int) -> dict[str, Any] | None:
+        row = self._rows.get(run_id)
+        return dict(row) if row is not None else None
+
+    async def update_run(self, run_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        row = self._rows.get(run_id)
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        row.update(updates)
+        row["updated_at"] = datetime.now(timezone.utc)
+        self._rows[run_id] = row
+        return dict(row)
+
+
+class RunService:
+    def __init__(self, storage: RunStorageBackend):
+        self.storage = storage
+
+    async def create_run(
+        self,
+        project_id: int,
+        model_defaults: dict[str, Any] | Any | None,
+        style_preset: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> PipelineRun:
+        model_defaults_payload: str | None = None
+        if model_defaults is not None:
+            model_dump = getattr(model_defaults, "model_dump", None)
+            if callable(model_dump):
+                model_defaults_payload = json.dumps(model_dump())
+            else:
+                model_defaults_payload = json.dumps(model_defaults)
+
+        metadata_payload: str | None = None
+        if metadata is not None:
+            metadata_payload = json.dumps(metadata)
+
+        row = await self.storage.create_run(
+            {
+                "project_id": project_id,
+                "current_stage": RunStage.IDEA_READY.value,
+                "status": "pending",
+                "review_stage": None,
+                "restart_from": None,
+                "model_defaults_json": model_defaults_payload,
+                "metadata_json": metadata_payload,
+                "style_preset": style_preset,
+                "started_at": None,
+                "finished_at": None,
+            }
+        )
+        return PipelineRun.from_row(row)
+
+    async def get_run(self, run_id: int) -> PipelineRun | None:
+        row = await self.storage.get_run(run_id)
+        if row is None:
+            return None
+        return PipelineRun.from_row(row)
+
+    async def restart_run(self, run_id: int, from_stage: str) -> PipelineRun:
+        run = await self.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        try:
+            target_stage = RunStage(from_stage)
+        except ValueError as exc:
+            raise ValueError(f"Invalid stage '{from_stage}'") from exc
+
+        if run.current_stage is None:
+            raise ValueError(f"Run {run_id} has no current stage")
+
+        try:
+            current_stage = RunStage(run.current_stage)
+        except ValueError as exc:
+            raise ValueError(f"Invalid current stage '{run.current_stage}' for run {run_id}") from exc
+
+        if not can_transition(current_stage, target_stage) and target_stage not in REVIEW_STAGES:
+            raise ValueError(f"Cannot restart run {run_id} from {current_stage.value} to {target_stage.value}")
+
+        row = await self.storage.update_run(
+            run_id,
+            {
+                "restart_from": target_stage.value,
+                "current_stage": target_stage.value,
+            },
+        )
+        return PipelineRun.from_row(row)
+
+
+run_service = RunService(InMemoryRunStorage())

--- a/packages/creator-service/run_service.py
+++ b/packages/creator-service/run_service.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import json
 import importlib
+import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -163,6 +163,37 @@ class RunService:
                 "restart_from": target_stage.value,
                 "current_stage": target_stage.value,
             },
+        )
+        return PipelineRun.from_row(row)
+
+    async def advance_stage(self, run_id: int, target_stage: str) -> PipelineRun:
+        """Advance a run to the next stage (approval/forward progression).
+
+        Unlike restart_run, this does NOT set restart_from.
+        """
+        run = await self.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        try:
+            target = RunStage(target_stage)
+        except ValueError as exc:
+            raise ValueError(f"Invalid stage '{target_stage}'") from exc
+
+        if run.current_stage is None:
+            raise ValueError(f"Run {run_id} has no current stage")
+
+        try:
+            current = RunStage(run.current_stage)
+        except ValueError as exc:
+            raise ValueError(f"Invalid current stage '{run.current_stage}' for run {run_id}") from exc
+
+        if not can_transition(current, target):
+            raise ValueError(f"Cannot transition from {current.value} to {target.value}")
+
+        row = await self.storage.update_run(
+            run_id,
+            {"current_stage": target.value},
         )
         return PipelineRun.from_row(row)
 

--- a/packages/creator-service/run_service.py
+++ b/packages/creator-service/run_service.py
@@ -44,6 +44,10 @@ class RunStorageBackend(Protocol):
         """
         ...
 
+    async def list_runs_by_project(self, project_id: int) -> list[dict[str, Any]]:
+        """Return all run rows for a given project, newest first."""
+        ...
+
 class InMemoryRunStorage:
     def __init__(self) -> None:
         self._rows: dict[int, dict[str, Any]] = {}
@@ -90,6 +94,14 @@ class InMemoryRunStorage:
         row["updated_at"] = datetime.now(timezone.utc)
         self._rows[run_id] = row
         return True, dict(row)
+
+    async def list_runs_by_project(self, project_id: int) -> list[dict[str, Any]]:
+        rows = [
+            dict(r) for r in self._rows.values()
+            if r.get("project_id") == project_id
+        ]
+        rows.sort(key=lambda r: r.get("id", 0), reverse=True)
+        return rows
 
 class RunService:
     def __init__(self, storage: RunStorageBackend):
@@ -196,6 +208,11 @@ class RunService:
             {"current_stage": target.value},
         )
         return PipelineRun.from_row(row)
+
+    async def list_runs_by_project(self, project_id: int) -> list[PipelineRun]:
+        """Return all runs for a project, newest first."""
+        rows = await self.storage.list_runs_by_project(project_id)
+        return [PipelineRun.from_row(r) for r in rows]
 
 
 run_service = RunService(InMemoryRunStorage())

--- a/packages/creator-service/run_service.py
+++ b/packages/creator-service/run_service.py
@@ -31,6 +31,18 @@ class RunStorageBackend(Protocol):
         """Update and return run row by id."""
         ...
 
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, Any],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Atomically update run only if current_stage is in expected_stages.
+
+        Returns (True, updated_row) on success, (False, current_row) if stage
+        doesn't match, or (False, None) if run not found.
+        """
+        ...
 
 class InMemoryRunStorage:
     def __init__(self) -> None:
@@ -63,6 +75,21 @@ class InMemoryRunStorage:
         self._rows[run_id] = row
         return dict(row)
 
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, Any],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        row = self._rows.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        row.update(updates)
+        row["updated_at"] = datetime.now(timezone.utc)
+        self._rows[run_id] = row
+        return True, dict(row)
 
 class RunService:
     def __init__(self, storage: RunStorageBackend):

--- a/packages/creator-service/run_service.py
+++ b/packages/creator-service/run_service.py
@@ -127,8 +127,8 @@ class RunService:
         except ValueError as exc:
             raise ValueError(f"Invalid current stage '{run.current_stage}' for run {run_id}") from exc
 
-        if not can_transition(current_stage, target_stage) and target_stage not in REVIEW_STAGES:
-            raise ValueError(f"Cannot restart run {run_id} from {current_stage.value} to {target_stage.value}")
+        if not can_transition(current_stage, target_stage):
+            raise ValueError(f"Cannot transition from {current_stage.value} to {target_stage.value}")
 
         row = await self.storage.update_run(
             run_id,

--- a/packages/creator-service/script_service.py
+++ b/packages/creator-service/script_service.py
@@ -18,7 +18,13 @@ from markdown_parser import parse_markdown
 
 class ScriptStorageBackend(Protocol):
     async def save_draft(self, row: dict[str, Any]) -> dict[str, Any]:
-        """Persist a script draft row and return stored row."""
+        """Persist a script draft row and return stored row with version assigned.
+
+        The storage backend is responsible for atomically allocating the
+        next version number for the given ``run_id``.  Callers MUST NOT
+        include a ``version`` key in *row*; the returned dict MUST
+        contain the allocated ``version``.
+        """
         ...
 
     async def get_active_draft(self, run_id: int) -> dict[str, Any] | None:
@@ -31,16 +37,28 @@ class ScriptStorageBackend(Protocol):
 
 
 class InMemoryScriptStorage:
+    """In-memory storage with atomic per-run_id version allocation."""
+
     def __init__(self) -> None:
         self._drafts: dict[int, list[dict[str, Any]]] = {}
         self._next_id = 1
+        self._run_locks: dict[int, asyncio.Lock] = {}
 
     async def save_draft(self, row: dict[str, Any]) -> dict[str, Any]:
-        now = datetime.now(timezone.utc)
-        saved = {"id": self._next_id, "created_at": now, **row}
-        self._next_id += 1
         run_id = row["run_id"]
-        self._drafts.setdefault(run_id, []).append(saved)
+        lock = self._run_locks.setdefault(run_id, asyncio.Lock())
+        async with lock:
+            drafts = self._drafts.setdefault(run_id, [])
+            next_version = max((d["version"] for d in drafts), default=0) + 1
+            now = datetime.now(timezone.utc)
+            saved = {
+                "id": self._next_id,
+                "created_at": now,
+                "version": next_version,
+                **row,
+            }
+            self._next_id += 1
+            drafts.append(saved)
         return dict(saved)
 
     async def get_active_draft(self, run_id: int) -> dict[str, Any] | None:
@@ -57,7 +75,6 @@ class InMemoryScriptStorage:
 class ScriptService:
     def __init__(self, storage: ScriptStorageBackend | None = None) -> None:
         self.storage = storage if storage is not None else InMemoryScriptStorage()
-        self._run_locks: dict[int, asyncio.Lock] = {}
 
     async def save_draft(
         self,
@@ -71,43 +88,38 @@ class ScriptService:
         If markdown_content is provided and structured_script is not,
         parse the markdown to generate the structured script.
         If this run already has drafts, use existing sections for stable IDs.
-        Every save increments the version number.
 
-        Version allocation is serialised per run_id via an asyncio.Lock
-        to prevent duplicate versions under concurrent saves.
+        Version allocation is delegated to the storage backend to
+        guarantee atomicity regardless of how many ScriptService
+        instances share the same backend.
         """
-        lock = self._run_locks.setdefault(run_id, asyncio.Lock())
-        async with lock:
-            current = await self.storage.get_active_draft(run_id)
-            next_version = 1
-            existing_sections: list[ScriptSection] | None = None
+        current = await self.storage.get_active_draft(run_id)
+        existing_sections: list[ScriptSection] | None = None
 
-            if current is not None:
-                next_version = current.get("version", 0) + 1
-                existing_json = current.get("structured_script_json")
-                if existing_json:
-                    try:
-                        existing_data = json.loads(existing_json)
-                        existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
-                    except (json.JSONDecodeError, Exception):
-                        existing_sections = None
+        if current is not None:
+            existing_json = current.get("structured_script_json")
+            if existing_json:
+                try:
+                    existing_data = json.loads(existing_json)
+                    existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
+                except (json.JSONDecodeError, Exception):
+                    existing_sections = None
 
-            if markdown_content is not None and structured_script is None:
-                structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
+        if markdown_content is not None and structured_script is None:
+            structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
 
-            structured_script_json: str | None = None
-            if structured_script is not None:
-                structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
+        structured_script_json: str | None = None
+        if structured_script is not None:
+            structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
 
-            row = await self.storage.save_draft(
-                {
-                    "run_id": run_id,
-                    "source_type": source_type,
-                    "markdown_content": markdown_content,
-                    "structured_script_json": structured_script_json,
-                    "version": next_version,
-                }
-            )
+        row = await self.storage.save_draft(
+            {
+                "run_id": run_id,
+                "source_type": source_type,
+                "markdown_content": markdown_content,
+                "structured_script_json": structured_script_json,
+            }
+        )
 
         return self._row_to_draft(row)
 

--- a/packages/creator-service/script_service.py
+++ b/packages/creator-service/script_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from pathlib import Path
@@ -56,6 +57,7 @@ class InMemoryScriptStorage:
 class ScriptService:
     def __init__(self, storage: ScriptStorageBackend | None = None) -> None:
         self.storage = storage if storage is not None else InMemoryScriptStorage()
+        self._run_locks: dict[int, asyncio.Lock] = {}
 
     async def save_draft(
         self,
@@ -70,37 +72,42 @@ class ScriptService:
         parse the markdown to generate the structured script.
         If this run already has drafts, use existing sections for stable IDs.
         Every save increments the version number.
+
+        Version allocation is serialised per run_id via an asyncio.Lock
+        to prevent duplicate versions under concurrent saves.
         """
-        current = await self.storage.get_active_draft(run_id)
-        next_version = 1
-        existing_sections: list[ScriptSection] | None = None
+        lock = self._run_locks.setdefault(run_id, asyncio.Lock())
+        async with lock:
+            current = await self.storage.get_active_draft(run_id)
+            next_version = 1
+            existing_sections: list[ScriptSection] | None = None
 
-        if current is not None:
-            next_version = current.get("version", 0) + 1
-            existing_json = current.get("structured_script_json")
-            if existing_json:
-                try:
-                    existing_data = json.loads(existing_json)
-                    existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
-                except (json.JSONDecodeError, Exception):
-                    existing_sections = None
+            if current is not None:
+                next_version = current.get("version", 0) + 1
+                existing_json = current.get("structured_script_json")
+                if existing_json:
+                    try:
+                        existing_data = json.loads(existing_json)
+                        existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
+                    except (json.JSONDecodeError, Exception):
+                        existing_sections = None
 
-        if markdown_content is not None and structured_script is None:
-            structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
+            if markdown_content is not None and structured_script is None:
+                structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
 
-        structured_script_json: str | None = None
-        if structured_script is not None:
-            structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
+            structured_script_json: str | None = None
+            if structured_script is not None:
+                structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
 
-        row = await self.storage.save_draft(
-            {
-                "run_id": run_id,
-                "source_type": source_type,
-                "markdown_content": markdown_content,
-                "structured_script_json": structured_script_json,
-                "version": next_version,
-            }
-        )
+            row = await self.storage.save_draft(
+                {
+                    "run_id": run_id,
+                    "source_type": source_type,
+                    "markdown_content": markdown_content,
+                    "structured_script_json": structured_script_json,
+                    "version": next_version,
+                }
+            )
 
         return self._row_to_draft(row)
 

--- a/packages/creator-service/script_service.py
+++ b/packages/creator-service/script_service.py
@@ -1,1 +1,142 @@
-"""Placeholder for script_service."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+_DOMAIN_DIR = str(Path(__file__).resolve().parent.parent / "creator-domain")
+if _DOMAIN_DIR not in sys.path:
+    sys.path.insert(0, _DOMAIN_DIR)
+
+from models.script_draft import ScriptDraft, ScriptSection  # type: ignore[reportMissingImports]
+
+from markdown_parser import parse_markdown
+
+
+class ScriptStorageBackend(Protocol):
+    async def save_draft(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist a script draft row and return stored row."""
+        ...
+
+    async def get_active_draft(self, run_id: int) -> dict[str, Any] | None:
+        """Fetch the active (latest version) draft for a run."""
+        ...
+
+    async def list_draft_versions(self, run_id: int) -> list[dict[str, Any]]:
+        """List all draft versions for a run, newest first."""
+        ...
+
+
+class InMemoryScriptStorage:
+    def __init__(self) -> None:
+        self._drafts: dict[int, list[dict[str, Any]]] = {}
+        self._next_id = 1
+
+    async def save_draft(self, row: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        saved = {"id": self._next_id, "created_at": now, **row}
+        self._next_id += 1
+        run_id = row["run_id"]
+        self._drafts.setdefault(run_id, []).append(saved)
+        return dict(saved)
+
+    async def get_active_draft(self, run_id: int) -> dict[str, Any] | None:
+        drafts = self._drafts.get(run_id, [])
+        if not drafts:
+            return None
+        return dict(max(drafts, key=lambda d: d["version"]))
+
+    async def list_draft_versions(self, run_id: int) -> list[dict[str, Any]]:
+        drafts = self._drafts.get(run_id, [])
+        return [dict(d) for d in sorted(drafts, key=lambda d: d["version"], reverse=True)]
+
+
+class ScriptService:
+    def __init__(self, storage: ScriptStorageBackend | None = None) -> None:
+        self.storage = storage if storage is not None else InMemoryScriptStorage()
+
+    async def save_draft(
+        self,
+        run_id: int,
+        source_type: str,
+        markdown_content: str | None = None,
+        structured_script: list[ScriptSection] | None = None,
+    ) -> ScriptDraft:
+        """Save a new script draft version.
+
+        If markdown_content is provided and structured_script is not,
+        parse the markdown to generate the structured script.
+        If this run already has drafts, use existing sections for stable IDs.
+        Every save increments the version number.
+        """
+        current = await self.storage.get_active_draft(run_id)
+        next_version = 1
+        existing_sections: list[ScriptSection] | None = None
+
+        if current is not None:
+            next_version = current.get("version", 0) + 1
+            existing_json = current.get("structured_script_json")
+            if existing_json:
+                try:
+                    existing_data = json.loads(existing_json)
+                    existing_sections = [ScriptSection.model_validate(section) for section in existing_data]
+                except (json.JSONDecodeError, Exception):
+                    existing_sections = None
+
+        if markdown_content is not None and structured_script is None:
+            structured_script = parse_markdown(markdown_content, existing_sections=existing_sections)
+
+        structured_script_json: str | None = None
+        if structured_script is not None:
+            structured_script_json = json.dumps([section.model_dump(mode="json") for section in structured_script])
+
+        row = await self.storage.save_draft(
+            {
+                "run_id": run_id,
+                "source_type": source_type,
+                "markdown_content": markdown_content,
+                "structured_script_json": structured_script_json,
+                "version": next_version,
+            }
+        )
+
+        return self._row_to_draft(row)
+
+    async def get_active_draft(self, run_id: int) -> ScriptDraft | None:
+        """Get the active (latest version) draft for a run."""
+        row = await self.storage.get_active_draft(run_id)
+        if row is None:
+            return None
+        return self._row_to_draft(row)
+
+    async def list_draft_versions(self, run_id: int) -> list[ScriptDraft]:
+        """List all draft versions for a run, newest first."""
+        rows = await self.storage.list_draft_versions(run_id)
+        return [self._row_to_draft(row) for row in rows]
+
+    @staticmethod
+    def _row_to_draft(row: dict[str, Any]) -> ScriptDraft:
+        """Convert a storage row to a ScriptDraft domain model."""
+        structured_script: list[ScriptSection] | None = None
+        structured_json = row.get("structured_script_json")
+        if structured_json:
+            try:
+                data = json.loads(structured_json)
+                structured_script = [ScriptSection.model_validate(section) for section in data]
+            except (json.JSONDecodeError, Exception):
+                structured_script = None
+
+        return ScriptDraft(
+            id=row["id"],
+            run_id=row["run_id"],
+            source_type=row["source_type"],
+            markdown_content=row.get("markdown_content"),
+            structured_script=structured_script,
+            version=row.get("version", 1),
+            created_at=row["created_at"],
+        )
+
+
+script_service = ScriptService()

--- a/packages/creator-service/stage_review_service.py
+++ b/packages/creator-service/stage_review_service.py
@@ -1,0 +1,103 @@
+"""Stage review service with in-memory storage backend."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
+domain_models = importlib.import_module("models")
+RunStage = domain_models.RunStage
+REVIEW_STAGES = domain_models.REVIEW_STAGES
+
+
+class StageReviewStorageBackend(Protocol):
+    async def create_review(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist a review row and return stored row."""
+        ...
+
+    async def get_latest_review(
+        self, run_id: int, stage_name: str
+    ) -> dict[str, Any] | None:
+        """Fetch the most recent review for a run and stage."""
+        ...
+
+
+class InMemoryStageReviewStorage:
+    def __init__(self) -> None:
+        self._rows: list[dict[str, Any]] = []
+        self._next_id = 1
+
+    async def create_review(self, row: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        saved = {
+            "id": self._next_id,
+            "created_at": now,
+            **row,
+        }
+        self._rows.append(saved)
+        self._next_id += 1
+        return dict(saved)
+
+    async def get_latest_review(
+        self, run_id: int, stage_name: str
+    ) -> dict[str, Any] | None:
+        matches = [
+            r
+            for r in self._rows
+            if r["run_id"] == run_id and r["stage_name"] == stage_name
+        ]
+        if not matches:
+            return None
+        return dict(max(matches, key=lambda r: r["created_at"]))
+
+
+class StageReviewService:
+    def __init__(self, storage: StageReviewStorageBackend) -> None:
+        self.storage = storage
+
+    async def record_approval(
+        self,
+        run_id: int,
+        stage_name: str,
+        reviewer: str = "agent",
+        notes: str | None = None,
+    ) -> dict[str, Any]:
+        """Record an approval for a review stage.
+
+        Validates that stage_name is a valid review stage.
+        Returns the persisted review row.
+        """
+        try:
+            stage = RunStage(stage_name)
+        except ValueError as exc:
+            raise ValueError(f"Invalid stage '{stage_name}'") from exc
+
+        if stage not in REVIEW_STAGES:
+            raise ValueError(
+                f"Stage '{stage_name}' is not a review stage. "
+                f"Valid review stages: {sorted(s.value for s in REVIEW_STAGES)}"
+            )
+
+        row = await self.storage.create_review(
+            {
+                "run_id": run_id,
+                "stage_name": stage_name,
+                "review_status": "approved",
+                "reviewer": reviewer,
+                "notes": notes,
+            }
+        )
+        return row
+
+    async def get_latest_review(
+        self, run_id: int, stage_name: str
+    ) -> dict[str, Any] | None:
+        """Get the latest review for a run and stage."""
+        return await self.storage.get_latest_review(run_id, stage_name)
+
+
+stage_review_service = StageReviewService(InMemoryStageReviewStorage())

--- a/packages/creator-service/stage_review_service.py
+++ b/packages/creator-service/stage_review_service.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "creator-domain"))
 domain_models = importlib.import_module("models")
 RunStage = domain_models.RunStage
 REVIEW_STAGES = domain_models.REVIEW_STAGES
+can_transition = domain_models.can_transition
 
 
 class StageReviewStorageBackend(Protocol):
@@ -92,6 +93,81 @@ class StageReviewService:
             }
         )
         return row
+
+    async def approve_and_advance(
+        self,
+        *,
+        run_service: Any,
+        run_id: int,
+        stage_name: str,
+        target_stage: str,
+        reviewer: str = "agent",
+        notes: str | None = None,
+    ) -> Any:
+        """Atomically validate stage, record approval, and advance.
+
+        Uses conditional_update_run for atomic stage transition so that a
+        concurrent change between the approval record and the advance cannot
+        leave the system in an inconsistent state.
+
+        Returns the updated PipelineRun.
+
+        Raises:
+            ValueError: If run not found, stage mismatch, or invalid transition.
+        """
+        # 1. Validate stage_name is a review stage
+        try:
+            stage = RunStage(stage_name)
+        except ValueError as exc:
+            raise ValueError(f"Invalid stage '{stage_name}'") from exc
+
+        if stage not in REVIEW_STAGES:
+            raise ValueError(
+                f"Stage '{stage_name}' is not a review stage. "
+                f"Valid review stages: {sorted(s.value for s in REVIEW_STAGES)}"
+            )
+
+        # 2. Validate target_stage is a valid enum and transition is allowed
+        try:
+            target = RunStage(target_stage)
+        except ValueError as exc:
+            raise ValueError(f"Invalid target stage '{target_stage}'") from exc
+
+        if not can_transition(stage, target):
+            raise ValueError(
+                f"Cannot transition from {stage.value} to {target.value}"
+            )
+
+        # 3. Atomically advance stage (CAS — fails if stage changed concurrently)
+        ok, row = await run_service.storage.conditional_update_run(
+            run_id,
+            {"current_stage": target.value},
+            frozenset({stage.value}),
+        )
+
+        if not ok:
+            if row is None:
+                raise ValueError(f"Run {run_id} not found")
+            raise ValueError(
+                f"Stage conflict: run is now in '{row.get('current_stage')}', "
+                f"expected '{stage_name}'"
+            )
+
+        # 4. Record approval (only after CAS succeeds — no orphan reviews)
+        await self.storage.create_review(
+            {
+                "run_id": run_id,
+                "stage_name": stage_name,
+                "review_status": "approved",
+                "reviewer": reviewer,
+                "notes": notes,
+            }
+        )
+
+        # 5. Build domain model from the CAS result
+        from run_service import PipelineRun  # noqa: E402 — avoid circular at module level
+
+        return PipelineRun.from_row(row)
 
     async def get_latest_review(
         self, run_id: int, stage_name: str

--- a/packages/creator-service/subtitle_service.py
+++ b/packages/creator-service/subtitle_service.py
@@ -1,1 +1,165 @@
-"""Placeholder for subtitle_service."""
+"""Subtitle service for artifact storage and retrieval.
+
+Manages subtitle artifacts generated for runs. Each run can have multiple subtitle
+artifacts. Subtitle artifacts are NOT scene-versioned; the latest artifact
+per run is the current one.
+
+Follows the same Protocol → InMemory → Service pattern as
+VisualAssetService and ScriptService.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+_DOMAIN_DIR = str(Path(__file__).resolve().parent.parent / "creator-domain")
+if _DOMAIN_DIR not in sys.path:
+    sys.path.insert(0, _DOMAIN_DIR)
+
+from models.subtitle_artifact import SubtitleArtifact  # type: ignore[reportMissingImports]  # noqa: E402, I001
+
+
+# ---------------------------------------------------------------------------
+# Storage Protocol
+# ---------------------------------------------------------------------------
+
+
+class SubtitleStorageBackend(Protocol):
+    async def save_artifact(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist a subtitle artifact row and return stored row with id assigned.
+
+        The storage backend allocates the next id and inserts the row.
+        Callers MUST NOT include ``id`` in *row*; the returned dict
+        MUST contain the allocated ``id``.
+        """
+        ...
+
+    async def get_artifact(self, artifact_id: int) -> dict[str, Any] | None:
+        """Fetch a single artifact by id."""
+        ...
+
+    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        """List all artifacts for a run, newest first."""
+        ...
+
+    async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
+        """Fetch the most recent artifact for a run."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-Memory Storage
+# ---------------------------------------------------------------------------
+
+
+class InMemorySubtitleStorage:
+    """In-memory storage for subtitle artifacts."""
+
+    def __init__(self) -> None:
+        self._artifacts: list[dict[str, Any]] = []
+        self._next_id = 1
+
+    async def save_artifact(self, row: dict[str, Any]) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        saved = {
+            "id": self._next_id,
+            "created_at": now,
+            **row,
+        }
+        self._next_id += 1
+        self._artifacts.append(saved)
+        return dict(saved)
+
+    async def get_artifact(self, artifact_id: int) -> dict[str, Any] | None:
+        for a in self._artifacts:
+            if a["id"] == artifact_id:
+                return dict(a)
+        return None
+
+    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        run_artifacts = [a for a in self._artifacts if a["run_id"] == run_id]
+        return [
+            dict(a)
+            for a in sorted(run_artifacts, key=lambda x: x["created_at"], reverse=True)
+        ]
+
+    async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
+        artifacts = await self.list_by_run(run_id)
+        return artifacts[0] if artifacts else None
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class SubtitleService:
+    def __init__(self, storage: SubtitleStorageBackend | None = None) -> None:
+        self.storage = storage if storage is not None else InMemorySubtitleStorage()
+
+    # -- Create -------------------------------------------------------------
+
+    async def create_artifact(
+        self,
+        run_id: int,
+        path: str,
+        *,
+        format: str = "srt",
+        model_used: str | None = None,
+        provider_type: str | None = None,
+    ) -> SubtitleArtifact:
+        """Create a new subtitle artifact for a run.
+
+        Subtitle artifacts are NOT versioned. The latest artifact per run
+        is the current one.
+        """
+        metadata = {}
+        if format is not None:
+            metadata["format"] = format
+        if model_used is not None:
+            metadata["model_used"] = model_used
+        if provider_type is not None:
+            metadata["provider_type"] = provider_type
+
+        row = {
+            "run_id": run_id,
+            "file_path": path,
+            "metadata_json": metadata,
+        }
+        saved = await self.storage.save_artifact(row)
+
+        return self._row_to_artifact(saved)
+
+    # -- Reads --------------------------------------------------------------
+
+    async def get_latest(self, run_id: int) -> SubtitleArtifact | None:
+        """Get the most recent subtitle artifact for a run."""
+        row = await self.storage.get_latest_by_run(run_id)
+        if row is None:
+            return None
+        return self._row_to_artifact(row)
+
+    async def list_by_run(self, run_id: int) -> list[SubtitleArtifact]:
+        """List all subtitle artifacts for a run, newest first."""
+        rows = await self.storage.list_by_run(run_id)
+        return [self._row_to_artifact(r) for r in rows]
+
+    async def get_by_id(self, artifact_id: int) -> SubtitleArtifact | None:
+        """Get a single artifact by id."""
+        row = await self.storage.get_artifact(artifact_id)
+        if row is None:
+            return None
+        return self._row_to_artifact(row)
+
+    # -- Internal -----------------------------------------------------------
+
+    @staticmethod
+    def _row_to_artifact(row: dict[str, Any]) -> SubtitleArtifact:
+        """Convert a storage row to a SubtitleArtifact domain model."""
+        return SubtitleArtifact.from_row(row)
+
+
+subtitle_service = SubtitleService()

--- a/packages/creator-service/tests/test_markdown_parser.py
+++ b/packages/creator-service/tests/test_markdown_parser.py
@@ -1,0 +1,164 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from markdown_parser import parse_markdown
+
+
+def test_parse_standard_markdown_headings():
+    markdown = """## hook
+Grab attention now.
+
+## intro
+Welcome to the episode.
+
+## body
+Main explanation.
+
+## outro
+Thanks for watching.
+"""
+
+    sections = parse_markdown(markdown)
+
+    assert [section.type for section in sections] == ["hook", "intro", "body", "outro"]
+    assert [section.section_id for section in sections] == ["hook-1", "intro-2", "body-3", "outro-4"]
+    assert [section.text for section in sections] == [
+        "Grab attention now.",
+        "Welcome to the episode.",
+        "Main explanation.",
+        "Thanks for watching.",
+    ]
+    for section in sections:
+        assert section.display_text == section.text
+        assert section.speaker == "host"
+        assert section.duration is None
+        assert section.turn_kind is None
+        assert section.visual_override is None
+
+
+def test_parse_markdown_with_duplicate_heading_types():
+    markdown = """## hook
+Opening A.
+
+## hook
+Opening B.
+
+## body
+Main section.
+"""
+
+    sections = parse_markdown(markdown)
+
+    assert [section.type for section in sections] == ["hook", "hook", "body"]
+    assert [section.section_id for section in sections] == ["hook-1", "hook-2", "body-3"]
+
+
+def test_parse_markdown_without_headings_creates_single_body_section():
+    markdown = "First line.\n\nSecond line."
+
+    sections = parse_markdown(markdown)
+
+    assert len(sections) == 1
+    assert sections[0].type == "body"
+    assert sections[0].section_id == "body-1"
+    assert sections[0].text == "First line.\n\nSecond line."
+
+
+def test_parse_empty_markdown_returns_empty_list():
+    assert parse_markdown("") == []
+    assert parse_markdown("   \n\n  ") == []
+
+
+def test_stable_id_preservation_reuses_existing_ids_for_same_type_and_position():
+    markdown = """## hook
+Original hook.
+
+## intro
+Original intro.
+
+## body
+Original body.
+"""
+    existing = parse_markdown(markdown)
+    existing[0].section_id = "sec-custom-hook"
+    existing[1].section_id = "sec-custom-intro"
+
+    updated_markdown = """## hook
+Updated hook text.
+
+## intro
+Updated intro text.
+
+## body
+Updated body text.
+"""
+    reparsed = parse_markdown(updated_markdown, existing_sections=existing)
+
+    assert [section.section_id for section in reparsed] == [
+        "sec-custom-hook",
+        "sec-custom-intro",
+        "body-3",
+    ]
+
+
+def test_stable_id_changes_when_sections_reordered():
+    original_markdown = """## hook
+Hook text.
+
+## intro
+Intro text.
+
+## body
+Body text.
+"""
+    existing = parse_markdown(original_markdown)
+
+    reordered_markdown = """## intro
+Intro text.
+
+## hook
+Hook text.
+
+## body
+Body text.
+"""
+    reparsed = parse_markdown(reordered_markdown, existing_sections=existing)
+
+    assert [section.section_id for section in reparsed] == ["intro-1", "hook-2", "body-3"]
+    assert reparsed[0].section_id != existing[1].section_id
+    assert reparsed[1].section_id != existing[0].section_id
+
+
+def test_malformed_markdown_best_effort_parsing_handles_partial_headings_and_empty_sections():
+    markdown = """##hook
+Hook line.
+### not-a-level-two-heading
+
+##
+
+##intro
+"""
+
+    sections = parse_markdown(markdown)
+
+    assert [section.type for section in sections] == ["hook", "body", "intro"]
+    assert [section.section_id for section in sections] == ["hook-1", "body-2", "intro-3"]
+    assert sections[0].text == "Hook line.\n### not-a-level-two-heading"
+    assert sections[1].text == ""
+    assert sections[2].text == ""
+
+
+def test_section_ids_are_deterministic_for_same_input():
+    markdown = """## cta
+Like and subscribe.
+
+## body
+One more thing.
+"""
+
+    first = parse_markdown(markdown)
+    second = parse_markdown(markdown)
+
+    assert [section.section_id for section in first] == [section.section_id for section in second]

--- a/packages/creator-service/tests/test_model_catalog_service.py
+++ b/packages/creator-service/tests/test_model_catalog_service.py
@@ -1,0 +1,131 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-provider"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from model_catalog_service import ModelCatalogService
+from model_health_service import ModelHealthResult, ModelStatus
+
+ProviderRegistry = importlib.import_module("registry").ProviderRegistry
+
+
+@pytest.fixture
+def registry():
+    return ProviderRegistry.create_default()
+
+
+@pytest.fixture
+def health_service() -> AsyncMock:
+    service = AsyncMock()
+    status_by_provider = {
+        "ollama": ModelStatus.HEALTHY,
+        "stable-diffusion": ModelStatus.UNHEALTHY,
+        "tts-qwen3": ModelStatus.UNKNOWN,
+        "stt-whisper": ModelStatus.HEALTHY,
+    }
+
+    async def check_model(name: str) -> ModelHealthResult:
+        status = status_by_provider.get(name, ModelStatus.UNKNOWN)
+        return ModelHealthResult(
+            model_name=name,
+            endpoint=f"http://{name}:1234",
+            status=status,
+        )
+
+    service.check_model.side_effect = check_model
+    return service
+
+
+class TestModelCatalogService:
+    @pytest.mark.asyncio
+    async def test_list_models_returns_all_categories(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.list_models()
+
+        assert set(result.keys()) == {"script_models", "image_models", "tts_models", "stt_models"}
+        assert len(result["script_models"]) == 1
+        assert len(result["image_models"]) == 1
+        assert len(result["tts_models"]) == 1
+        assert len(result["stt_models"]) == 1
+
+        script_model = result["script_models"][0]
+        assert script_model["key"] == "qwen3-4b"
+        assert script_model["label"] == "Qwen3 4B (Local)"
+        assert script_model["provider_type"] == "ollama"
+        assert script_model["is_local"] is True
+        assert script_model["requires_gpu"] is True
+        assert script_model["status"] == "available"
+
+        image_model = result["image_models"][0]
+        assert image_model["status"] == "unavailable"
+
+        tts_model = result["tts_models"][0]
+        assert tts_model["status"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_list_models_filters_script_category(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.list_models(category="script")
+
+        assert len(result["script_models"]) == 1
+        assert result["script_models"][0]["key"] == "qwen3-4b"
+        assert result["image_models"] == []
+        assert result["tts_models"] == []
+        assert result["stt_models"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_models_filters_image_category(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.list_models(category="image")
+
+        assert len(result["image_models"]) == 1
+        assert result["image_models"][0]["key"] == "sd15"
+        assert result["script_models"] == []
+        assert result["tts_models"] == []
+        assert result["stt_models"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_status_returns_expected_shape(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.get_status()
+
+        assert set(result.keys()) == {"providers", "gpu_lock"}
+        assert isinstance(result["providers"], list)
+        assert len(result["providers"]) == 4
+
+        provider = result["providers"][0]
+        assert set(provider.keys()) == {"name", "endpoint", "healthy", "loaded_model", "gpu_locked"}
+        assert provider["loaded_model"] is None
+        assert provider["gpu_locked"] is False
+
+        assert result["gpu_lock"] == {
+            "active": False,
+            "holder": None,
+            "ttl_remaining": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_model_entries_have_required_fields(self, registry, health_service: AsyncMock):
+        service = ModelCatalogService(registry, health_service)
+
+        result = await service.list_models()
+
+        required_fields = {"key", "label", "provider_type", "is_local", "requires_gpu", "status"}
+        all_entries = (
+            result["script_models"]
+            + result["image_models"]
+            + result["tts_models"]
+            + result["stt_models"]
+        )
+
+        for entry in all_entries:
+            assert set(entry.keys()) == required_fields

--- a/packages/creator-service/tests/test_model_catalog_service.py
+++ b/packages/creator-service/tests/test_model_catalog_service.py
@@ -64,9 +64,14 @@ class TestModelCatalogService:
 
         image_model = result["image_models"][0]
         assert image_model["status"] == "unavailable"
+        assert image_model["label"] == "Stable Diffusion 1.5 (Local)"
 
         tts_model = result["tts_models"][0]
         assert tts_model["status"] == "unknown"
+        assert tts_model["label"] == "Qwen TTS (Local)"
+
+        stt_model = result["stt_models"][0]
+        assert stt_model["label"] == "Whisper Medium (Local)"
 
     @pytest.mark.asyncio
     async def test_list_models_filters_script_category(self, registry, health_service: AsyncMock):
@@ -107,6 +112,14 @@ class TestModelCatalogService:
         assert provider["loaded_model"] is None
         assert provider["gpu_locked"] is False
 
+        # Provider names should match health service keys (Docker hostnames),
+        # not provider_type values from registry
+        provider_names = {p["name"] for p in result["providers"]}
+        assert provider_names == {"ollama", "stable-diffusion", "tts-qwen3", "stt-whisper"}
+        assert set(provider.keys()) == {"name", "endpoint", "healthy", "loaded_model", "gpu_locked"}
+        assert provider["loaded_model"] is None
+        assert provider["gpu_locked"] is False
+
         assert result["gpu_lock"] == {
             "active": False,
             "holder": None,
@@ -129,3 +142,16 @@ class TestModelCatalogService:
 
         for entry in all_entries:
             assert set(entry.keys()) == required_fields
+
+    @pytest.mark.asyncio
+    async def test_health_key_matches_health_service_keys(
+        self, registry, health_service: AsyncMock
+    ):
+        """Verify _health_key() produces keys that ModelHealthService recognises."""
+        service = ModelCatalogService(registry, health_service)
+
+        await service.list_models()
+
+        called_keys = {call.args[0] for call in health_service.check_model.call_args_list}
+        expected_keys = {"ollama", "stable-diffusion", "tts-qwen3", "stt-whisper"}
+        assert called_keys == expected_keys

--- a/packages/creator-service/tests/test_model_health.py
+++ b/packages/creator-service/tests/test_model_health.py
@@ -1,0 +1,101 @@
+"""Unit tests for model health service."""
+
+import pytest
+from creator_service.model_health_service import (
+    ModelHealthService,
+    ModelHealthResult,
+    ModelStatus,
+)
+
+
+@pytest.fixture
+def health_service():
+    """Create a model health service instance."""
+    return ModelHealthService()
+
+
+class TestModelHealthService:
+    """Test suite for ModelHealthService."""
+
+    def test_initialization_with_default_endpoints(self, health_service):
+        """Test ModelHealthService initializes with default endpoints."""
+        assert health_service.endpoints is not None
+        assert "ollama" in health_service.endpoints
+        assert "stable-diffusion" in health_service.endpoints
+        assert "tts-qwen3" in health_service.endpoints
+        assert "stt-whisper" in health_service.endpoints
+        
+        # Verify default URLs
+        assert health_service.endpoints["ollama"] == "http://ollama:11434"
+        assert health_service.endpoints["stable-diffusion"] == "http://stable-diffusion:7860"
+        assert health_service.endpoints["tts-qwen3"] == "http://tts-qwen3:9880"
+        assert health_service.endpoints["stt-whisper"] == "http://stt-whisper:9000"
+
+    def test_initialization_with_env_variables(self, monkeypatch):
+        """Test ModelHealthService initializes with environment variables."""
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://custom-ollama:11434")
+        monkeypatch.setenv("STABLE_DIFFUSION_BASE_URL", "http://custom-sd:7860")
+        
+        service = ModelHealthService()
+        
+        assert service.endpoints["ollama"] == "http://custom-ollama:11434"
+        assert service.endpoints["stable-diffusion"] == "http://custom-sd:7860"
+
+    @pytest.mark.asyncio
+    async def test_check_model_returns_result_with_correct_model_name(self, health_service):
+        """Test check_model returns result with correct model_name."""
+        result = await health_service.check_model("ollama")
+        
+        assert isinstance(result, ModelHealthResult)
+        assert result.model_name == "ollama"
+        assert result.endpoint == "http://ollama:11434"
+
+    @pytest.mark.asyncio
+    async def test_check_model_returns_unknown_for_invalid_model(self, health_service):
+        """Test check_model returns UNKNOWN status for invalid model."""
+        result = await health_service.check_model("invalid-model")
+        
+        assert result.status == ModelStatus.UNKNOWN
+        assert result.error == "Unknown model"
+        assert result.endpoint == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_check_all_returns_results_for_all_models(self, health_service):
+        """Test check_all returns results for all 4 models."""
+        results = await health_service.check_all()
+        
+        assert isinstance(results, list)
+        assert len(results) == 4
+        
+        model_names = {result.model_name for result in results}
+        expected_models = {"ollama", "stable-diffusion", "tts-qwen3", "stt-whisper"}
+        assert model_names == expected_models
+
+    @pytest.mark.asyncio
+    async def test_check_all_returns_model_health_results(self, health_service):
+        """Test check_all returns ModelHealthResult instances."""
+        results = await health_service.check_all()
+        
+        for result in results:
+            assert isinstance(result, ModelHealthResult)
+            assert result.model_name
+            assert result.endpoint
+            assert result.status in [ModelStatus.HEALTHY, ModelStatus.UNHEALTHY, ModelStatus.UNKNOWN]
+
+    def test_health_paths_configured(self, health_service):
+        """Test health paths are configured for all models."""
+        assert health_service.health_paths is not None
+        assert "ollama" in health_service.health_paths
+        assert "stable-diffusion" in health_service.health_paths
+        assert "tts-qwen3" in health_service.health_paths
+        assert "stt-whisper" in health_service.health_paths
+        
+        # Verify health paths
+        assert health_service.health_paths["ollama"] == "/api/tags"
+        assert health_service.health_paths["stable-diffusion"] == "/sdapi/v1/options"
+
+    def test_model_status_enum_values(self):
+        """Test ModelStatus enum has expected values."""
+        assert ModelStatus.HEALTHY.value == "healthy"
+        assert ModelStatus.UNHEALTHY.value == "unhealthy"
+        assert ModelStatus.UNKNOWN.value == "unknown"

--- a/packages/creator-service/tests/test_project_service.py
+++ b/packages/creator-service/tests/test_project_service.py
@@ -142,3 +142,75 @@ def test_create_project_with_url_missing_source_raises_value_error(service: Proj
 def test_create_project_with_idea_missing_brief_raises_value_error(service: ProjectService) -> None:
     with pytest.raises(ValueError, match="source_type='idea' requires idea_brief"):
         run(service.create_project(title="Bad Idea", source_type="idea"))
+
+
+def test_create_project_idea_with_markdown_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='idea' cannot have markdown_source or url_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="idea",
+                idea_brief="My idea",
+                markdown_source="# This should not be here",
+            )
+        )
+
+
+def test_create_project_idea_with_url_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='idea' cannot have markdown_source or url_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="idea",
+                idea_brief="My idea",
+                url_source="https://example.com",
+            )
+        )
+
+
+def test_create_project_markdown_with_url_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='markdown' cannot have idea_brief or url_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="markdown",
+                markdown_source="# Content",
+                url_source="https://example.com",
+            )
+        )
+
+
+def test_create_project_markdown_with_idea_brief_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='markdown' cannot have idea_brief or url_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="markdown",
+                markdown_source="# Content",
+                idea_brief="My idea",
+            )
+        )
+
+
+def test_create_project_url_with_idea_brief_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='url' cannot have idea_brief or markdown_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="url",
+                url_source="https://example.com",
+                idea_brief="My idea",
+            )
+        )
+
+
+def test_create_project_url_with_markdown_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='url' cannot have idea_brief or markdown_source set"):
+        run(
+            service.create_project(
+                title="Conflicting Fields",
+                source_type="url",
+                url_source="https://example.com",
+                markdown_source="# Content",
+            )
+        )

--- a/packages/creator-service/tests/test_project_service.py
+++ b/packages/creator-service/tests/test_project_service.py
@@ -1,0 +1,129 @@
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from project_service import InMemoryProjectStorage, ProjectService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def storage() -> InMemoryProjectStorage:
+    return InMemoryProjectStorage()
+
+
+@pytest.fixture
+def service(storage: InMemoryProjectStorage) -> ProjectService:
+    return ProjectService(storage)
+
+
+def test_create_project_with_idea_source_type(service: ProjectService) -> None:
+    project = run(
+        service.create_project(
+            title="Idea Project",
+            source_type="idea",
+            idea_brief="Build a short-form video script from one concept.",
+        )
+    )
+
+    assert project.id == 1
+    assert project.title == "Idea Project"
+    assert project.source_type == "idea"
+    assert project.idea_brief == "Build a short-form video script from one concept."
+    assert project.markdown_source is None
+    assert project.url_source is None
+    assert project.status == "draft"
+
+
+def test_create_project_with_markdown_source_type(service: ProjectService) -> None:
+    markdown = "# Topic\n\nTurn this into a video script."
+    project = run(
+        service.create_project(
+            title="Markdown Project",
+            source_type="markdown",
+            markdown_source=markdown,
+        )
+    )
+
+    assert project.title == "Markdown Project"
+    assert project.source_type == "markdown"
+    assert project.markdown_source == markdown
+    assert project.idea_brief is None
+    assert project.url_source is None
+
+
+def test_create_project_with_invalid_source_type_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="Unsupported source_type"):
+        run(service.create_project(title="Invalid", source_type=cast(Any, "pdf")))
+
+
+def test_get_project_returns_none_for_missing_project(service: ProjectService) -> None:
+    assert run(service.get_project(9999)) is None
+
+
+def test_get_project_returns_existing_project(service: ProjectService) -> None:
+    created = run(service.create_project(title="Existing", source_type="url", url_source="https://example.com"))
+    fetched = run(service.get_project(created.id))
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.title == "Existing"
+    assert fetched.source_type == "url"
+    assert fetched.url_source == "https://example.com"
+    assert fetched.model_dump()["latest_run"] is None
+
+
+def test_list_projects_returns_newest_first(service: ProjectService) -> None:
+    older = run(service.create_project(title="Older", source_type="idea", idea_brief="old"))
+    newer = run(service.create_project(title="Newer", source_type="idea", idea_brief="new"))
+
+    projects = run(service.list_projects())
+
+    assert [project.id for project in projects[:2]] == [newer.id, older.id]
+
+
+def test_list_projects_respects_limit_and_offset(service: ProjectService) -> None:
+    first = run(service.create_project(title="First", source_type="idea"))
+    second = run(service.create_project(title="Second", source_type="idea"))
+    third = run(service.create_project(title="Third", source_type="idea"))
+
+    projects = run(service.list_projects(limit=1, offset=1))
+
+    assert len(projects) == 1
+    assert projects[0].id == second.id
+    assert projects[0].title == "Second"
+    assert first.id != projects[0].id
+    assert third.id != projects[0].id
+
+
+def test_get_and_list_include_latest_run_summary(
+    service: ProjectService,
+    storage: InMemoryProjectStorage,
+) -> None:
+    project = run(service.create_project(title="With Run", source_type="idea"))
+
+    run(storage.insert_run(project.id, current_stage="script_generating", status="running"))
+    latest = run(storage.insert_run(project.id, current_stage="script_review", status="paused"))
+
+    detailed = run(service.get_project(project.id))
+    listed = run(service.list_projects())
+
+    assert detailed is not None
+    assert detailed.model_dump()["latest_run"] == {
+        "run_id": latest["id"],
+        "current_stage": "script_review",
+        "status": "paused",
+    }
+    assert listed[0].model_dump()["latest_run"] == {
+        "run_id": latest["id"],
+        "current_stage": "script_review",
+        "status": "paused",
+    }

--- a/packages/creator-service/tests/test_project_service.py
+++ b/packages/creator-service/tests/test_project_service.py
@@ -91,9 +91,9 @@ def test_list_projects_returns_newest_first(service: ProjectService) -> None:
 
 
 def test_list_projects_respects_limit_and_offset(service: ProjectService) -> None:
-    first = run(service.create_project(title="First", source_type="idea"))
-    second = run(service.create_project(title="Second", source_type="idea"))
-    third = run(service.create_project(title="Third", source_type="idea"))
+    first = run(service.create_project(title="First", source_type="idea", idea_brief="first idea"))
+    second = run(service.create_project(title="Second", source_type="idea", idea_brief="second idea"))
+    third = run(service.create_project(title="Third", source_type="idea", idea_brief="third idea"))
 
     projects = run(service.list_projects(limit=1, offset=1))
 
@@ -108,7 +108,7 @@ def test_get_and_list_include_latest_run_summary(
     service: ProjectService,
     storage: InMemoryProjectStorage,
 ) -> None:
-    project = run(service.create_project(title="With Run", source_type="idea"))
+    project = run(service.create_project(title="With Run", source_type="idea", idea_brief="test idea"))
 
     run(storage.insert_run(project.id, current_stage="script_generating", status="running"))
     latest = run(storage.insert_run(project.id, current_stage="script_review", status="paused"))
@@ -127,3 +127,18 @@ def test_get_and_list_include_latest_run_summary(
         "current_stage": "script_review",
         "status": "paused",
     }
+
+
+def test_create_project_with_markdown_missing_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='markdown' requires markdown_source"):
+        run(service.create_project(title="Bad Markdown", source_type="markdown"))
+
+
+def test_create_project_with_url_missing_source_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='url' requires url_source"):
+        run(service.create_project(title="Bad URL", source_type="url"))
+
+
+def test_create_project_with_idea_missing_brief_raises_value_error(service: ProjectService) -> None:
+    with pytest.raises(ValueError, match="source_type='idea' requires idea_brief"):
+        run(service.create_project(title="Bad Idea", source_type="idea"))

--- a/packages/creator-service/tests/test_render_profile.py
+++ b/packages/creator-service/tests/test_render_profile.py
@@ -1,0 +1,214 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from creator_service.render_profile import (
+    RenderProfile, Codec, AudioCodec, TransitionStyle
+)
+from creator_service.ffmpeg_service import FFmpegService, RenderInput
+
+
+class TestRenderProfile(unittest.TestCase):
+    """Tests for RenderProfile dataclass."""
+
+    def test_default_profile(self):
+        """Test default profile values."""
+        profile = RenderProfile.default()
+        
+        self.assertEqual(profile.name, "shorts_default")
+        self.assertEqual(profile.width, 1080)
+        self.assertEqual(profile.height, 1920)
+        self.assertEqual(profile.fps, 30)
+        self.assertEqual(profile.video_codec, Codec.H264)
+        self.assertEqual(profile.audio_codec, AudioCodec.AAC)
+        self.assertEqual(profile.transition_style, TransitionStyle.KEN_BURNS)
+        self.assertEqual(profile.crf, 23)
+        self.assertEqual(profile.preset, "medium")
+        self.assertTrue(profile.burn_subtitles)
+        self.assertEqual(profile.subtitle_font_size, 24)
+
+    def test_high_quality_preset(self):
+        """Test high_quality preset."""
+        profile = RenderProfile.high_quality()
+        
+        self.assertEqual(profile.name, "high_quality")
+        self.assertEqual(profile.crf, 18)
+        self.assertEqual(profile.preset, "slow")
+        # Check that inherited values are still correct
+        self.assertEqual(profile.width, 1080)
+        self.assertEqual(profile.height, 1920)
+
+    def test_fast_preview_preset(self):
+        """Test fast_preview preset."""
+        profile = RenderProfile.fast_preview()
+        
+        self.assertEqual(profile.name, "fast_preview")
+        self.assertEqual(profile.width, 540)
+        self.assertEqual(profile.height, 960)
+        self.assertEqual(profile.fps, 15)
+        self.assertEqual(profile.crf, 28)
+        self.assertEqual(profile.preset, "ultrafast")
+
+    def test_codec_enum_values(self):
+        """Test video codec enum values."""
+        self.assertEqual(Codec.H264.value, "libx264")
+        self.assertEqual(Codec.H265.value, "libx265")
+
+    def test_audio_codec_enum_values(self):
+        """Test audio codec enum values."""
+        self.assertEqual(AudioCodec.AAC.value, "aac")
+        self.assertEqual(AudioCodec.MP3.value, "libmp3lame")
+
+    def test_transition_style_enum_values(self):
+        """Test transition style enum values."""
+        self.assertEqual(TransitionStyle.CUT.value, "cut")
+        self.assertEqual(TransitionStyle.FADE.value, "fade")
+        self.assertEqual(TransitionStyle.KEN_BURNS.value, "ken_burns")
+
+
+class TestFFmpegService(unittest.TestCase):
+    """Tests for FFmpegService."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.profile = RenderProfile.default()
+        self.service = FFmpegService(self.profile)
+
+    def test_build_command_basic(self):
+        """Test build_command produces valid FFmpeg command list."""
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png"), Path("/tmp/img2.png")],
+            audio_path=None,
+            subtitle_path=None,
+            scene_durations=[3.0, 4.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        cmd = self.service.build_command(input_data, output_path)
+        
+        # Verify it's a list of strings
+        self.assertIsInstance(cmd, list)
+        self.assertTrue(all(isinstance(item, str) for item in cmd))
+        
+        # Verify key elements are present
+        self.assertIn("ffmpeg", cmd)
+        self.assertIn("-y", cmd)  # overwrite flag
+        self.assertIn(str(output_path), cmd)
+        
+        # Verify codec settings
+        self.assertIn("-c:v", cmd)
+        self.assertIn(self.profile.video_codec.value, cmd)
+        self.assertIn("-crf", cmd)
+        self.assertIn(str(self.profile.crf), cmd)
+        self.assertIn("-preset", cmd)
+        self.assertIn(self.profile.preset, cmd)
+
+    def test_build_command_with_audio(self):
+        """Test build_command includes audio mapping."""
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=Path("/tmp/audio.mp3"),
+            subtitle_path=None,
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        cmd = self.service.build_command(input_data, output_path)
+        
+        # Verify audio codec is set
+        self.assertIn("-c:a", cmd)
+        self.assertIn(self.profile.audio_codec.value, cmd)
+
+    def test_build_command_with_subtitles(self):
+        """Test build_command includes subtitle filter."""
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=None,
+            subtitle_path=Path("/tmp/subs.srt"),
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        cmd = self.service.build_command(input_data, output_path)
+        
+        # Verify subtitle filter is present
+        self.assertIn("-vf", cmd)
+        # Find the -vf value
+        vf_idx = cmd.index("-vf")
+        vf_filter = cmd[vf_idx + 1]
+        self.assertIn("subtitles", vf_filter)
+
+    def test_custom_profile(self):
+        """Test FFmpegService with custom profile."""
+        custom_profile = RenderProfile(
+            name="custom",
+            width=720,
+            height=1280,
+            fps=24,
+            crf=20,
+            preset="fast"
+        )
+        service = FFmpegService(custom_profile)
+        
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=None,
+            subtitle_path=None,
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        cmd = service.build_command(input_data, output_path)
+        
+        # Verify custom settings are in command
+        self.assertIn("720", cmd)
+        self.assertIn("1280", cmd)
+        self.assertIn("24", cmd)
+        self.assertIn("20", cmd)
+        self.assertIn("fast", cmd)
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.mkdir")
+    def test_render_success(self, mock_mkdir, mock_run):
+        """Test render method on success."""
+        mock_run.return_value = MagicMock(returncode=0)
+        
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=None,
+            subtitle_path=None,
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        result = self.service.render(input_data, output_path)
+        
+        self.assertEqual(result, output_path)
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    @patch("pathlib.Path.mkdir")
+    def test_render_failure(self, mock_mkdir, mock_run):
+        """Test render method on FFmpeg failure."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="FFmpeg error message"
+        )
+        
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=None,
+            subtitle_path=None,
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+        
+        with self.assertRaises(RuntimeError) as cm:
+            self.service.render(input_data, output_path)
+        
+        self.assertIn("FFmpeg render failed", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/creator-service/tests/test_render_service.py
+++ b/packages/creator-service/tests/test_render_service.py
@@ -1,0 +1,439 @@
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from render_service import (  # noqa: E402
+    InMemoryRenderStorage,
+    RenderService,
+)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def storage() -> InMemoryRenderStorage:
+    return InMemoryRenderStorage()
+
+
+@pytest.fixture
+def service(storage: InMemoryRenderStorage) -> RenderService:
+    return RenderService(storage)
+
+
+# -- Fake dependencies for build_render_manifest tests -----------------------
+
+
+@dataclass
+class FakeVisualAsset:
+    scene_id: str
+    asset_path: str
+    prompt_snapshot: str
+    is_active: bool
+
+
+class FakeVisualAssetService:
+    def __init__(self, grouped: dict[str, list[FakeVisualAsset]]):
+        self._grouped = grouped
+
+    async def list_by_run(self, run_id: int) -> dict[str, list[FakeVisualAsset]]:
+        return self._grouped
+
+
+@dataclass
+class FakeAudioArtifact:
+    path: str
+
+
+class FakeAudioService:
+    def __init__(self, artifact=None):
+        self._artifact = artifact
+
+    async def get_latest(self, run_id):
+        return self._artifact
+
+
+@dataclass
+class FakeSubtitleArtifact:
+    path: str
+
+
+class FakeSubtitleService:
+    def __init__(self, artifact=None):
+        self._artifact = artifact
+
+    async def get_latest(self, run_id):
+        return self._artifact
+
+
+# -- create_artifact ---------------------------------------------------------------
+
+
+def test_create_artifact(service: RenderService) -> None:
+    artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/render.mp4",
+        )
+    )
+
+    assert artifact.run_id == 1
+    assert artifact.path == "/data/artifacts/1/render.mp4"
+    assert artifact.render_profile is None
+    assert artifact.created_at is not None
+
+
+def test_create_artifact_with_render_profile_metadata(service: RenderService) -> None:
+    artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/render.mp4",
+            render_profile="high_quality",
+        )
+    )
+
+    assert artifact.run_id == 1
+    assert artifact.path == "/data/artifacts/1/render.mp4"
+    assert artifact.render_profile == "high_quality"
+    assert artifact.created_at is not None
+
+
+def test_create_artifact_has_id(service: RenderService) -> None:
+    artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/render.mp4",
+        )
+    )
+
+    assert artifact.id is not None
+    assert artifact.id > 0
+
+
+# -- get_latest ---------------------------------------------------------------
+
+
+def test_get_latest_returns_most_recent(service: RenderService) -> None:
+    """Create 2 artifacts, get_latest returns newest."""
+    first = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/render_v1.mp4",
+        )
+    )
+    second = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/render_v2.mp4",
+        )
+    )
+
+    latest = run(service.get_latest(run_id=1))
+
+    assert latest is not None
+    assert latest.id == second.id
+    assert latest.id != first.id
+    assert latest.path == "/data/artifacts/1/render_v2.mp4"
+
+
+def test_get_latest_empty(service: RenderService) -> None:
+    """Returns None when no artifacts."""
+    latest = run(service.get_latest(run_id=999))
+
+    assert latest is None
+
+
+# -- list_by_run ---------------------------------------------------------------
+
+
+def test_list_by_run_newest_first(service: RenderService) -> None:
+    """Multiple artifacts, sorted by created_at desc."""
+    a1 = run(service.create_artifact(run_id=1, path="/render_1.mp4"))
+    a2 = run(service.create_artifact(run_id=1, path="/render_2.mp4"))
+    a3 = run(service.create_artifact(run_id=1, path="/render_3.mp4"))
+
+    artifacts = run(service.list_by_run(run_id=1))
+
+    assert len(artifacts) == 3
+    assert artifacts[0].id == a3.id
+    assert artifacts[1].id == a2.id
+    assert artifacts[2].id == a1.id
+
+
+def test_list_by_run_empty(service: RenderService) -> None:
+    """Returns empty list."""
+    artifacts = run(service.list_by_run(run_id=999))
+
+    assert artifacts == []
+
+
+def test_list_by_run_filters_by_run(service: RenderService) -> None:
+    """Create for run_id=1 and run_id=2, verify isolation."""
+    run(service.create_artifact(run_id=1, path="/run1_render.mp4"))
+    run(service.create_artifact(run_id=1, path="/run1_render_v2.mp4"))
+    run(service.create_artifact(run_id=2, path="/run2_render.mp4"))
+
+    run1_artifacts = run(service.list_by_run(run_id=1))
+    run2_artifacts = run(service.list_by_run(run_id=2))
+
+    assert len(run1_artifacts) == 2
+    assert len(run2_artifacts) == 1
+    assert all(a.run_id == 1 for a in run1_artifacts)
+    assert all(a.run_id == 2 for a in run2_artifacts)
+
+
+# -- get_by_id ---------------------------------------------------------------
+
+
+def test_get_by_id(service: RenderService) -> None:
+    """Fetch by specific id."""
+    created = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/render.mp4",
+        )
+    )
+
+    fetched = run(service.get_by_id(created.id))
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.path == "/data/artifacts/1/render.mp4"
+
+
+def test_get_by_id_not_found(service: RenderService) -> None:
+    """Returns None for nonexistent id."""
+    fetched = run(service.get_by_id(999))
+
+    assert fetched is None
+
+
+# -- Concurrent saves -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_produce_unique_ids() -> None:
+    """Two concurrent saves must produce distinct ids."""
+    storage = InMemoryRenderStorage()
+    svc = RenderService(storage)
+
+    results = await asyncio.gather(
+        svc.create_artifact(run_id=1, path="/a.mp4"),
+        svc.create_artifact(run_id=1, path="/b.mp4"),
+    )
+
+    ids = sorted(a.id for a in results)
+    assert ids == [1, 2], f"Expected unique ids [1, 2], got {ids}"
+
+
+# -- Isolation -------------------------------------------------------------------
+
+
+def test_different_runs_have_independent_artifacts(service: RenderService) -> None:
+    run(service.create_artifact(run_id=1, path="/r1_render.mp4"))
+    run(service.create_artifact(run_id=2, path="/r2_render.mp4"))
+
+    r1_artifacts = run(service.list_by_run(run_id=1))
+    r2_artifacts = run(service.list_by_run(run_id=2))
+
+    assert len(r1_artifacts) == 1
+    assert len(r2_artifacts) == 1
+    assert r1_artifacts[0].run_id == 1
+    assert r2_artifacts[0].run_id == 2
+
+
+def test_create_artifact_incremental_ids(service: RenderService) -> None:
+    """IDs should increment sequentially."""
+    a1 = run(service.create_artifact(run_id=1, path="/render1.mp4"))
+    a2 = run(service.create_artifact(run_id=1, path="/render2.mp4"))
+    a3 = run(service.create_artifact(run_id=2, path="/render3.mp4"))
+
+    assert a1.id == 1
+    assert a2.id == 2
+    assert a3.id == 3
+
+
+# -- build_render_manifest -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_render_manifest_with_assets_audio_subtitles() -> None:
+    """Test build_render_manifest with all dependencies."""
+    service = RenderService()
+
+    # Create fake dependencies
+    grouped_assets = {
+        "scene_1": [
+            FakeVisualAsset(
+                scene_id="scene_1",
+                asset_path="/path/to/scene_1_asset.png",
+                prompt_snapshot="A beautiful sunset",
+                is_active=True,
+            ),
+        ],
+        "scene_2": [
+            FakeVisualAsset(
+                scene_id="scene_2",
+                asset_path="/path/to/scene_2_asset.png",
+                prompt_snapshot="Ocean waves",
+                is_active=True,
+            ),
+        ],
+    }
+
+    visual_service = FakeVisualAssetService(grouped_assets)
+    audio_service = FakeAudioService(FakeAudioArtifact(path="/path/to/audio.wav"))
+    subtitle_service = FakeSubtitleService(FakeSubtitleArtifact(path="/path/to/subs.srt"))
+
+    manifest = await service.build_render_manifest(
+        run_id=1,
+        visual_asset_service=visual_service,
+        audio_service=audio_service,
+        subtitle_service=subtitle_service,
+        render_profile_name="shorts_default",
+    )
+
+    assert manifest["run_id"] == 1
+    assert len(manifest["scenes"]) == 2
+    assert manifest["scenes"][0]["scene_id"] == "scene_1"
+    assert manifest["scenes"][0]["asset_path"] == "/path/to/scene_1_asset.png"
+    assert manifest["scenes"][0]["prompt_snapshot"] == "A beautiful sunset"
+    assert manifest["audio_path"] == "/path/to/audio.wav"
+    assert manifest["subtitle_path"] == "/path/to/subs.srt"
+    assert manifest["render_profile"]["name"] == "shorts_default"
+    assert manifest["render_profile"]["width"] == 1080
+    assert manifest["render_profile"]["height"] == 1920
+
+
+@pytest.mark.asyncio
+async def test_build_render_manifest_without_audio_subtitles() -> None:
+    """Test build_render_manifest when audio/subtitles are None."""
+    service = RenderService()
+
+    grouped_assets = {
+        "scene_1": [
+            FakeVisualAsset(
+                scene_id="scene_1",
+                asset_path="/path/to/scene_1_asset.png",
+                prompt_snapshot="A beautiful sunset",
+                is_active=True,
+            ),
+        ],
+    }
+
+    visual_service = FakeVisualAssetService(grouped_assets)
+    audio_service = FakeAudioService(None)
+    subtitle_service = FakeSubtitleService(None)
+
+    manifest = await service.build_render_manifest(
+        run_id=1,
+        visual_asset_service=visual_service,
+        audio_service=audio_service,
+        subtitle_service=subtitle_service,
+    )
+
+    assert manifest["run_id"] == 1
+    assert len(manifest["scenes"]) == 1
+    assert manifest["audio_path"] is None
+    assert manifest["subtitle_path"] is None
+    assert manifest["render_profile"]["name"] == "shorts_default"
+
+
+@pytest.mark.asyncio
+async def test_build_render_manifest_with_empty_scenes() -> None:
+    """Test build_render_manifest with no active assets."""
+    service = RenderService()
+
+    grouped_assets = {}
+
+    visual_service = FakeVisualAssetService(grouped_assets)
+    audio_service = FakeAudioService(FakeAudioArtifact(path="/path/to/audio.wav"))
+    subtitle_service = FakeSubtitleService(None)
+
+    manifest = await service.build_render_manifest(
+        run_id=1,
+        visual_asset_service=visual_service,
+        audio_service=audio_service,
+        subtitle_service=subtitle_service,
+    )
+
+    assert manifest["run_id"] == 1
+    assert manifest["scenes"] == []
+    assert manifest["audio_path"] == "/path/to/audio.wav"
+    assert manifest["subtitle_path"] is None
+
+
+@pytest.mark.asyncio
+async def test_build_render_manifest_high_quality_profile() -> None:
+    """Test build_render_manifest with high_quality profile."""
+    service = RenderService()
+
+    grouped_assets = {
+        "scene_1": [
+            FakeVisualAsset(
+                scene_id="scene_1",
+                asset_path="/asset.png",
+                prompt_snapshot="test",
+                is_active=True,
+            ),
+        ],
+    }
+
+    visual_service = FakeVisualAssetService(grouped_assets)
+    audio_service = FakeAudioService(None)
+    subtitle_service = FakeSubtitleService(None)
+
+    manifest = await service.build_render_manifest(
+        run_id=1,
+        visual_asset_service=visual_service,
+        audio_service=audio_service,
+        subtitle_service=subtitle_service,
+        render_profile_name="high_quality",
+    )
+
+    assert manifest["render_profile"]["name"] == "high_quality"
+    assert manifest["render_profile"]["crf"] == 18
+    assert manifest["render_profile"]["preset"] == "slow"
+
+
+@pytest.mark.asyncio
+async def test_build_render_manifest_fast_preview_profile() -> None:
+    """Test build_render_manifest with fast_preview profile."""
+    service = RenderService()
+
+    grouped_assets = {
+        "scene_1": [
+            FakeVisualAsset(
+                scene_id="scene_1",
+                asset_path="/asset.png",
+                prompt_snapshot="test",
+                is_active=True,
+            ),
+        ],
+    }
+
+    visual_service = FakeVisualAssetService(grouped_assets)
+    audio_service = FakeAudioService(None)
+    subtitle_service = FakeSubtitleService(None)
+
+    manifest = await service.build_render_manifest(
+        run_id=1,
+        visual_asset_service=visual_service,
+        audio_service=audio_service,
+        subtitle_service=subtitle_service,
+        render_profile_name="fast_preview",
+    )
+
+    assert manifest["render_profile"]["name"] == "fast_preview"
+    assert manifest["render_profile"]["width"] == 540
+    assert manifest["render_profile"]["height"] == 960
+    assert manifest["render_profile"]["fps"] == 15
+    assert manifest["render_profile"]["crf"] == 28
+    assert manifest["render_profile"]["preset"] == "ultrafast"

--- a/packages/creator-service/tests/test_run_service.py
+++ b/packages/creator-service/tests/test_run_service.py
@@ -106,11 +106,12 @@ def test_restart_run_rejects_invalid_stage_transition() -> None:
         )
     )
 
-    with pytest.raises(ValueError, match="Cannot restart run"):
+    with pytest.raises(ValueError, match="Cannot transition"):
         asyncio.run(service.restart_run(created.id, RunStage.PUBLISHED.value))
 
 
-def test_restart_run_allows_review_stage_restart() -> None:
+def test_restart_run_rejects_review_stage_from_non_review_stage() -> None:
+    """Verify that IDEA_READY cannot jump directly to SCRIPT_REVIEW (was incorrectly allowed)."""
     service = RunService(InMemoryRunStorage())
     created = asyncio.run(
         service.create_run(
@@ -120,7 +121,39 @@ def test_restart_run_allows_review_stage_restart() -> None:
         )
     )
 
-    restarted = asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_REVIEW.value))
+    with pytest.raises(ValueError, match="Cannot transition"):
+        asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_REVIEW.value))
 
-    assert restarted.current_stage == RunStage.SCRIPT_REVIEW.value
-    assert restarted.restart_from == RunStage.SCRIPT_REVIEW.value
+
+def test_restart_run_allows_valid_review_stage_restart() -> None:
+    """Verify that review stages can restart to their generating stage via TRANSITIONS."""
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=13,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    # First transition to SCRIPT_GENERATING (valid from IDEA_READY)
+    stage1 = asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_GENERATING.value))
+    assert stage1.current_stage == RunStage.SCRIPT_GENERATING.value
+
+    # Now manually set the stage to SCRIPT_REVIEW for testing (simulate it was reviewed)
+    # We need to restart from SCRIPT_GENERATING to SCRIPT_REVIEW first
+    # But since we can't directly manipulate, let's test SCRIPT_GENERATING -> SCRIPT_REVIEW transition
+    # by using the fact that stage1 is now in SCRIPT_GENERATING
+    
+    # Test: from SCRIPT_REVIEW, can restart to SCRIPT_GENERATING (the generating stage)
+    # We'll create a test scenario differently:
+    storage = InMemoryRunStorage()
+    service2 = RunService(storage)
+    created2 = asyncio.run(service2.create_run(project_id=14, model_defaults={"script_model": "qwen3-4b"}, style_preset="default"))
+    
+    # Simulate being in SCRIPT_REVIEW by manually updating storage
+    asyncio.run(storage.update_run(created2.id, {"current_stage": RunStage.SCRIPT_REVIEW.value}))
+    
+    # Now restart from SCRIPT_REVIEW to SCRIPT_GENERATING should succeed (per TRANSITIONS dict)
+    restarted = asyncio.run(service2.restart_run(created2.id, RunStage.SCRIPT_GENERATING.value))
+    assert restarted.current_stage == RunStage.SCRIPT_GENERATING.value

--- a/packages/creator-service/tests/test_run_service.py
+++ b/packages/creator-service/tests/test_run_service.py
@@ -1,0 +1,126 @@
+import asyncio
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from run_service import InMemoryRunStorage, RunService
+
+domain_models = importlib.import_module("models")
+ModelSelection = domain_models.ModelSelection
+RunStage = domain_models.RunStage
+
+
+def test_create_run_with_model_defaults_and_style_preset() -> None:
+    service = RunService(InMemoryRunStorage())
+
+    run = asyncio.run(
+        service.create_run(
+            project_id=7,
+            model_defaults=ModelSelection(script_model="qwen3-4b", image_model="sd15"),
+            style_preset="cinematic",
+        )
+    )
+
+    assert run.project_id == 7
+    assert run.current_stage == RunStage.IDEA_READY.value
+    assert run.status == "pending"
+    assert run.style_preset == "cinematic"
+    assert run.model_defaults is not None
+    assert run.model_defaults.script_model == "qwen3-4b"
+    assert run.model_defaults.image_model == "sd15"
+
+
+def test_create_run_stores_metadata_in_metadata_json() -> None:
+    storage = InMemoryRunStorage()
+    service = RunService(storage)
+    metadata = {"origin": "manual", "attempt": 1}
+
+    run = asyncio.run(
+        service.create_run(
+            project_id=8,
+            model_defaults={"script_model": "qwen3-8b"},
+            style_preset="default",
+            metadata=metadata,
+        )
+    )
+    row = asyncio.run(storage.get_run(run.id))
+
+    assert row is not None
+    assert row["metadata_json"] == json.dumps(metadata)
+
+
+def test_get_run_returns_none_for_missing() -> None:
+    service = RunService(InMemoryRunStorage())
+
+    run = asyncio.run(service.get_run(9999))
+
+    assert run is None
+
+
+def test_get_run_returns_existing_run() -> None:
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=9,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    fetched = asyncio.run(service.get_run(created.id))
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.project_id == 9
+
+
+def test_restart_run_transitions_correctly() -> None:
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=10,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    restarted = asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_GENERATING.value))
+
+    assert restarted.current_stage == RunStage.SCRIPT_GENERATING.value
+    assert restarted.restart_from == RunStage.SCRIPT_GENERATING.value
+
+
+def test_restart_run_rejects_invalid_stage_transition() -> None:
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=11,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    with pytest.raises(ValueError, match="Cannot restart run"):
+        asyncio.run(service.restart_run(created.id, RunStage.PUBLISHED.value))
+
+
+def test_restart_run_allows_review_stage_restart() -> None:
+    service = RunService(InMemoryRunStorage())
+    created = asyncio.run(
+        service.create_run(
+            project_id=12,
+            model_defaults={"script_model": "qwen3-4b"},
+            style_preset="default",
+        )
+    )
+
+    restarted = asyncio.run(service.restart_run(created.id, RunStage.SCRIPT_REVIEW.value))
+
+    assert restarted.current_stage == RunStage.SCRIPT_REVIEW.value
+    assert restarted.restart_from == RunStage.SCRIPT_REVIEW.value

--- a/packages/creator-service/tests/test_script_service.py
+++ b/packages/creator-service/tests/test_script_service.py
@@ -1,0 +1,129 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from markdown_parser import parse_markdown
+from models.script_draft import ScriptSection  # type: ignore[reportMissingImports]
+from script_service import InMemoryScriptStorage, ScriptService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def storage() -> InMemoryScriptStorage:
+    return InMemoryScriptStorage()
+
+
+@pytest.fixture
+def service(storage: InMemoryScriptStorage) -> ScriptService:
+    return ScriptService(storage)
+
+
+def test_save_draft_creates_version_1(service: ScriptService) -> None:
+    draft = run(
+        service.save_draft(
+            run_id=101,
+            source_type="pasted_markdown",
+            markdown_content="## hook\nHello",
+        )
+    )
+
+    assert draft.run_id == 101
+    assert draft.version == 1
+
+
+def test_save_draft_increments_version(service: ScriptService) -> None:
+    run(service.save_draft(run_id=102, source_type="pasted_markdown", markdown_content="## hook\nFirst"))
+    second = run(
+        service.save_draft(
+            run_id=102,
+            source_type="edited_manually",
+            markdown_content="## hook\nSecond",
+        )
+    )
+
+    assert second.version == 2
+
+
+def test_save_draft_parses_markdown_when_no_structured_script(service: ScriptService) -> None:
+    markdown = "## hook\nHook line\n\n## body\nBody line"
+
+    draft = run(service.save_draft(run_id=103, source_type="pasted_markdown", markdown_content=markdown))
+
+    assert draft.structured_script is not None
+    assert draft.structured_script == parse_markdown(markdown)
+
+
+def test_save_draft_preserves_explicit_structured_script(service: ScriptService) -> None:
+    explicit = [
+        ScriptSection(
+            section_id="custom-1",
+            type="custom",
+            text="Explicit text",
+            display_text="Explicit display",
+            speaker="host",
+            duration=None,
+            turn_kind=None,
+            visual_override=None,
+        )
+    ]
+
+    draft = run(
+        service.save_draft(
+            run_id=104,
+            source_type="edited_manually",
+            markdown_content="## hook\nIgnored by explicit sections",
+            structured_script=explicit,
+        )
+    )
+
+    assert draft.structured_script is not None
+    assert [section.section_id for section in draft.structured_script] == ["custom-1"]
+    assert [section.type for section in draft.structured_script] == ["custom"]
+    assert [section.text for section in draft.structured_script] == ["Explicit text"]
+
+
+def test_save_draft_stable_section_ids(service: ScriptService) -> None:
+    first_markdown = "## hook\nFirst hook\n\n## intro\nFirst intro"
+    second_markdown = "## hook\nUpdated hook\n\n## intro\nUpdated intro"
+
+    first = run(service.save_draft(run_id=105, source_type="pasted_markdown", markdown_content=first_markdown))
+    second = run(service.save_draft(run_id=105, source_type="edited_manually", markdown_content=second_markdown))
+
+    assert first.structured_script is not None
+    assert second.structured_script is not None
+    assert [section.section_id for section in second.structured_script] == [
+        section.section_id for section in first.structured_script
+    ]
+
+
+def test_get_active_draft_returns_latest(service: ScriptService) -> None:
+    run(service.save_draft(run_id=106, source_type="pasted_markdown", markdown_content="## hook\nV1"))
+    run(service.save_draft(run_id=106, source_type="edited_manually", markdown_content="## hook\nV2"))
+
+    active = run(service.get_active_draft(106))
+
+    assert active is not None
+    assert active.version == 2
+    assert active.markdown_content == "## hook\nV2"
+
+
+def test_get_active_draft_returns_none_for_missing(service: ScriptService) -> None:
+    assert run(service.get_active_draft(9999)) is None
+
+
+def test_list_draft_versions_returns_newest_first(service: ScriptService) -> None:
+    run(service.save_draft(run_id=107, source_type="pasted_markdown", markdown_content="## hook\nV1"))
+    run(service.save_draft(run_id=107, source_type="edited_manually", markdown_content="## hook\nV2"))
+    run(service.save_draft(run_id=107, source_type="edited_manually", markdown_content="## hook\nV3"))
+
+    drafts = run(service.list_draft_versions(107))
+
+    assert [draft.version for draft in drafts] == [3, 2, 1]

--- a/packages/creator-service/tests/test_script_service.py
+++ b/packages/creator-service/tests/test_script_service.py
@@ -127,3 +127,18 @@ def test_list_draft_versions_returns_newest_first(service: ScriptService) -> Non
     drafts = run(service.list_draft_versions(107))
 
     assert [draft.version for draft in drafts] == [3, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_produce_unique_versions() -> None:
+    """Two concurrent saves for the same run_id must produce distinct versions."""
+    storage = InMemoryScriptStorage()
+    service = ScriptService(storage)
+
+    results = await asyncio.gather(
+        service.save_draft(run_id=200, source_type="pasted_markdown", markdown_content="## hook\nA"),
+        service.save_draft(run_id=200, source_type="pasted_markdown", markdown_content="## hook\nB"),
+    )
+
+    versions = sorted(d.version for d in results)
+    assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"

--- a/packages/creator-service/tests/test_script_service.py
+++ b/packages/creator-service/tests/test_script_service.py
@@ -142,3 +142,19 @@ async def test_concurrent_saves_produce_unique_versions() -> None:
 
     versions = sorted(d.version for d in results)
     assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_across_service_instances() -> None:
+    """Two ScriptService instances sharing one storage must still produce unique versions."""
+    storage = InMemoryScriptStorage()
+    service_a = ScriptService(storage)
+    service_b = ScriptService(storage)
+
+    results = await asyncio.gather(
+        service_a.save_draft(run_id=201, source_type="pasted_markdown", markdown_content="## hook\nA"),
+        service_b.save_draft(run_id=201, source_type="pasted_markdown", markdown_content="## hook\nB"),
+    )
+
+    versions = sorted(d.version for d in results)
+    assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"

--- a/packages/creator-service/tests/test_subtitle_service.py
+++ b/packages/creator-service/tests/test_subtitle_service.py
@@ -1,0 +1,286 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from subtitle_service import (  # noqa: E402
+    InMemorySubtitleStorage,
+    SubtitleService,
+)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def storage() -> InMemorySubtitleStorage:
+    return InMemorySubtitleStorage()
+
+
+@pytest.fixture
+def service(storage: InMemorySubtitleStorage) -> SubtitleService:
+    return SubtitleService(storage)
+
+
+# -- create_artifact ---------------------------------------------------------------
+
+
+def test_create_artifact(service: SubtitleService) -> None:
+    artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/subtitle.srt",
+        )
+    )
+
+    assert artifact.run_id == 1
+    assert artifact.path == "/data/artifacts/1/subtitle.srt"
+    assert artifact.format == "srt"
+    assert artifact.created_at is not None
+
+
+def test_create_artifact_with_metadata(service: SubtitleService) -> None:
+    artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/subtitle.vtt",
+            format="vtt",
+            model_used="whisper-large",
+            provider_type="openai",
+        )
+    )
+
+    assert artifact.run_id == 1
+    assert artifact.path == "/data/artifacts/1/subtitle.vtt"
+    assert artifact.format == "vtt"
+    assert artifact.created_at is not None
+
+
+def test_create_artifact_default_format(service: SubtitleService) -> None:
+    """Verify default format is 'srt'."""
+    artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/subtitle.srt",
+        )
+    )
+
+    assert artifact.format == "srt"
+
+
+def test_create_artifact_has_id(service: SubtitleService) -> None:
+    artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/subtitle.srt",
+        )
+    )
+
+    assert artifact.id is not None
+    assert artifact.id > 0
+
+
+# -- get_latest ---------------------------------------------------------------
+
+
+def test_get_latest_returns_most_recent(service: SubtitleService) -> None:
+    """Create 2 artifacts, get_latest returns newest."""
+    first = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/subtitle_v1.srt",
+        )
+    )
+    second = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/subtitle_v2.srt",
+        )
+    )
+
+    latest = run(service.get_latest(run_id=1))
+
+    assert latest is not None
+    assert latest.id == second.id
+    assert latest.id != first.id
+    assert latest.path == "/data/artifacts/1/subtitle_v2.srt"
+
+
+def test_get_latest_empty(service: SubtitleService) -> None:
+    """Returns None when no artifacts."""
+    latest = run(service.get_latest(run_id=999))
+
+    assert latest is None
+
+
+# -- list_by_run ---------------------------------------------------------------
+
+
+def test_list_by_run_newest_first(service: SubtitleService) -> None:
+    """Multiple artifacts, sorted by created_at desc."""
+    a1 = run(service.create_artifact(run_id=1, path="/subtitle_1.srt"))
+    a2 = run(service.create_artifact(run_id=1, path="/subtitle_2.srt"))
+    a3 = run(service.create_artifact(run_id=1, path="/subtitle_3.srt"))
+
+    artifacts = run(service.list_by_run(run_id=1))
+
+    assert len(artifacts) == 3
+    assert artifacts[0].id == a3.id
+    assert artifacts[1].id == a2.id
+    assert artifacts[2].id == a1.id
+
+
+def test_list_by_run_empty(service: SubtitleService) -> None:
+    """Returns empty list."""
+    artifacts = run(service.list_by_run(run_id=999))
+
+    assert artifacts == []
+
+
+def test_list_by_run_filters_by_run(service: SubtitleService) -> None:
+    """Create for run_id=1 and run_id=2, verify isolation."""
+    run(service.create_artifact(run_id=1, path="/run1_subtitle.srt"))
+    run(service.create_artifact(run_id=1, path="/run1_subtitle_v2.srt"))
+    run(service.create_artifact(run_id=2, path="/run2_subtitle.srt"))
+
+    run1_artifacts = run(service.list_by_run(run_id=1))
+    run2_artifacts = run(service.list_by_run(run_id=2))
+
+    assert len(run1_artifacts) == 2
+    assert len(run2_artifacts) == 1
+    assert all(a.run_id == 1 for a in run1_artifacts)
+    assert all(a.run_id == 2 for a in run2_artifacts)
+
+
+# -- get_by_id ---------------------------------------------------------------
+
+
+def test_get_by_id(service: SubtitleService) -> None:
+    """Fetch by specific id."""
+    created = run(
+        service.create_artifact(
+            run_id=1,
+            path="/data/artifacts/1/subtitle.srt",
+        )
+    )
+
+    fetched = run(service.get_by_id(created.id))
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.path == "/data/artifacts/1/subtitle.srt"
+
+
+def test_get_by_id_not_found(service: SubtitleService) -> None:
+    """Returns None for nonexistent id."""
+    fetched = run(service.get_by_id(999))
+
+    assert fetched is None
+
+
+# -- Concurrent saves -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_produce_unique_ids() -> None:
+    """Two concurrent saves must produce distinct ids."""
+    storage = InMemorySubtitleStorage()
+    svc = SubtitleService(storage)
+
+    results = await asyncio.gather(
+        svc.create_artifact(run_id=1, path="/a.srt"),
+        svc.create_artifact(run_id=1, path="/b.srt"),
+    )
+
+    ids = sorted(a.id for a in results)
+    assert ids == [1, 2], f"Expected unique ids [1, 2], got {ids}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_across_service_instances() -> None:
+    """Two service instances sharing storage must still produce unique ids."""
+    storage = InMemorySubtitleStorage()
+    service_a = SubtitleService(storage)
+    service_b = SubtitleService(storage)
+
+    results = await asyncio.gather(
+        service_a.create_artifact(run_id=1, path="/a.srt"),
+        service_b.create_artifact(run_id=1, path="/b.srt"),
+    )
+
+    ids = sorted(a.id for a in results)
+    assert ids == [1, 2], f"Expected unique ids [1, 2], got {ids}"
+
+
+# -- Isolation -------------------------------------------------------------------
+
+
+def test_different_runs_have_independent_artifacts(service: SubtitleService) -> None:
+    run(service.create_artifact(run_id=1, path="/r1_subtitle.srt"))
+    run(service.create_artifact(run_id=2, path="/r2_subtitle.srt"))
+
+    r1_artifacts = run(service.list_by_run(run_id=1))
+    r2_artifacts = run(service.list_by_run(run_id=2))
+
+    assert len(r1_artifacts) == 1
+    assert len(r2_artifacts) == 1
+    assert r1_artifacts[0].run_id == 1
+    assert r2_artifacts[0].run_id == 2
+
+
+def test_format_variations(service: SubtitleService) -> None:
+    """Test both supported formats."""
+    srt_artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/subtitle.srt",
+            format="srt",
+        )
+    )
+    vtt_artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/subtitle.vtt",
+            format="vtt",
+        )
+    )
+
+    assert srt_artifact.format == "srt"
+    assert vtt_artifact.format == "vtt"
+
+    latest = run(service.get_latest(run_id=1))
+    assert latest is not None
+    assert latest.format == "vtt"  # Most recent
+
+
+def test_metadata_preservation(service: SubtitleService) -> None:
+    """Verify metadata fields are preserved."""
+    artifact = run(
+        service.create_artifact(
+            run_id=1,
+            path="/subtitle.srt",
+            format="vtt",
+            model_used="whisper-medium",
+            provider_type="openai",
+        )
+    )
+
+    fetched = run(service.get_by_id(artifact.id))
+    assert fetched is not None
+    assert fetched.format == "vtt"
+
+
+def test_create_artifact_incremental_ids(service: SubtitleService) -> None:
+    """IDs should increment sequentially."""
+    a1 = run(service.create_artifact(run_id=1, path="/sub1.srt"))
+    a2 = run(service.create_artifact(run_id=1, path="/sub2.srt"))
+    a3 = run(service.create_artifact(run_id=2, path="/sub3.srt"))
+
+    assert a1.id == 1
+    assert a2.id == 2
+    assert a3.id == 3

--- a/packages/creator-service/tests/test_visual_asset_service.py
+++ b/packages/creator-service/tests/test_visual_asset_service.py
@@ -348,3 +348,64 @@ def test_different_runs_have_independent_assets(service: VisualAssetService) -> 
     assert len(r2_assets) == 1
     assert r1_assets[0].version == 1
     assert r2_assets[0].version == 1
+
+
+# -- Concurrent active invariant (Oracle PR #140 feedback) ---------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_creates_exactly_one_active() -> None:
+    """Two concurrent active creates for the same scene must leave exactly one
+    active asset, and it must be the latest version."""
+    storage = InMemoryVisualAssetStorage()
+    svc = VisualAssetService(storage)
+
+    results = await asyncio.gather(
+        svc.create_asset(run_id=1, scene_id="sc-1", asset_path="/a.png"),
+        svc.create_asset(run_id=1, scene_id="sc-1", asset_path="/b.png"),
+    )
+
+    # Both should have unique versions
+    versions = sorted(a.version for a in results)
+    assert versions == [1, 2]
+
+    # Exactly one active asset
+    all_assets = await storage.list_assets_by_scene(1, "sc-1")
+    active_assets = [a for a in all_assets if a.get("is_active", False)]
+    assert len(active_assets) == 1, f"Expected 1 active, got {len(active_assets)}"
+
+    # The active one must be the latest version
+    assert active_assets[0]["version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_creates_across_instances_exactly_one_active() -> None:
+    """Two service instances sharing storage: exactly one active after concurrent creates."""
+    storage = InMemoryVisualAssetStorage()
+    svc_a = VisualAssetService(storage)
+    svc_b = VisualAssetService(storage)
+
+    await asyncio.gather(
+        svc_a.create_asset(run_id=1, scene_id="sc-1", asset_path="/a.png"),
+        svc_b.create_asset(run_id=1, scene_id="sc-1", asset_path="/b.png"),
+    )
+
+    all_assets = await storage.list_assets_by_scene(1, "sc-1")
+    active_assets = [a for a in all_assets if a.get("is_active", False)]
+    assert len(active_assets) == 1
+    assert active_assets[0]["version"] == 2
+
+
+def test_create_inactive_preserves_existing_active(service: VisualAssetService) -> None:
+    """Creating an asset with is_active=False must not deactivate the existing active asset."""
+    first = run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/v1.png", is_active=True))
+    assert first.is_active is True
+
+    second = run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/v2.png", is_active=False))
+    assert second.is_active is False
+
+    # First should still be active
+    active = run(service.get_active_asset(run_id=1, scene_id="sc-1"))
+    assert active is not None
+    assert active.id == first.id
+    assert active.is_active is True

--- a/packages/creator-service/tests/test_visual_asset_service.py
+++ b/packages/creator-service/tests/test_visual_asset_service.py
@@ -1,0 +1,350 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from visual_asset_service import (  # noqa: E402
+    InMemoryVisualAssetStorage,
+    VisualAssetService,
+)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def storage() -> InMemoryVisualAssetStorage:
+    return InMemoryVisualAssetStorage()
+
+
+@pytest.fixture
+def service(storage: InMemoryVisualAssetStorage) -> VisualAssetService:
+    return VisualAssetService(storage)
+
+
+# -- create_asset ---------------------------------------------------------------
+
+
+def test_create_asset_version_1(service: VisualAssetService) -> None:
+    asset = run(
+        service.create_asset(
+            run_id=1,
+            scene_id="sc-1",
+            asset_path="/data/artifacts/1/1/sc-1_v1.png",
+            prompt_snapshot="A dramatic opening shot",
+            model_used="stable-diffusion-v1-5",
+            provider_type="comfyui",
+        )
+    )
+
+    assert asset.run_id == 1
+    assert asset.scene_id == "sc-1"
+    assert asset.version == 1
+    assert asset.asset_path == "/data/artifacts/1/1/sc-1_v1.png"
+    assert asset.prompt_snapshot == "A dramatic opening shot"
+    assert asset.model_used == "stable-diffusion-v1-5"
+    assert asset.provider_type == "comfyui"
+    assert asset.is_active is True
+
+
+def test_create_asset_increments_version(service: VisualAssetService) -> None:
+    run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/data/artifacts/1/1/sc-1_v1.png",
+        )
+    )
+    second = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/data/artifacts/1/1/sc-1_v2.png",
+        )
+    )
+
+    assert second.version == 2
+
+
+def test_create_asset_inactive(service: VisualAssetService) -> None:
+    asset = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/data/artifacts/1/1/sc-1_v1.png",
+            is_active=False,
+        )
+    )
+
+    assert asset.is_active is False
+
+
+def test_create_asset_deactivates_previous(service: VisualAssetService) -> None:
+    """When a new active asset is created, previous active asset is deactivated."""
+    first = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/data/artifacts/1/1/sc-1_v1.png",
+        )
+    )
+    assert first.is_active is True
+
+    run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/data/artifacts/1/1/sc-1_v2.png",
+        )
+    )
+
+    # First asset should now be inactive
+    first_now = run(service.get_asset(first.id))
+    assert first_now is not None
+    assert first_now.is_active is False
+
+
+def test_create_asset_different_scenes_independent(service: VisualAssetService) -> None:
+    """Assets in different scenes have independent version counters."""
+    a1 = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/data/artifacts/1/1/sc-1_v1.png",
+        )
+    )
+    a2 = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-2",
+            asset_path="/data/artifacts/1/1/sc-2_v1.png",
+        )
+    )
+
+    assert a1.version == 1
+    assert a2.version == 1
+
+
+def test_create_asset_provider_type_mapping(service: VisualAssetService) -> None:
+    """provider_type param is stored as 'provider' in DB and mapped back."""
+    asset = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/path.png",
+            provider_type="comfyui",
+        )
+    )
+    assert asset.provider_type == "comfyui"
+
+
+# -- select_active ---------------------------------------------------------------
+
+
+def test_select_active_changes_active_asset(service: VisualAssetService) -> None:
+    first = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/v1.png",
+        )
+    )
+    second = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/v2.png",
+        )
+    )
+
+    # Second is now active, select first
+    result = run(service.select_active(run_id=1, scene_id="sc-1", asset_id=first.id))
+    assert result.is_active is True
+    assert result.id == first.id
+
+    # Verify second is now inactive
+    second_now = run(service.get_asset(second.id))
+    assert second_now is not None
+    assert second_now.is_active is False
+
+
+def test_select_active_idempotent(service: VisualAssetService) -> None:
+    """Selecting an already-active asset succeeds without error."""
+    asset = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/v1.png",
+        )
+    )
+
+    result = run(service.select_active(run_id=1, scene_id="sc-1", asset_id=asset.id))
+    assert result.is_active is True
+
+
+def test_select_active_not_found(service: VisualAssetService) -> None:
+    with pytest.raises(ValueError, match="Asset 999 not found"):
+        run(service.select_active(run_id=1, scene_id="sc-1", asset_id=999))
+
+
+def test_select_active_wrong_scene(service: VisualAssetService) -> None:
+    asset = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/v1.png",
+        )
+    )
+
+    with pytest.raises(ValueError, match="does not belong to"):
+        run(service.select_active(run_id=1, scene_id="sc-other", asset_id=asset.id))
+
+
+def test_select_active_wrong_run(service: VisualAssetService) -> None:
+    asset = run(
+        service.create_asset(
+            run_id=1, scene_id="sc-1",
+            asset_path="/v1.png",
+        )
+    )
+
+    with pytest.raises(ValueError, match="does not belong to"):
+        run(service.select_active(run_id=999, scene_id="sc-1", asset_id=asset.id))
+
+
+# -- list_by_scene ---------------------------------------------------------------
+
+
+def test_list_by_scene_newest_first(service: VisualAssetService) -> None:
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/v1.png"))
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/v2.png"))
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/v3.png"))
+
+    assets = run(service.list_by_scene(run_id=1, scene_id="sc-1"))
+
+    assert [a.version for a in assets] == [3, 2, 1]
+
+
+def test_list_by_scene_empty(service: VisualAssetService) -> None:
+    assets = run(service.list_by_scene(run_id=999, scene_id="sc-1"))
+    assert assets == []
+
+
+def test_list_by_scene_excludes_other_scenes(service: VisualAssetService) -> None:
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/sc1.png"))
+    run(service.create_asset(run_id=1, scene_id="sc-2", asset_path="/sc2.png"))
+
+    assets = run(service.list_by_scene(run_id=1, scene_id="sc-1"))
+    assert len(assets) == 1
+    assert assets[0].scene_id == "sc-1"
+
+
+# -- list_by_run ---------------------------------------------------------------
+
+
+def test_list_by_run_grouped_by_scene(service: VisualAssetService) -> None:
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/sc1_v1.png"))
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/sc1_v2.png"))
+    run(service.create_asset(run_id=1, scene_id="sc-2", asset_path="/sc2_v1.png"))
+
+    grouped = run(service.list_by_run(run_id=1))
+
+    assert set(grouped.keys()) == {"sc-1", "sc-2"}
+    assert len(grouped["sc-1"]) == 2
+    assert len(grouped["sc-2"]) == 1
+    # Within each scene, newest first
+    assert grouped["sc-1"][0].version > grouped["sc-1"][1].version
+
+
+def test_list_by_run_empty(service: VisualAssetService) -> None:
+    grouped = run(service.list_by_run(run_id=999))
+    assert grouped == {}
+
+
+def test_list_by_run_excludes_other_runs(service: VisualAssetService) -> None:
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/r1.png"))
+    run(service.create_asset(run_id=2, scene_id="sc-1", asset_path="/r2.png"))
+
+    grouped = run(service.list_by_run(run_id=1))
+    assert len(grouped) == 1
+    assert all(a.run_id == 1 for a in grouped["sc-1"])
+
+
+# -- get_active_asset -----------------------------------------------------------
+
+
+def test_get_active_asset(service: VisualAssetService) -> None:
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/v1.png"))
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/v2.png"))
+
+    active = run(service.get_active_asset(run_id=1, scene_id="sc-1"))
+
+    assert active is not None
+    assert active.version == 2  # Last created with is_active=True
+    assert active.is_active is True
+
+
+def test_get_active_asset_none(service: VisualAssetService) -> None:
+    assert run(service.get_active_asset(run_id=999, scene_id="sc-1")) is None
+
+
+# -- get_asset -------------------------------------------------------------------
+
+
+def test_get_asset(service: VisualAssetService) -> None:
+    created = run(
+        service.create_asset(run_id=1, scene_id="sc-1", asset_path="/v1.png")
+    )
+
+    fetched = run(service.get_asset(created.id))
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.asset_path == "/v1.png"
+
+
+def test_get_asset_not_found(service: VisualAssetService) -> None:
+    assert run(service.get_asset(999)) is None
+
+
+# -- Concurrent saves -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_produce_unique_versions() -> None:
+    """Two concurrent saves for the same scene must produce distinct versions."""
+    storage = InMemoryVisualAssetStorage()
+    svc = VisualAssetService(storage)
+
+    results = await asyncio.gather(
+        svc.create_asset(run_id=1, scene_id="sc-1", asset_path="/a.png"),
+        svc.create_asset(run_id=1, scene_id="sc-1", asset_path="/b.png"),
+    )
+
+    versions = sorted(a.version for a in results)
+    assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_across_service_instances() -> None:
+    """Two service instances sharing storage must still produce unique versions."""
+    storage = InMemoryVisualAssetStorage()
+    service_a = VisualAssetService(storage)
+    service_b = VisualAssetService(storage)
+
+    results = await asyncio.gather(
+        service_a.create_asset(run_id=1, scene_id="sc-1", asset_path="/a.png"),
+        service_b.create_asset(run_id=1, scene_id="sc-1", asset_path="/b.png"),
+    )
+
+    versions = sorted(a.version for a in results)
+    assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"
+
+
+# -- Isolation -------------------------------------------------------------------
+
+
+def test_different_runs_have_independent_assets(service: VisualAssetService) -> None:
+    run(service.create_asset(run_id=1, scene_id="sc-1", asset_path="/r1.png"))
+    run(service.create_asset(run_id=2, scene_id="sc-1", asset_path="/r2.png"))
+
+    r1_assets = run(service.list_by_scene(run_id=1, scene_id="sc-1"))
+    r2_assets = run(service.list_by_scene(run_id=2, scene_id="sc-1"))
+
+    assert len(r1_assets) == 1
+    assert len(r2_assets) == 1
+    assert r1_assets[0].version == 1
+    assert r2_assets[0].version == 1

--- a/packages/creator-service/tests/test_visual_plan_service.py
+++ b/packages/creator-service/tests/test_visual_plan_service.py
@@ -8,7 +8,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from models.visual_plan import VisualScene  # type: ignore[reportMissingImports]
-from visual_plan_service import InMemoryVisualPlanStorage, VisualPlanService
+from visual_plan_service import (  # noqa: E402
+    DataIntegrityError,
+    InMemoryVisualPlanStorage,
+    VersionConflictError,
+    VisualPlanService,
+)
 
 
 def run(coro):
@@ -135,22 +140,6 @@ def test_patch_scene_updates_prompt(service: VisualPlanService) -> None:
     assert untouched.prompt == "Keep this"
 
 
-def test_patch_scene_updates_generation_status(service: VisualPlanService) -> None:
-    scenes = [_make_scene(scene_id="sc-1")]
-    run(service.save_plan(run_id=202, scenes=scenes))
-
-    plan = run(
-        service.patch_scene(
-            run_id=202,
-            scene_id="sc-1",
-            updates={"generation_status": "completed", "latest_asset_id": 99},
-        )
-    )
-
-    assert plan.scenes[0].generation_status == "completed"
-    assert plan.scenes[0].latest_asset_id == 99
-
-
 def test_patch_scene_raises_when_no_active_plan(service: VisualPlanService) -> None:
     with pytest.raises(ValueError, match="No active visual plan"):
         run(service.patch_scene(run_id=999, scene_id="sc-1", updates={"prompt": "x"}))
@@ -164,6 +153,120 @@ def test_patch_scene_raises_when_scene_not_found(service: VisualPlanService) -> 
         run(
             service.patch_scene(
                 run_id=203, scene_id="sc-missing", updates={"prompt": "x"}
+            )
+        )
+
+
+# -- patch_scene: expected_version (optimistic concurrency) -------------------
+
+
+def test_patch_scene_with_matching_expected_version(service: VisualPlanService) -> None:
+    """Patch succeeds when expected_version matches active version."""
+    run(service.save_plan(run_id=210, scenes=[_make_scene()]))
+
+    plan = run(
+        service.patch_scene(
+            run_id=210,
+            scene_id="sc-1",
+            updates={"prompt": "Updated"},
+            expected_version=1,
+        )
+    )
+    assert plan.version == 2
+    assert plan.scenes[0].prompt == "Updated"
+
+
+def test_patch_scene_with_stale_expected_version(service: VisualPlanService) -> None:
+    """Patch raises VersionConflictError when expected_version is stale."""
+    run(service.save_plan(run_id=211, scenes=[_make_scene()]))
+    # Advance to version 2
+    run(service.save_plan(run_id=211, scenes=[_make_scene(prompt="V2")]))
+
+    with pytest.raises(VersionConflictError) as exc_info:
+        run(
+            service.patch_scene(
+                run_id=211,
+                scene_id="sc-1",
+                updates={"prompt": "Stale"},
+                expected_version=1,
+            )
+        )
+
+    assert exc_info.value.run_id == 211
+    assert exc_info.value.expected_version == 1
+    assert exc_info.value.actual_version == 2
+
+
+def test_patch_scene_skips_version_check_when_none(service: VisualPlanService) -> None:
+    """Patch succeeds without version check when expected_version is None."""
+    run(service.save_plan(run_id=212, scenes=[_make_scene()]))
+    run(service.save_plan(run_id=212, scenes=[_make_scene(prompt="V2")]))
+
+    # expected_version=None (default) — no check, always succeeds
+    plan = run(
+        service.patch_scene(
+            run_id=212,
+            scene_id="sc-1",
+            updates={"prompt": "No version check"},
+        )
+    )
+    assert plan.version == 3
+    assert plan.scenes[0].prompt == "No version check"
+
+
+# -- patch_scene: field allowlist ----------------------------------------------
+
+
+def test_patch_scene_rejects_scene_id(service: VisualPlanService) -> None:
+    """Immutable identity field scene_id cannot be patched."""
+    run(service.save_plan(run_id=220, scenes=[_make_scene()]))
+
+    with pytest.raises(ValueError, match="immutable/unknown fields"):
+        run(
+            service.patch_scene(
+                run_id=220, scene_id="sc-1", updates={"scene_id": "sc-hacked"}
+            )
+        )
+
+
+def test_patch_scene_rejects_generation_status(service: VisualPlanService) -> None:
+    """System-managed field generation_status cannot be patched."""
+    run(service.save_plan(run_id=221, scenes=[_make_scene()]))
+
+    with pytest.raises(ValueError, match="immutable/unknown fields"):
+        run(
+            service.patch_scene(
+                run_id=221,
+                scene_id="sc-1",
+                updates={"generation_status": "completed"},
+            )
+        )
+
+
+def test_patch_scene_rejects_latest_asset_id(service: VisualPlanService) -> None:
+    """System-managed field latest_asset_id cannot be patched."""
+    run(service.save_plan(run_id=222, scenes=[_make_scene()]))
+
+    with pytest.raises(ValueError, match="immutable/unknown fields"):
+        run(
+            service.patch_scene(
+                run_id=222,
+                scene_id="sc-1",
+                updates={"latest_asset_id": 99},
+            )
+        )
+
+
+def test_patch_scene_rejects_unknown_field(service: VisualPlanService) -> None:
+    """Completely unknown fields are rejected."""
+    run(service.save_plan(run_id=223, scenes=[_make_scene()]))
+
+    with pytest.raises(ValueError, match="immutable/unknown fields"):
+        run(
+            service.patch_scene(
+                run_id=223,
+                scene_id="sc-1",
+                updates={"hackerfield": "pwned"},
             )
         )
 
@@ -210,11 +313,11 @@ def test_list_plan_versions_empty_for_missing(service: VisualPlanService) -> Non
 async def test_concurrent_saves_produce_unique_versions() -> None:
     """Two concurrent saves for the same run_id must produce distinct versions."""
     storage = InMemoryVisualPlanStorage()
-    service = VisualPlanService(storage)
+    svc = VisualPlanService(storage)
 
     results = await asyncio.gather(
-        service.save_plan(run_id=500, scenes=[_make_scene(prompt="A")]),
-        service.save_plan(run_id=500, scenes=[_make_scene(prompt="B")]),
+        svc.save_plan(run_id=500, scenes=[_make_scene(prompt="A")]),
+        svc.save_plan(run_id=500, scenes=[_make_scene(prompt="B")]),
     )
 
     versions = sorted(p.version for p in results)
@@ -252,3 +355,70 @@ def test_different_runs_have_independent_versions(service: VisualPlanService) ->
     assert plan_601.version == 2
     assert plan_602 is not None
     assert plan_602.version == 1
+
+
+# -- DataIntegrityError (malformed JSON) ---------------------------------------
+
+
+def test_parse_scenes_raises_on_invalid_json(service: VisualPlanService) -> None:
+    """Malformed JSON in scenes_json raises DataIntegrityError, not silent []."""
+    storage = service.storage
+    # Manually inject a corrupt row
+    import asyncio as _aio
+
+    async def _inject():
+        plans = storage._plans.setdefault(700, [])
+        plans.append({
+            "id": 9000,
+            "run_id": 700,
+            "version": 1,
+            "scenes_json": "{not valid json",
+            "created_at": __import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+        })
+
+    _aio.run(_inject())
+
+    with pytest.raises(DataIntegrityError, match="Malformed scenes_json"):
+        run(service.get_active_plan(700))
+
+
+def test_parse_scenes_raises_on_non_array_json(service: VisualPlanService) -> None:
+    """scenes_json that is valid JSON but not an array raises DataIntegrityError."""
+    storage = service.storage
+    import asyncio as _aio
+
+    async def _inject():
+        plans = storage._plans.setdefault(701, [])
+        plans.append({
+            "id": 9001,
+            "run_id": 701,
+            "version": 1,
+            "scenes_json": '{"not": "an array"}',
+            "created_at": __import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+        })
+
+    _aio.run(_inject())
+
+    with pytest.raises(DataIntegrityError, match="not a JSON array"):
+        run(service.get_active_plan(701))
+
+
+def test_parse_scenes_raises_on_invalid_scene_data(service: VisualPlanService) -> None:
+    """scenes_json with array of invalid scene objects raises DataIntegrityError."""
+    storage = service.storage
+    import asyncio as _aio
+
+    async def _inject():
+        plans = storage._plans.setdefault(702, [])
+        plans.append({
+            "id": 9002,
+            "run_id": 702,
+            "version": 1,
+            "scenes_json": '[{"missing": "required fields"}]',
+            "created_at": __import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+        })
+
+    _aio.run(_inject())
+
+    with pytest.raises(DataIntegrityError, match="Invalid scene data"):
+        run(service.get_active_plan(702))

--- a/packages/creator-service/tests/test_visual_plan_service.py
+++ b/packages/creator-service/tests/test_visual_plan_service.py
@@ -1,0 +1,254 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "creator-domain"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models.visual_plan import VisualScene  # type: ignore[reportMissingImports]
+from visual_plan_service import InMemoryVisualPlanStorage, VisualPlanService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def storage() -> InMemoryVisualPlanStorage:
+    return InMemoryVisualPlanStorage()
+
+
+@pytest.fixture
+def service(storage: InMemoryVisualPlanStorage) -> VisualPlanService:
+    return VisualPlanService(storage)
+
+
+def _make_scene(
+    scene_id: str = "sc-1",
+    section_id: str = "sec-1",
+    scene_index: int = 0,
+    section_type: str = "hook",
+    original_text: str = "Hook text",
+    prompt: str = "A dramatic opening shot",
+) -> VisualScene:
+    return VisualScene(
+        scene_id=scene_id,
+        section_id=section_id,
+        scene_index=scene_index,
+        section_type=section_type,
+        original_text=original_text,
+        prompt=prompt,
+    )
+
+
+# -- save_plan ---------------------------------------------------------------
+
+
+def test_save_plan_creates_version_1(service: VisualPlanService) -> None:
+    scenes = [_make_scene()]
+    plan = run(service.save_plan(run_id=101, scenes=scenes))
+
+    assert plan.run_id == 101
+    assert plan.version == 1
+    assert len(plan.scenes) == 1
+    assert plan.scenes[0].scene_id == "sc-1"
+
+
+def test_save_plan_increments_version(service: VisualPlanService) -> None:
+    scenes_v1 = [_make_scene(prompt="V1 prompt")]
+    scenes_v2 = [_make_scene(prompt="V2 prompt")]
+
+    run(service.save_plan(run_id=102, scenes=scenes_v1))
+    second = run(service.save_plan(run_id=102, scenes=scenes_v2))
+
+    assert second.version == 2
+    assert second.scenes[0].prompt == "V2 prompt"
+
+
+def test_save_plan_preserves_all_scene_fields(service: VisualPlanService) -> None:
+    scene = VisualScene(
+        scene_id="sc-full",
+        section_id="sec-full",
+        scene_index=2,
+        section_type="body",
+        original_text="Body text",
+        prompt="Detailed body shot",
+        prompt_edited=True,
+        prompt_source="user_edited",
+        style_tags=["cinematic", "dark"],
+        mood="tense",
+        composition="close-up",
+        generation_status="completed",
+        latest_asset_id=42,
+    )
+    plan = run(service.save_plan(run_id=103, scenes=[scene]))
+
+    saved_scene = plan.scenes[0]
+    assert saved_scene.prompt_edited is True
+    assert saved_scene.prompt_source == "user_edited"
+    assert saved_scene.style_tags == ["cinematic", "dark"]
+    assert saved_scene.mood == "tense"
+    assert saved_scene.composition == "close-up"
+    assert saved_scene.generation_status == "completed"
+    assert saved_scene.latest_asset_id == 42
+
+
+def test_save_plan_multi_scene(service: VisualPlanService) -> None:
+    scenes = [
+        _make_scene(scene_id="sc-1", scene_index=0, section_type="hook"),
+        _make_scene(scene_id="sc-2", scene_index=1, section_type="body"),
+        _make_scene(scene_id="sc-3", scene_index=2, section_type="cta"),
+    ]
+    plan = run(service.save_plan(run_id=104, scenes=scenes))
+
+    assert len(plan.scenes) == 3
+    assert [s.scene_id for s in plan.scenes] == ["sc-1", "sc-2", "sc-3"]
+    assert [s.scene_index for s in plan.scenes] == [0, 1, 2]
+
+
+# -- patch_scene --------------------------------------------------------------
+
+
+def test_patch_scene_updates_prompt(service: VisualPlanService) -> None:
+    scenes = [
+        _make_scene(scene_id="sc-1", prompt="Original prompt"),
+        _make_scene(scene_id="sc-2", scene_index=1, prompt="Keep this"),
+    ]
+    run(service.save_plan(run_id=201, scenes=scenes))
+
+    plan = run(
+        service.patch_scene(
+            run_id=201,
+            scene_id="sc-1",
+            updates={"prompt": "Edited prompt", "prompt_edited": True},
+        )
+    )
+
+    assert plan.version == 2
+    patched = next(s for s in plan.scenes if s.scene_id == "sc-1")
+    assert patched.prompt == "Edited prompt"
+    assert patched.prompt_edited is True
+
+    untouched = next(s for s in plan.scenes if s.scene_id == "sc-2")
+    assert untouched.prompt == "Keep this"
+
+
+def test_patch_scene_updates_generation_status(service: VisualPlanService) -> None:
+    scenes = [_make_scene(scene_id="sc-1")]
+    run(service.save_plan(run_id=202, scenes=scenes))
+
+    plan = run(
+        service.patch_scene(
+            run_id=202,
+            scene_id="sc-1",
+            updates={"generation_status": "completed", "latest_asset_id": 99},
+        )
+    )
+
+    assert plan.scenes[0].generation_status == "completed"
+    assert plan.scenes[0].latest_asset_id == 99
+
+
+def test_patch_scene_raises_when_no_active_plan(service: VisualPlanService) -> None:
+    with pytest.raises(ValueError, match="No active visual plan"):
+        run(service.patch_scene(run_id=999, scene_id="sc-1", updates={"prompt": "x"}))
+
+
+def test_patch_scene_raises_when_scene_not_found(service: VisualPlanService) -> None:
+    scenes = [_make_scene(scene_id="sc-1")]
+    run(service.save_plan(run_id=203, scenes=scenes))
+
+    with pytest.raises(ValueError, match="Scene 'sc-missing' not found"):
+        run(
+            service.patch_scene(
+                run_id=203, scene_id="sc-missing", updates={"prompt": "x"}
+            )
+        )
+
+
+# -- get_active_plan -----------------------------------------------------------
+
+
+def test_get_active_plan_returns_latest(service: VisualPlanService) -> None:
+    run(service.save_plan(run_id=301, scenes=[_make_scene(prompt="V1")]))
+    run(service.save_plan(run_id=301, scenes=[_make_scene(prompt="V2")]))
+
+    active = run(service.get_active_plan(301))
+
+    assert active is not None
+    assert active.version == 2
+    assert active.scenes[0].prompt == "V2"
+
+
+def test_get_active_plan_returns_none_for_missing(service: VisualPlanService) -> None:
+    assert run(service.get_active_plan(9999)) is None
+
+
+# -- list_plan_versions --------------------------------------------------------
+
+
+def test_list_plan_versions_returns_newest_first(service: VisualPlanService) -> None:
+    run(service.save_plan(run_id=401, scenes=[_make_scene(prompt="V1")]))
+    run(service.save_plan(run_id=401, scenes=[_make_scene(prompt="V2")]))
+    run(service.save_plan(run_id=401, scenes=[_make_scene(prompt="V3")]))
+
+    plans = run(service.list_plan_versions(401))
+
+    assert [p.version for p in plans] == [3, 2, 1]
+
+
+def test_list_plan_versions_empty_for_missing(service: VisualPlanService) -> None:
+    assert run(service.list_plan_versions(9999)) == []
+
+
+# -- Concurrent saves ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_produce_unique_versions() -> None:
+    """Two concurrent saves for the same run_id must produce distinct versions."""
+    storage = InMemoryVisualPlanStorage()
+    service = VisualPlanService(storage)
+
+    results = await asyncio.gather(
+        service.save_plan(run_id=500, scenes=[_make_scene(prompt="A")]),
+        service.save_plan(run_id=500, scenes=[_make_scene(prompt="B")]),
+    )
+
+    versions = sorted(p.version for p in results)
+    assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_across_service_instances() -> None:
+    """Two service instances sharing storage must still produce unique versions."""
+    storage = InMemoryVisualPlanStorage()
+    service_a = VisualPlanService(storage)
+    service_b = VisualPlanService(storage)
+
+    results = await asyncio.gather(
+        service_a.save_plan(run_id=501, scenes=[_make_scene(prompt="A")]),
+        service_b.save_plan(run_id=501, scenes=[_make_scene(prompt="B")]),
+    )
+
+    versions = sorted(p.version for p in results)
+    assert versions == [1, 2], f"Expected unique versions [1, 2], got {versions}"
+
+
+# -- Isolation between runs ----------------------------------------------------
+
+
+def test_different_runs_have_independent_versions(service: VisualPlanService) -> None:
+    run(service.save_plan(run_id=601, scenes=[_make_scene(prompt="Run601 V1")]))
+    run(service.save_plan(run_id=602, scenes=[_make_scene(prompt="Run602 V1")]))
+    run(service.save_plan(run_id=601, scenes=[_make_scene(prompt="Run601 V2")]))
+
+    plan_601 = run(service.get_active_plan(601))
+    plan_602 = run(service.get_active_plan(602))
+
+    assert plan_601 is not None
+    assert plan_601.version == 2
+    assert plan_602 is not None
+    assert plan_602.version == 1

--- a/packages/creator-service/visual_asset_service.py
+++ b/packages/creator-service/visual_asset_service.py
@@ -1,1 +1,292 @@
-"""Placeholder for visual_asset_service."""
+"""Visual asset service for scene-versioned image storage and selection.
+
+Manages image assets generated for visual-plan scenes.  Each scene can have
+multiple asset versions (e.g. regenerations).  Exactly one asset per scene
+is marked *active* at any time.
+
+Follows the same Protocol \u2192 InMemory \u2192 Service pattern as
+VisualPlanService and ScriptService.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+_DOMAIN_DIR = str(Path(__file__).resolve().parent.parent / "creator-domain")
+if _DOMAIN_DIR not in sys.path:
+    sys.path.insert(0, _DOMAIN_DIR)
+
+from models.visual_asset import VisualAsset  # type: ignore[reportMissingImports]  # noqa: E402, I001
+
+
+# ---------------------------------------------------------------------------
+# Storage Protocol
+# ---------------------------------------------------------------------------
+
+
+class VisualAssetStorageBackend(Protocol):
+    async def save_asset(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist a visual asset row and return stored row with id assigned.
+
+        The storage backend atomically allocates the next version number
+        for the given ``(run_id, scene_id)`` pair.  Callers MUST NOT
+        include ``version`` in *row*; the returned dict MUST contain the
+        allocated ``version``.
+        """
+        ...
+
+    async def get_asset(self, asset_id: int) -> dict[str, Any] | None:
+        """Fetch a single asset by id."""
+        ...
+
+    async def list_assets_by_scene(
+        self, run_id: int, scene_id: str
+    ) -> list[dict[str, Any]]:
+        """List all asset versions for a scene, newest first."""
+        ...
+
+    async def list_assets_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        """List all assets for a run, grouped by scene_id then newest first."""
+        ...
+
+    async def set_active(
+        self, run_id: int, scene_id: str, asset_id: int
+    ) -> bool:
+        """Mark *asset_id* as active for the given scene and deactivate others.
+
+        Returns True if the asset was found and activated, False otherwise.
+        """
+        ...
+
+    async def get_active_asset(
+        self, run_id: int, scene_id: str
+    ) -> dict[str, Any] | None:
+        """Fetch the currently active asset for a scene."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-Memory Storage
+# ---------------------------------------------------------------------------
+
+
+class InMemoryVisualAssetStorage:
+    """In-memory storage with atomic per-(run_id, scene_id) version allocation."""
+
+    def __init__(self) -> None:
+        self._assets: list[dict[str, Any]] = []
+        self._next_id = 1
+        self._scene_locks: dict[tuple[int, str], asyncio.Lock] = {}
+
+    async def save_asset(self, row: dict[str, Any]) -> dict[str, Any]:
+        run_id = row["run_id"]
+        scene_id = row["scene_id"]
+        key = (run_id, scene_id)
+        lock = self._scene_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            # Compute next version for this scene
+            scene_assets = [
+                a for a in self._assets
+                if a["run_id"] == run_id and a["scene_id"] == scene_id
+            ]
+            next_version = max((a["version"] for a in scene_assets), default=0) + 1
+            now = datetime.now(timezone.utc)
+            saved = {
+                "id": self._next_id,
+                "version": next_version,
+                "created_at": now,
+                **row,
+            }
+            self._next_id += 1
+            self._assets.append(saved)
+        return dict(saved)
+
+    async def get_asset(self, asset_id: int) -> dict[str, Any] | None:
+        for a in self._assets:
+            if a["id"] == asset_id:
+                return dict(a)
+        return None
+
+    async def list_assets_by_scene(
+        self, run_id: int, scene_id: str
+    ) -> list[dict[str, Any]]:
+        scene_assets = [
+            a for a in self._assets
+            if a["run_id"] == run_id and a["scene_id"] == scene_id
+        ]
+        return [
+            dict(a)
+            for a in sorted(scene_assets, key=lambda x: x["version"], reverse=True)
+        ]
+
+    async def list_assets_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        run_assets = [a for a in self._assets if a["run_id"] == run_id]
+        # Sort by scene_id ASC, then version DESC within each scene
+        return [
+            dict(a)
+            for a in sorted(
+                run_assets,
+                key=lambda x: (x["scene_id"], -x["version"]),
+            )
+        ]
+
+    async def set_active(
+        self, run_id: int, scene_id: str, asset_id: int
+    ) -> bool:
+        key = (run_id, scene_id)
+        lock = self._scene_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            found = False
+            for a in self._assets:
+                if a["run_id"] == run_id and a["scene_id"] == scene_id:
+                    if a["id"] == asset_id:
+                        a["is_active"] = True
+                        found = True
+                    else:
+                        a["is_active"] = False
+            return found
+
+    async def get_active_asset(
+        self, run_id: int, scene_id: str
+    ) -> dict[str, Any] | None:
+        for a in self._assets:
+            if (
+                a["run_id"] == run_id
+                and a["scene_id"] == scene_id
+                and a.get("is_active", False)
+            ):
+                return dict(a)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class VisualAssetService:
+    def __init__(self, storage: VisualAssetStorageBackend | None = None) -> None:
+        self.storage = storage if storage is not None else InMemoryVisualAssetStorage()
+
+    # -- Create -------------------------------------------------------------
+
+    async def create_asset(
+        self,
+        run_id: int,
+        scene_id: str,
+        asset_path: str,
+        *,
+        prompt_snapshot: str | None = None,
+        model_used: str | None = None,
+        provider_type: str | None = None,
+        is_active: bool = True,
+    ) -> VisualAsset:
+        """Create a new asset version for a scene.
+
+        If *is_active* is True (default), any previously-active asset for
+        the same scene is deactivated first.
+
+        Version allocation is delegated to the storage backend to
+        guarantee atomicity.
+        """
+        row = {
+            "run_id": run_id,
+            "scene_id": scene_id,
+            "asset_path": asset_path,
+            "prompt_snapshot": prompt_snapshot,
+            "model_used": model_used,
+            "provider": provider_type,  # DB column is 'provider'
+            "is_active": is_active,
+        }
+        saved = await self.storage.save_asset(row)
+
+        # If this asset should be active, deactivate others
+        if is_active:
+            await self.storage.set_active(run_id, scene_id, saved["id"])
+
+        return self._row_to_asset(saved)
+
+    # -- Select active ------------------------------------------------------
+
+    async def select_active(
+        self,
+        run_id: int,
+        scene_id: str,
+        asset_id: int,
+    ) -> VisualAsset:
+        """Set the given asset as active for its scene.
+
+        Raises ValueError if the asset is not found or doesn't belong
+        to the specified run/scene.
+        """
+        asset_row = await self.storage.get_asset(asset_id)
+        if asset_row is None:
+            raise ValueError(f"Asset {asset_id} not found")
+        if asset_row["run_id"] != run_id or asset_row["scene_id"] != scene_id:
+            raise ValueError(
+                f"Asset {asset_id} does not belong to run {run_id} "
+                f"scene '{scene_id}'"
+            )
+
+        success = await self.storage.set_active(run_id, scene_id, asset_id)
+        if not success:
+            raise ValueError(f"Failed to activate asset {asset_id}")
+
+        # Re-fetch to get updated is_active state
+        updated = await self.storage.get_asset(asset_id)
+        return self._row_to_asset(updated)  # type: ignore[arg-type]
+
+    # -- Reads --------------------------------------------------------------
+
+    async def list_by_scene(
+        self, run_id: int, scene_id: str
+    ) -> list[VisualAsset]:
+        """List all asset versions for a scene, newest first."""
+        rows = await self.storage.list_assets_by_scene(run_id, scene_id)
+        return [self._row_to_asset(r) for r in rows]
+
+    async def list_by_run(self, run_id: int) -> dict[str, list[VisualAsset]]:
+        """List all assets for a run, grouped by scene_id.
+
+        Returns a dict mapping scene_id \u2192 list[VisualAsset] (newest first
+        within each scene).
+        """
+        rows = await self.storage.list_assets_by_run(run_id)
+        grouped: dict[str, list[VisualAsset]] = {}
+        for row in rows:
+            asset = self._row_to_asset(row)
+            grouped.setdefault(asset.scene_id, []).append(asset)
+        return grouped
+
+    async def get_active_asset(
+        self, run_id: int, scene_id: str
+    ) -> VisualAsset | None:
+        """Get the currently active asset for a scene."""
+        row = await self.storage.get_active_asset(run_id, scene_id)
+        if row is None:
+            return None
+        return self._row_to_asset(row)
+
+    async def get_asset(self, asset_id: int) -> VisualAsset | None:
+        """Get a single asset by id."""
+        row = await self.storage.get_asset(asset_id)
+        if row is None:
+            return None
+        return self._row_to_asset(row)
+
+    # -- Internal -----------------------------------------------------------
+
+    @staticmethod
+    def _row_to_asset(row: dict[str, Any]) -> VisualAsset:
+        """Convert a storage row to a VisualAsset domain model.
+
+        Handles the provider\u2192provider_type column mapping.
+        """
+        return VisualAsset.from_row(row)
+
+
+visual_asset_service = VisualAssetService()

--- a/packages/creator-service/visual_asset_service.py
+++ b/packages/creator-service/visual_asset_service.py
@@ -32,10 +32,17 @@ class VisualAssetStorageBackend(Protocol):
     async def save_asset(self, row: dict[str, Any]) -> dict[str, Any]:
         """Persist a visual asset row and return stored row with id assigned.
 
-        The storage backend atomically allocates the next version number
-        for the given ``(run_id, scene_id)`` pair.  Callers MUST NOT
-        include ``version`` in *row*; the returned dict MUST contain the
-        allocated ``version``.
+        The storage backend atomically:
+        1. Allocates the next version number for ``(run_id, scene_id)``.
+        2. If ``row["is_active"]`` is True, deactivates any previously-active
+           asset for the same ``(run_id, scene_id)``.
+        3. Inserts the new row.
+
+        All three steps MUST execute under a single lock/transaction so that
+        concurrent creates cannot produce two active assets for one scene.
+
+        Callers MUST NOT include ``version`` in *row*; the returned dict
+        MUST contain the allocated ``version``.
         """
         ...
 
@@ -88,6 +95,15 @@ class InMemoryVisualAssetStorage:
         key = (run_id, scene_id)
         lock = self._scene_locks.setdefault(key, asyncio.Lock())
         async with lock:
+            # Deactivate previous active if this asset should be active.
+            if row.get("is_active", False):
+                for a in self._assets:
+                    if (
+                        a["run_id"] == run_id
+                        and a["scene_id"] == scene_id
+                        and a.get("is_active", False)
+                    ):
+                        a["is_active"] = False
             # Compute next version for this scene
             scene_assets = [
                 a for a in self._assets
@@ -188,10 +204,10 @@ class VisualAssetService:
         """Create a new asset version for a scene.
 
         If *is_active* is True (default), any previously-active asset for
-        the same scene is deactivated first.
-
-        Version allocation is delegated to the storage backend to
-        guarantee atomicity.
+        the same scene is deactivated first.  Version allocation AND
+        deactivation are delegated to the storage backend as a single
+        atomic operation (under one lock) to prevent race conditions
+        between concurrent creates.
         """
         row = {
             "run_id": run_id,
@@ -202,11 +218,9 @@ class VisualAssetService:
             "provider": provider_type,  # DB column is 'provider'
             "is_active": is_active,
         }
+        # save_asset atomically: allocates version, deactivates previous
+        # active (when is_active=True), and inserts — all under one lock.
         saved = await self.storage.save_asset(row)
-
-        # If this asset should be active, deactivate others
-        if is_active:
-            await self.storage.set_active(run_id, scene_id, saved["id"])
 
         return self._row_to_asset(saved)
 

--- a/packages/creator-service/visual_plan_service.py
+++ b/packages/creator-service/visual_plan_service.py
@@ -22,6 +22,40 @@ from models.visual_plan import VisualPlan, VisualScene  # type: ignore[reportMis
 
 
 # ---------------------------------------------------------------------------
+# Patchable field allowlist
+# ---------------------------------------------------------------------------
+
+# Fields that patch_scene is allowed to modify.  Immutable identity fields
+# (scene_id, section_id, scene_index, section_type, original_text) and
+# system-managed fields (latest_asset_id, generation_status) are excluded.
+_PATCHABLE_SCENE_FIELDS: frozenset[str] = frozenset({
+    "prompt",
+    "prompt_edited",
+    "prompt_source",
+    "style_tags",
+    "mood",
+    "composition",
+})
+
+
+class VersionConflictError(Exception):
+    """Raised when a patch targets a stale plan version."""
+
+    def __init__(self, run_id: int, expected: int, actual: int) -> None:
+        self.run_id = run_id
+        self.expected_version = expected
+        self.actual_version = actual
+        super().__init__(
+            f"Version conflict for run {run_id}: "
+            f"expected version {expected}, active is {actual}"
+        )
+
+
+class DataIntegrityError(Exception):
+    """Raised when stored scenes_json is malformed or unparseable."""
+
+
+# ---------------------------------------------------------------------------
 # Storage Protocol
 # ---------------------------------------------------------------------------
 
@@ -129,18 +163,34 @@ class VisualPlanService:
         run_id: int,
         scene_id: str,
         updates: dict[str, Any],
+        *,
+        expected_version: int | None = None,
     ) -> VisualPlan:
         """Patch a single scene in the active plan and save a new version.
 
-        Loads the active plan, applies *updates* to the scene matching
-        *scene_id*, then persists the entire plan as a new version.
+        Loads the active plan, validates *expected_version* if provided,
+        applies *updates* (restricted to patchable fields) to the scene
+        matching *scene_id*, then persists the entire plan as a new version.
 
         Raises:
-            ValueError: If no active plan exists or scene_id not found.
+            ValueError: If no active plan, scene_id not found, or unknown keys.
+            VersionConflictError: If expected_version doesn't match active version.
         """
+        # Validate update keys against allowlist
+        unknown_keys = set(updates.keys()) - _PATCHABLE_SCENE_FIELDS
+        if unknown_keys:
+            raise ValueError(
+                f"Cannot patch immutable/unknown fields: {sorted(unknown_keys)}"
+            )
+
         active_row = await self.storage.get_active_plan(run_id)
         if active_row is None:
             raise ValueError(f"No active visual plan for run {run_id}")
+
+        # Optimistic concurrency check
+        active_version = active_row.get("version", 1)
+        if expected_version is not None and active_version != expected_version:
+            raise VersionConflictError(run_id, expected_version, active_version)
 
         scenes = self._parse_scenes(active_row)
         patched = False
@@ -178,27 +228,41 @@ class VisualPlanService:
 
     @staticmethod
     def _parse_scenes(row: dict[str, Any]) -> list[VisualScene]:
-        """Parse scenes_json from a storage row into domain objects."""
+        """Parse scenes_json from a storage row into domain objects.
+
+        Raises DataIntegrityError if the stored JSON is malformed or
+        contains invalid scene data — callers should NOT silently
+        swallow corruption.
+        """
         scenes_json = row.get("scenes_json")
         if not scenes_json:
             return []
         try:
             data = json.loads(scenes_json)
+        except json.JSONDecodeError as exc:
+            raise DataIntegrityError(
+                f"Malformed scenes_json for run {row.get('run_id')}: {exc}"
+            ) from exc
+
+        if not isinstance(data, list):
+            raise DataIntegrityError(
+                f"scenes_json for run {row.get('run_id')} is not a JSON array"
+            )
+
+        try:
             return [VisualScene.model_validate(s) for s in data]
-        except (json.JSONDecodeError, Exception):
-            return []
+        except Exception as exc:
+            raise DataIntegrityError(
+                f"Invalid scene data for run {row.get('run_id')}: {exc}"
+            ) from exc
 
     @staticmethod
     def _row_to_plan(row: dict[str, Any]) -> VisualPlan:
-        """Convert a storage row to a VisualPlan domain model."""
-        scenes_json = row.get("scenes_json")
-        scenes: list[VisualScene] = []
-        if scenes_json:
-            try:
-                data = json.loads(scenes_json)
-                scenes = [VisualScene.model_validate(s) for s in data]
-            except (json.JSONDecodeError, Exception):
-                scenes = []
+        """Convert a storage row to a VisualPlan domain model.
+
+        Raises DataIntegrityError on malformed scenes_json.
+        """
+        scenes = VisualPlanService._parse_scenes(row)
 
         return VisualPlan(
             id=row["id"],

--- a/packages/creator-service/visual_plan_service.py
+++ b/packages/creator-service/visual_plan_service.py
@@ -1,1 +1,212 @@
-"""Placeholder for visual_plan_service."""
+"""Visual plan service with versioned scene document storage.
+
+Provides persistence and versioning for visual plans — ordered scene
+documents that map script sections to image-generation prompts. Follows
+the same Protocol→InMemory→Service pattern as ScriptService.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+_DOMAIN_DIR = str(Path(__file__).resolve().parent.parent / "creator-domain")
+if _DOMAIN_DIR not in sys.path:
+    sys.path.insert(0, _DOMAIN_DIR)
+
+from models.visual_plan import VisualPlan, VisualScene  # type: ignore[reportMissingImports]  # noqa: E402, I001
+
+
+# ---------------------------------------------------------------------------
+# Storage Protocol
+# ---------------------------------------------------------------------------
+
+
+class VisualPlanStorageBackend(Protocol):
+    async def save_plan(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Persist a visual plan row and return stored row with version assigned.
+
+        The storage backend atomically allocates the next version number
+        for the given ``run_id``.  Callers MUST NOT include a ``version``
+        key in *row*; the returned dict MUST contain the allocated
+        ``version``.
+        """
+        ...
+
+    async def get_active_plan(self, run_id: int) -> dict[str, Any] | None:
+        """Fetch the active (latest version) plan for a run."""
+        ...
+
+    async def list_plan_versions(self, run_id: int) -> list[dict[str, Any]]:
+        """List all plan versions for a run, newest first."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-Memory Storage
+# ---------------------------------------------------------------------------
+
+
+class InMemoryVisualPlanStorage:
+    """In-memory storage with atomic per-run_id version allocation."""
+
+    def __init__(self) -> None:
+        self._plans: dict[int, list[dict[str, Any]]] = {}
+        self._next_id = 1
+        self._run_locks: dict[int, asyncio.Lock] = {}
+
+    async def save_plan(self, row: dict[str, Any]) -> dict[str, Any]:
+        run_id = row["run_id"]
+        lock = self._run_locks.setdefault(run_id, asyncio.Lock())
+        async with lock:
+            plans = self._plans.setdefault(run_id, [])
+            next_version = max((p["version"] for p in plans), default=0) + 1
+            now = datetime.now(timezone.utc)
+            saved = {
+                "id": self._next_id,
+                "created_at": now,
+                "version": next_version,
+                **row,
+            }
+            self._next_id += 1
+            plans.append(saved)
+        return dict(saved)
+
+    async def get_active_plan(self, run_id: int) -> dict[str, Any] | None:
+        plans = self._plans.get(run_id, [])
+        if not plans:
+            return None
+        return dict(max(plans, key=lambda p: p["version"]))
+
+    async def list_plan_versions(self, run_id: int) -> list[dict[str, Any]]:
+        plans = self._plans.get(run_id, [])
+        return [dict(p) for p in sorted(plans, key=lambda p: p["version"], reverse=True)]
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class VisualPlanService:
+    def __init__(self, storage: VisualPlanStorageBackend | None = None) -> None:
+        self.storage = storage if storage is not None else InMemoryVisualPlanStorage()
+
+    # -- Full replace -------------------------------------------------------
+
+    async def save_plan(
+        self,
+        run_id: int,
+        scenes: list[VisualScene],
+    ) -> VisualPlan:
+        """Save a new visual plan version (full replace).
+
+        Version allocation is delegated to the storage backend to
+        guarantee atomicity regardless of how many service instances
+        share the same backend.
+        """
+        scenes_json = json.dumps(
+            [scene.model_dump(mode="json") for scene in scenes]
+        )
+
+        row = await self.storage.save_plan(
+            {
+                "run_id": run_id,
+                "scenes_json": scenes_json,
+            }
+        )
+
+        return self._row_to_plan(row)
+
+    # -- Single-scene patch -------------------------------------------------
+
+    async def patch_scene(
+        self,
+        run_id: int,
+        scene_id: str,
+        updates: dict[str, Any],
+    ) -> VisualPlan:
+        """Patch a single scene in the active plan and save a new version.
+
+        Loads the active plan, applies *updates* to the scene matching
+        *scene_id*, then persists the entire plan as a new version.
+
+        Raises:
+            ValueError: If no active plan exists or scene_id not found.
+        """
+        active_row = await self.storage.get_active_plan(run_id)
+        if active_row is None:
+            raise ValueError(f"No active visual plan for run {run_id}")
+
+        scenes = self._parse_scenes(active_row)
+        patched = False
+
+        for i, scene in enumerate(scenes):
+            if scene.scene_id == scene_id:
+                scene_dict = scene.model_dump()
+                scene_dict.update(updates)
+                scenes[i] = VisualScene.model_validate(scene_dict)
+                patched = True
+                break
+
+        if not patched:
+            raise ValueError(
+                f"Scene '{scene_id}' not found in visual plan for run {run_id}"
+            )
+
+        return await self.save_plan(run_id, scenes)
+
+    # -- Reads --------------------------------------------------------------
+
+    async def get_active_plan(self, run_id: int) -> VisualPlan | None:
+        """Get the active (latest version) visual plan for a run."""
+        row = await self.storage.get_active_plan(run_id)
+        if row is None:
+            return None
+        return self._row_to_plan(row)
+
+    async def list_plan_versions(self, run_id: int) -> list[VisualPlan]:
+        """List all plan versions for a run, newest first."""
+        rows = await self.storage.list_plan_versions(run_id)
+        return [self._row_to_plan(row) for row in rows]
+
+    # -- Internal -----------------------------------------------------------
+
+    @staticmethod
+    def _parse_scenes(row: dict[str, Any]) -> list[VisualScene]:
+        """Parse scenes_json from a storage row into domain objects."""
+        scenes_json = row.get("scenes_json")
+        if not scenes_json:
+            return []
+        try:
+            data = json.loads(scenes_json)
+            return [VisualScene.model_validate(s) for s in data]
+        except (json.JSONDecodeError, Exception):
+            return []
+
+    @staticmethod
+    def _row_to_plan(row: dict[str, Any]) -> VisualPlan:
+        """Convert a storage row to a VisualPlan domain model."""
+        scenes_json = row.get("scenes_json")
+        scenes: list[VisualScene] = []
+        if scenes_json:
+            try:
+                data = json.loads(scenes_json)
+                scenes = [VisualScene.model_validate(s) for s in data]
+            except (json.JSONDecodeError, Exception):
+                scenes = []
+
+        return VisualPlan(
+            id=row["id"],
+            run_id=row["run_id"],
+            version=row.get("version", 1),
+            scenes=scenes,
+            created_at=row["created_at"],
+        )
+
+
+visual_plan_service = VisualPlanService()

--- a/packages/creator_domain
+++ b/packages/creator_domain
@@ -1,1 +1,0 @@
-creator-domain

--- a/packages/creator_domain
+++ b/packages/creator_domain
@@ -1,0 +1,1 @@
+creator-domain

--- a/packages/creator_provider
+++ b/packages/creator_provider
@@ -1,1 +1,0 @@
-creator-provider

--- a/packages/creator_provider
+++ b/packages/creator_provider
@@ -1,0 +1,1 @@
+creator-provider

--- a/packages/creator_service
+++ b/packages/creator_service
@@ -1,1 +1,0 @@
-creator-service

--- a/packages/creator_service
+++ b/packages/creator_service
@@ -1,0 +1,1 @@
+creator-service

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,9 @@
+target-version = "py312"
+line-length = 100
+
+[lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[format]
+quote-style = "double"

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
-ignore = ["E501"]
+ignore = ["E501", "UP017"]
 
 [format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
- Add `ReviewPage` component at `/review/:runId` for read-only review of pipeline outputs
- Conditionally fetches and displays: script, visual plan, visual assets, audio, subtitles, video
- Shows `PipelineStepper` for stage visualization, empty state for early stages
- "Edit in Project" links and "Back to Editor" CTA for navigation
- 9/9 tests pass

## Testing
- `npx vitest run src/__tests__/ReviewPage.test.tsx` — 9/9 pass

Closes #67