### PR TITLE
fix(#167): remove sys.path hacks from all app files

### DIFF
--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -1,22 +1,8 @@
 """FastAPI entrypoint for shorts_api."""
-# pyright: reportMissingImports=false
-
 import logging
-import os
-import sys
 
 from fastapi import FastAPI
-
-# Add packages to path for imports
-_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../..", "packages")
-sys.path.insert(0, _PACKAGES_DIR)
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
-
-try:
-    from creator_service.logging_config import setup_json_logging
-except ImportError:
-    from logging_config import setup_json_logging
+from creator_service.logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
 from shorts_api.routes.creator_projects import router as projects_router
 from shorts_api.routes.creator_runs import router as runs_router

--- a/apps/api/src/shorts_api/routes/creator_models.py
+++ b/apps/api/src/shorts_api/routes/creator_models.py
@@ -1,26 +1,10 @@
 """Routes for creator model management."""
-# pyright: reportMissingImports=false
-
 import logging
-import os
-import sys
 
 from fastapi import APIRouter, HTTPException, Query
-
-# Add packages to path for imports
-_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
-sys.path.insert(0, _PACKAGES_DIR)
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
-
-try:
-    from creator_provider.registry import ProviderRegistry
-    from creator_service.model_catalog_service import ModelCatalogService
-    from creator_service.model_health_service import ModelHealthService
-except ImportError:
-    from model_catalog_service import ModelCatalogService
-    from model_health_service import ModelHealthService
-    from registry import ProviderRegistry
+from creator_provider.registry import ProviderRegistry
+from creator_service.model_catalog_service import ModelCatalogService
+from creator_service.model_health_service import ModelHealthService
 
 logger = logging.getLogger(__name__)
 

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -1,23 +1,9 @@
 """Routes for creator project management."""
-# pyright: reportMissingImports=false
-
-import os
-import sys
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
-
-# Add packages to path for imports
-_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
-sys.path.insert(0, _PACKAGES_DIR)
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
-
-try:
-    from creator_service.project_service import project_service
-except ImportError:
-    from project_service import project_service
+from creator_service.project_service import project_service
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -1,33 +1,13 @@
 """Routes for creator run management."""
-# pyright: reportMissingImports=false
-
-import os
-import sys
-
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-
-# Add packages to path for imports
-_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
-sys.path.insert(0, _PACKAGES_DIR)
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
-
-try:
-    from creator_service.project_service import project_service
-    from creator_service.run_service import run_service
-    from creator_service.stage_review_service import stage_review_service
-    from creator_service.visual_asset_service import visual_asset_service
-    from creator_service.render_service import render_service
-    from creator_service.audio_service import audio_service
-    from creator_service.subtitle_service import subtitle_service
-except ImportError:
-    from project_service import project_service
-    from run_service import run_service
-    from stage_review_service import stage_review_service
-    from visual_asset_service import visual_asset_service
-    from render_service import render_service
-    from audio_service import audio_service
-    from subtitle_service import subtitle_service
+from creator_service.audio_service import audio_service
+from creator_service.project_service import project_service
+from creator_service.render_service import render_service
+from creator_service.run_service import run_service
+from creator_service.stage_review_service import stage_review_service
+from creator_service.subtitle_service import subtitle_service
+from creator_service.visual_asset_service import visual_asset_service
 
 
 def dispatch_generate_script(

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -1,43 +1,11 @@
 """Routes for creator script management."""
-# pyright: reportMissingImports=false
-
-import os
-import sys
-
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ValidationError
-
-# Add packages to path for imports
-_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
-sys.path.insert(0, _PACKAGES_DIR)
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-provider"))
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-domain"))
-
-try:
-    from creator_service.project_service import project_service
-except ImportError:
-    from project_service import project_service
-
-try:
-    from creator_service.run_service import run_service
-except ImportError:
-    from run_service import run_service
-
-try:
-    from creator_service.script_service import script_service
-except ImportError:
-    from script_service import script_service
-
-try:
-    from creator_service.markdown_parser import parse_markdown
-except ImportError:
-    from markdown_parser import parse_markdown
-
-try:
-    from creator_domain.models.script_draft import ScriptSection
-except ImportError:
-    from models.script_draft import ScriptSection
+from creator_domain.models.script_draft import ScriptSection
+from creator_service.markdown_parser import parse_markdown
+from creator_service.project_service import project_service
+from creator_service.run_service import run_service
+from creator_service.script_service import script_service
 
 router = APIRouter(prefix="/projects/{project_id}/script", tags=["script"])
 run_script_router = APIRouter(prefix="/runs/{run_id}/script", tags=["script"])

--- a/apps/api/src/shorts_api/routes/creator_visual_plan.py
+++ b/apps/api/src/shorts_api/routes/creator_visual_plan.py
@@ -1,32 +1,9 @@
 """Routes for creator visual plan management."""
-# pyright: reportMissingImports=false
-
-import os
-import sys
-
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict, ValidationError
-
-# Add packages to path for imports
-_PACKAGES_DIR = os.path.join(os.path.dirname(__file__), "../../../../..", "packages")
-sys.path.insert(0, _PACKAGES_DIR)
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-service"))
-sys.path.insert(0, os.path.join(_PACKAGES_DIR, "creator-domain"))
-
-try:
-    from creator_service.run_service import run_service
-except ImportError:
-    from run_service import run_service
-
-try:
-    from creator_service.visual_plan_service import VersionConflictError, visual_plan_service
-except ImportError:
-    from visual_plan_service import VersionConflictError, visual_plan_service
-
-try:
-    from creator_domain.models.visual_plan import VisualScene
-except ImportError:
-    from models.visual_plan import VisualScene
+from creator_domain.models.visual_plan import VisualScene
+from creator_service.run_service import run_service
+from creator_service.visual_plan_service import VersionConflictError, visual_plan_service
 
 router = APIRouter(prefix="/runs/{run_id}/visual-plan", tags=["visual-plan"])
 

--- a/apps/worker-orchestrator/celery_app.py
+++ b/apps/worker-orchestrator/celery_app.py
@@ -3,13 +3,9 @@
 
 import logging
 import os
-import sys
 
 from celery import Celery
 from celery.signals import after_setup_logger
-
-# Add packages to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../..", "packages"))
 
 from creator_service.logging_config import setup_json_logging
 

--- a/apps/worker-orchestrator/tasks/generate_audio.py
+++ b/apps/worker-orchestrator/tasks/generate_audio.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false
 """Celery task for run-level TTS audio generation via audio providers.
 
 Consumes an approved script draft and generates a single audio artifact
@@ -15,14 +14,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
 from datetime import datetime, timezone
 from typing import Any
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
 
 try:
     import redis
@@ -30,33 +23,12 @@ except ImportError:
     redis = None  # type: ignore[assignment]
 
 from celery_app import celery_app
-
-try:
-    from creator_domain.models.stage import RunStage
-except ImportError:
-    from models.stage import RunStage
-
-try:
-    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from creator_provider.registry import ProviderRegistry
-except ImportError:
-    from gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from registry import ProviderRegistry
-
-try:
-    from creator_service.run_service import run_service as _run_service
-except ImportError:
-    from run_service import run_service as _run_service
-
-try:
-    from creator_service.audio_service import audio_service as _audio_service
-except ImportError:
-    from audio_service import audio_service as _audio_service
-
-try:
-    from creator_service.script_service import script_service as _script_service
-except ImportError:
-    from script_service import script_service as _script_service
+from creator_domain.models.stage import RunStage
+from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+from creator_provider.registry import ProviderRegistry
+from creator_service.audio_service import audio_service as _audio_service
+from creator_service.run_service import run_service as _run_service
+from creator_service.script_service import script_service as _script_service
 
 logger = logging.getLogger(__name__)
 

--- a/apps/worker-orchestrator/tasks/generate_scene_image.py
+++ b/apps/worker-orchestrator/tasks/generate_scene_image.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false
 """Celery task for scene image generation via image providers.
 
 Consumes an approved visual plan and generates images for one or all scenes.
@@ -18,15 +17,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
 
 try:
     import redis
@@ -34,33 +27,12 @@ except ImportError:
     redis = None  # type: ignore[assignment]
 
 from celery_app import celery_app
-
-try:
-    from creator_domain.models.stage import RunStage
-except ImportError:
-    from models.stage import RunStage
-
-try:
-    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from creator_provider.registry import ProviderRegistry
-except ImportError:
-    from gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from registry import ProviderRegistry
-
-try:
-    from creator_service.run_service import run_service as _run_service
-except ImportError:
-    from run_service import run_service as _run_service
-
-try:
-    from creator_service.visual_plan_service import visual_plan_service as _visual_plan_service
-except ImportError:
-    from visual_plan_service import visual_plan_service as _visual_plan_service
-
-try:
-    from creator_service.visual_asset_service import visual_asset_service as _visual_asset_service
-except ImportError:
-    from visual_asset_service import visual_asset_service as _visual_asset_service
+from creator_domain.models.stage import RunStage
+from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+from creator_provider.registry import ProviderRegistry
+from creator_service.run_service import run_service as _run_service
+from creator_service.visual_asset_service import visual_asset_service as _visual_asset_service
+from creator_service.visual_plan_service import visual_plan_service as _visual_plan_service
 
 logger = logging.getLogger(__name__)
 

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false
 """Celery task for script generation via model providers."""
 
 from __future__ import annotations
@@ -6,14 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
 from datetime import datetime, timezone
 from typing import Any
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
 
 try:
     import redis
@@ -21,28 +14,11 @@ except ImportError:
     redis = None  # type: ignore[assignment]
 
 from celery_app import celery_app
-
-try:
-    from creator_domain.models.stage import RunStage
-except ImportError:
-    from models.stage import RunStage
-
-try:
-    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from creator_provider.registry import ProviderRegistry
-except ImportError:
-    from gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from registry import ProviderRegistry
-
-try:
-    from creator_service.run_service import run_service as _run_service
-except ImportError:
-    from run_service import run_service as _run_service
-
-try:
-    from creator_service.script_service import script_service as _script_service
-except ImportError:
-    from script_service import script_service as _script_service
+from creator_domain.models.stage import RunStage
+from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+from creator_provider.registry import ProviderRegistry
+from creator_service.run_service import run_service as _run_service
+from creator_service.script_service import script_service as _script_service
 
 logger = logging.getLogger(__name__)
 

--- a/apps/worker-orchestrator/tasks/generate_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_subtitles.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false
 """Celery task for run-level subtitle generation via subtitle providers.
 
 Consumes an approved script draft AND optionally audio artifact timing data
@@ -15,14 +14,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
 from datetime import datetime, timezone
 from typing import Any
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
 
 try:
     import redis
@@ -30,38 +23,13 @@ except ImportError:
     redis = None  # type: ignore[assignment]
 
 from celery_app import celery_app
-
-try:
-    from creator_domain.models.stage import RunStage
-except ImportError:
-    from models.stage import RunStage
-
-try:
-    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from creator_provider.registry import ProviderRegistry
-except ImportError:
-    from gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from registry import ProviderRegistry
-
-try:
-    from creator_service.run_service import run_service as _run_service
-except ImportError:
-    from run_service import run_service as _run_service
-
-try:
-    from creator_service.subtitle_service import subtitle_service as _subtitle_service
-except ImportError:
-    from subtitle_service import subtitle_service as _subtitle_service
-
-try:
-    from creator_service.script_service import script_service as _script_service
-except ImportError:
-    from script_service import script_service as _script_service
-
-try:
-    from creator_service.audio_service import audio_service as _audio_service
-except ImportError:
-    from audio_service import audio_service as _audio_service
+from creator_domain.models.stage import RunStage
+from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+from creator_provider.registry import ProviderRegistry
+from creator_service.audio_service import audio_service as _audio_service
+from creator_service.run_service import run_service as _run_service
+from creator_service.script_service import script_service as _script_service
+from creator_service.subtitle_service import subtitle_service as _subtitle_service
 
 logger = logging.getLogger(__name__)
 

--- a/apps/worker-orchestrator/tasks/generate_visual_plan.py
+++ b/apps/worker-orchestrator/tasks/generate_visual_plan.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false
 """Celery task for visual plan generation via LLM providers.
 
 Consumes an approved script draft and generates a visual plan — one scene
@@ -12,14 +11,8 @@ import asyncio
 import json
 import logging
 import os
-import sys
 from datetime import datetime, timezone
 from typing import Any
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
 
 try:
     import redis
@@ -27,38 +20,13 @@ except ImportError:
     redis = None  # type: ignore[assignment]
 
 from celery_app import celery_app
-
-try:
-    from creator_domain.models.stage import RunStage
-except ImportError:
-    from models.stage import RunStage
-
-try:
-    from creator_domain.models.visual_plan import VisualScene
-except ImportError:
-    from models.visual_plan import VisualScene
-
-try:
-    from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from creator_provider.registry import ProviderRegistry
-except ImportError:
-    from gpu_lock import acquire_gpu_lock, release_gpu_lock
-    from registry import ProviderRegistry
-
-try:
-    from creator_service.run_service import run_service as _run_service
-except ImportError:
-    from run_service import run_service as _run_service
-
-try:
-    from creator_service.script_service import script_service as _script_service
-except ImportError:
-    from script_service import script_service as _script_service
-
-try:
-    from creator_service.visual_plan_service import visual_plan_service as _visual_plan_service
-except ImportError:
-    from visual_plan_service import visual_plan_service as _visual_plan_service
+from creator_domain.models.stage import RunStage
+from creator_domain.models.visual_plan import VisualScene
+from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+from creator_provider.registry import ProviderRegistry
+from creator_service.run_service import run_service as _run_service
+from creator_service.script_service import script_service as _script_service
+from creator_service.visual_plan_service import visual_plan_service as _visual_plan_service
 
 logger = logging.getLogger(__name__)
 

--- a/apps/worker-orchestrator/tasks/render_video.py
+++ b/apps/worker-orchestrator/tasks/render_video.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 

--- a/apps/worker-orchestrator/tasks/render_video.py
+++ b/apps/worker-orchestrator/tasks/render_video.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false
 """Celery task for run-level video rendering via FFmpeg.
 
 Consumes active visual assets and optional audio/subtitle artifacts,
@@ -10,53 +9,18 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-service"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-provider"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../..", "packages", "creator-domain"))
-
 from celery_app import celery_app
-
-try:
-    from creator_domain.models.stage import RunStage
-except ImportError:
-    from models.stage import RunStage
-
-try:
-    from creator_service.run_service import run_service as _run_service
-except ImportError:
-    from run_service import run_service as _run_service
-
-try:
-    from creator_service.render_service import render_service as _render_service
-except ImportError:
-    from render_service import render_service as _render_service
-
-try:
-    from creator_service.visual_asset_service import visual_asset_service as _visual_asset_service
-except ImportError:
-    from visual_asset_service import visual_asset_service as _visual_asset_service
-
-try:
-    from creator_service.audio_service import audio_service as _audio_service
-except ImportError:
-    from audio_service import audio_service as _audio_service
-
-try:
-    from creator_service.subtitle_service import subtitle_service as _subtitle_service
-except ImportError:
-    from subtitle_service import subtitle_service as _subtitle_service
-
-try:
-    from creator_service.ffmpeg_service import FFmpegService, RenderInput
-    from creator_service.render_profile import RenderProfile
-except ImportError:
-    from ffmpeg_service import FFmpegService, RenderInput
-    from render_profile import RenderProfile
+from creator_domain.models.stage import RunStage
+from creator_service.audio_service import audio_service as _audio_service
+from creator_service.ffmpeg_service import FFmpegService, RenderInput
+from creator_service.render_profile import RenderProfile
+from creator_service.render_service import render_service as _render_service
+from creator_service.run_service import run_service as _run_service
+from creator_service.subtitle_service import subtitle_service as _subtitle_service
+from creator_service.visual_asset_service import visual_asset_service as _visual_asset_service
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Remove all `sys.path.insert()` calls from 13 application files
- Replace `try/except ImportError` fallbacks with direct absolute imports
- Remove `# pyright: reportMissingImports=false` from all files
- Remove unused `import os` and `import sys` where applicable

## Changes
- **6 API files**: Cleaned up path hacking and fallback imports
- **7 worker files**: Cleaned up path hacking and fallback imports, preserved intentional `try: import redis` patterns

## Verification
- Zero `sys.path.insert` remaining in `apps/`
- Zero `_PACKAGES_DIR` remaining in `apps/`
- Zero `reportMissingImports` remaining in `apps/`
- Intentional `try: import redis / except ImportError` preserved in 5 worker tasks

Closes #167