### PR TITLE
fix(#168): pip install shared packages in Dockerfiles

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,8 +2,12 @@
 FROM python:3.12-slim AS builder
 WORKDIR /build
 RUN pip install --no-cache-dir --upgrade pip
+COPY packages ./packages
 COPY apps/api/requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt \
+    ./packages/creator-domain \
+    ./packages/creator-service \
+    ./packages/creator-provider
 
 # --- runtime stage ---
 FROM python:3.12-slim AS runtime
@@ -12,8 +16,7 @@ COPY --from=builder /install /usr/local
 COPY apps/api/src ./src
 COPY apps/api/alembic.ini ./alembic.ini
 COPY apps/api/migrations ./migrations
-COPY packages ./packages
-ENV PYTHONPATH=/app/src:/app
+ENV PYTHONPATH=/app/src
 EXPOSE 8000
 CMD ["uvicorn", "shorts_api.main:app", "--host", "0.0.0.0", "--port", "8000"]
 

--- a/apps/worker-orchestrator/Dockerfile
+++ b/apps/worker-orchestrator/Dockerfile
@@ -2,8 +2,12 @@
 FROM python:3.12-slim AS builder
 WORKDIR /build
 RUN pip install --no-cache-dir --upgrade pip
+COPY packages ./packages
 COPY apps/worker-orchestrator/requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt \
+    ./packages/creator-domain \
+    ./packages/creator-service \
+    ./packages/creator-provider
 
 # --- runtime stage ---
 FROM python:3.12-slim AS runtime
@@ -11,8 +15,6 @@ WORKDIR /app
 COPY --from=builder /install /usr/local
 COPY apps/worker-orchestrator/tasks ./tasks
 COPY apps/worker-orchestrator/celery_app.py ./celery_app.py
-COPY packages ./packages
-ENV PYTHONPATH=/app:/app/packages
 CMD ["celery", "-A", "celery_app.celery_app", "worker", "--loglevel=info"]
 
 # --- dev stage ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
       - "8000:8000"
     volumes:
       - ./apps/api/src:/app/src
-      - ./packages:/app/packages
     env_file:
       - .env
     depends_on:
@@ -56,7 +55,6 @@ services:
     volumes:
       - ./apps/worker-orchestrator/tasks:/app/tasks
       - ./apps/worker-orchestrator/celery_app.py:/app/celery_app.py
-      - ./packages:/app/packages
       - ./data/artifacts:/app/data/artifacts
     env_file:
       - .env


### PR DESCRIPTION
## Summary
- Update API and Worker Dockerfiles to `pip install` shared packages in builder stage
- Remove `COPY packages ./packages` from runtime stages
- Remove `PYTHONPATH` hacks from Dockerfiles
- Remove `./packages:/app/packages` volume mounts from docker-compose.yml

## Changes
- `apps/api/Dockerfile`: pip install packages in builder, simplify PYTHONPATH
- `apps/worker-orchestrator/Dockerfile`: pip install packages in builder, remove PYTHONPATH
- `docker-compose.yml`: remove packages volume mounts from api and worker services

## Notes
- In dev mode, changes to `packages/` now require `docker compose build` to take effect
- This is intentional: shared packages are libraries, not application code

Closes #168