### PR TITLE
feat(#169): add PostgreSQL storage backends for all 9 creator services

### DIFF
--- a/apps/api/migrations/versions/006_create_creator_script_drafts.py
+++ b/apps/api/migrations/versions/006_create_creator_script_drafts.py
@@ -1,0 +1,46 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "006"
+down_revision: Union[str, None] = "005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_script_drafts",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "run_id",
+            sa.Integer(),
+            sa.ForeignKey("creator_runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("source_type", sa.String(length=50), nullable=False),
+        sa.Column("markdown_content", sa.Text(), nullable=True),
+        sa.Column("structured_script_json", sa.Text(), nullable=True),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_index("ix_creator_script_drafts_run_id", "creator_script_drafts", ["run_id"])
+    op.create_unique_constraint(
+        "uq_creator_script_drafts_run_version",
+        "creator_script_drafts",
+        ["run_id", "version"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_creator_script_drafts_run_version", "creator_script_drafts")
+    op.drop_index("ix_creator_script_drafts_run_id")
+    op.drop_table("creator_script_drafts")

--- a/apps/api/migrations/versions/007_create_creator_visual_plans.py
+++ b/apps/api/migrations/versions/007_create_creator_visual_plans.py
@@ -1,0 +1,44 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "007"
+down_revision: Union[str, None] = "006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "creator_visual_plans",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "run_id",
+            sa.Integer(),
+            sa.ForeignKey("creator_runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("scenes_json", sa.Text(), nullable=True),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_index("ix_creator_visual_plans_run_id", "creator_visual_plans", ["run_id"])
+    op.create_unique_constraint(
+        "uq_creator_visual_plans_run_version",
+        "creator_visual_plans",
+        ["run_id", "version"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_creator_visual_plans_run_version", "creator_visual_plans")
+    op.drop_index("ix_creator_visual_plans_run_id")
+    op.drop_table("creator_visual_plans")

--- a/packages/creator-service/creator_service/audio_service.py
+++ b/packages/creator-service/creator_service/audio_service.py
@@ -156,4 +156,14 @@ class AudioService:
         return AudioArtifact.from_row(row)
 
 
-audio_service = AudioService()
+def _create_storage() -> AudioStorageBackend:
+    import os
+
+    if os.getenv("DATABASE_URL"):
+        from .postgres_audio_storage import PostgresAudioStorage
+
+        return PostgresAudioStorage()
+    return InMemoryAudioStorage()
+
+
+audio_service = AudioService(_create_storage())

--- a/packages/creator-service/creator_service/db.py
+++ b/packages/creator-service/creator_service/db.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import asyncpg
+
+_pool: asyncpg.Pool | None = None
+_pool_lock = asyncio.Lock()
+
+
+async def get_pool() -> asyncpg.Pool:
+    global _pool
+    if _pool is not None:
+        return _pool
+
+    async with _pool_lock:
+        if _pool is not None:
+            return _pool
+
+        database_url = os.getenv("DATABASE_URL")
+        if not database_url:
+            raise RuntimeError("DATABASE_URL is required for Postgres storage")
+
+        _pool = await asyncpg.create_pool(database_url, min_size=2, max_size=10)
+        return _pool
+
+
+async def fetch_one(query: str, *args: Any) -> dict[str, Any] | None:
+    pool = await get_pool()
+    async with pool.acquire() as connection:
+        row = await connection.fetchrow(query, *args)
+    if row is None:
+        return None
+    return dict(row)
+
+
+async def fetch_all(query: str, *args: Any) -> list[dict[str, Any]]:
+    pool = await get_pool()
+    async with pool.acquire() as connection:
+        rows = await connection.fetch(query, *args)
+    return [dict(row) for row in rows]
+
+
+async def execute(query: str, *args: Any) -> str:
+    pool = await get_pool()
+    async with pool.acquire() as connection:
+        return await connection.execute(query, *args)

--- a/packages/creator-service/creator_service/postgres_audio_storage.py
+++ b/packages/creator-service/creator_service/postgres_audio_storage.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .db import fetch_all, fetch_one
+
+
+class PostgresAudioStorage:
+    async def save_artifact(self, row: dict[str, Any]) -> dict[str, Any]:
+        metadata_json = row.get("metadata_json")
+        if isinstance(metadata_json, dict):
+            metadata_payload: str | None = json.dumps(metadata_json)
+        else:
+            metadata_payload = metadata_json
+
+        saved = await fetch_one(
+            """
+            INSERT INTO creator_artifacts (
+                run_id,
+                artifact_type,
+                scene_id,
+                file_path,
+                file_size_bytes,
+                mime_type,
+                metadata_json
+            )
+            VALUES ($1, 'audio', $2, $3, $4, $5, $6)
+            RETURNING *
+            """,
+            row.get("run_id"),
+            row.get("scene_id"),
+            row.get("file_path"),
+            row.get("file_size_bytes"),
+            row.get("mime_type"),
+            metadata_payload,
+        )
+        if saved is None:
+            raise ValueError("Failed to save audio artifact")
+        return saved
+
+    async def get_artifact(self, artifact_id: int) -> dict[str, Any] | None:
+        return await fetch_one(
+            "SELECT * FROM creator_artifacts WHERE id = $1 AND artifact_type = 'audio'",
+            artifact_id,
+        )
+
+    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND artifact_type = 'audio'
+            ORDER BY created_at DESC
+            """,
+            run_id,
+        )
+
+    async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
+        return await fetch_one(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND artifact_type = 'audio'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            run_id,
+        )

--- a/packages/creator-service/creator_service/postgres_project_storage.py
+++ b/packages/creator-service/creator_service/postgres_project_storage.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .db import fetch_all, fetch_one
+
+
+class PostgresProjectStorage:
+    async def insert_project(self, payload: dict[str, Any]) -> dict[str, Any]:
+        row = await fetch_one(
+            """
+            INSERT INTO creator_projects (
+                title,
+                source_type,
+                idea_brief,
+                markdown_source,
+                url_source,
+                status
+            )
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING *
+            """,
+            payload.get("title"),
+            payload.get("source_type", "idea"),
+            payload.get("idea_brief"),
+            payload.get("markdown_source"),
+            payload.get("url_source"),
+            payload.get("status", "draft"),
+        )
+        if row is None:
+            raise ValueError("Failed to insert project")
+        return row
+
+    async def fetch_project(self, project_id: int) -> dict[str, Any] | None:
+        return await fetch_one("SELECT * FROM creator_projects WHERE id = $1", project_id)
+
+    async def list_projects(self, limit: int, offset: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_projects
+            ORDER BY created_at DESC, id DESC
+            LIMIT $1 OFFSET $2
+            """,
+            limit,
+            offset,
+        )
+
+    async def count_projects(self) -> int:
+        row = await fetch_one("SELECT COUNT(*) AS count FROM creator_projects")
+        if row is None:
+            return 0
+        return int(row["count"])
+
+    async def fetch_latest_run_summary(self, project_id: int) -> dict[str, int | str | None] | None:
+        row = await fetch_one(
+            """
+            SELECT id AS run_id, current_stage, status
+            FROM creator_runs
+            WHERE project_id = $1
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            project_id,
+        )
+        if row is None:
+            return None
+        return {
+            "run_id": row["run_id"],
+            "current_stage": row["current_stage"],
+            "status": row["status"],
+        }

--- a/packages/creator-service/creator_service/postgres_render_storage.py
+++ b/packages/creator-service/creator_service/postgres_render_storage.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .db import fetch_all, fetch_one
+
+
+class PostgresRenderStorage:
+    async def save_artifact(self, row: dict[str, Any]) -> dict[str, Any]:
+        metadata_json = row.get("metadata_json")
+        if isinstance(metadata_json, dict):
+            metadata_payload: str | None = json.dumps(metadata_json)
+        else:
+            metadata_payload = metadata_json
+
+        saved = await fetch_one(
+            """
+            INSERT INTO creator_artifacts (
+                run_id,
+                artifact_type,
+                scene_id,
+                file_path,
+                file_size_bytes,
+                mime_type,
+                metadata_json
+            )
+            VALUES ($1, 'video', $2, $3, $4, $5, $6)
+            RETURNING *
+            """,
+            row.get("run_id"),
+            row.get("scene_id"),
+            row.get("file_path"),
+            row.get("file_size_bytes"),
+            row.get("mime_type"),
+            metadata_payload,
+        )
+        if saved is None:
+            raise ValueError("Failed to save render artifact")
+        return saved
+
+    async def get_artifact(self, artifact_id: int) -> dict[str, Any] | None:
+        return await fetch_one(
+            "SELECT * FROM creator_artifacts WHERE id = $1 AND artifact_type = 'video'",
+            artifact_id,
+        )
+
+    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND artifact_type = 'video'
+            ORDER BY created_at DESC
+            """,
+            run_id,
+        )
+
+    async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
+        return await fetch_one(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND artifact_type = 'video'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            run_id,
+        )

--- a/packages/creator-service/creator_service/postgres_run_storage.py
+++ b/packages/creator-service/creator_service/postgres_run_storage.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .db import fetch_all, fetch_one
+
+_UPDATABLE_COLUMNS = {
+    "project_id",
+    "current_stage",
+    "status",
+    "review_stage",
+    "restart_from",
+    "model_defaults_json",
+    "metadata_json",
+    "style_preset",
+    "started_at",
+    "finished_at",
+}
+
+
+class PostgresRunStorage:
+    async def create_run(self, row: dict[str, Any]) -> dict[str, Any]:
+        saved = await fetch_one(
+            """
+            INSERT INTO creator_runs (
+                project_id,
+                current_stage,
+                status,
+                review_stage,
+                restart_from,
+                model_defaults_json,
+                metadata_json,
+                style_preset,
+                started_at,
+                finished_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            RETURNING *
+            """,
+            row.get("project_id"),
+            row.get("current_stage"),
+            row.get("status", "pending"),
+            row.get("review_stage"),
+            row.get("restart_from"),
+            row.get("model_defaults_json"),
+            row.get("metadata_json"),
+            row.get("style_preset"),
+            row.get("started_at"),
+            row.get("finished_at"),
+        )
+        if saved is None:
+            raise ValueError("Failed to create run")
+        return saved
+
+    async def get_run(self, run_id: int) -> dict[str, Any] | None:
+        return await fetch_one("SELECT * FROM creator_runs WHERE id = $1", run_id)
+
+    async def update_run(self, run_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        if not updates:
+            current = await self.get_run(run_id)
+            if current is None:
+                raise ValueError(f"Run {run_id} not found")
+            return current
+
+        invalid_columns = set(updates) - _UPDATABLE_COLUMNS
+        if invalid_columns:
+            invalid_list = ", ".join(sorted(invalid_columns))
+            raise ValueError(f"Invalid update columns: {invalid_list}")
+
+        keys = list(updates.keys())
+        assignments = ", ".join(f"{key} = ${idx}" for idx, key in enumerate(keys, start=2))
+        values = [run_id, *[updates[key] for key in keys]]
+        query = f"UPDATE creator_runs SET {assignments} WHERE id = $1 RETURNING *"
+        updated = await fetch_one(query, *values)
+        if updated is None:
+            raise ValueError(f"Run {run_id} not found")
+        return updated
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, Any],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        if not updates:
+            current = await self.get_run(run_id)
+            if current is None:
+                return False, None
+            if current.get("current_stage") in expected_stages:
+                return True, current
+            return False, current
+
+        invalid_columns = set(updates) - _UPDATABLE_COLUMNS
+        if invalid_columns:
+            invalid_list = ", ".join(sorted(invalid_columns))
+            raise ValueError(f"Invalid update columns: {invalid_list}")
+
+        keys = list(updates.keys())
+        assignments = ", ".join(f"{key} = ${idx}" for idx, key in enumerate(keys, start=3))
+        values = [run_id, list(expected_stages), *[updates[key] for key in keys]]
+        query = (
+            f"UPDATE creator_runs SET {assignments} "
+            "WHERE id = $1 AND current_stage = ANY($2::text[]) RETURNING *"
+        )
+        updated = await fetch_one(query, *values)
+        if updated is not None:
+            return True, updated
+        current = await self.get_run(run_id)
+        if current is None:
+            return False, None
+        return False, current
+
+    async def list_runs_by_project(self, project_id: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            "SELECT * FROM creator_runs WHERE project_id = $1 ORDER BY id DESC",
+            project_id,
+        )

--- a/packages/creator-service/creator_service/postgres_script_storage.py
+++ b/packages/creator-service/creator_service/postgres_script_storage.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .db import fetch_all, fetch_one, get_pool
+
+
+class PostgresScriptStorage:
+    async def save_draft(self, row: dict[str, Any]) -> dict[str, Any]:
+        run_id = row["run_id"]
+        pool = await get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock($1::int, $2::int)",
+                    6101,
+                    run_id,
+                )
+                await connection.fetch(
+                    "SELECT id FROM creator_script_drafts WHERE run_id = $1 FOR UPDATE",
+                    run_id,
+                )
+                version_row = await connection.fetchrow(
+                    "SELECT COALESCE(MAX(version), 0) + 1 AS next_version FROM creator_script_drafts WHERE run_id = $1",
+                    run_id,
+                )
+                next_version = int(version_row["next_version"]) if version_row is not None else 1
+                saved = await connection.fetchrow(
+                    """
+                    INSERT INTO creator_script_drafts (
+                        run_id,
+                        source_type,
+                        markdown_content,
+                        structured_script_json,
+                        version
+                    )
+                    VALUES ($1, $2, $3, $4, $5)
+                    RETURNING *
+                    """,
+                    run_id,
+                    row.get("source_type"),
+                    row.get("markdown_content"),
+                    row.get("structured_script_json"),
+                    next_version,
+                )
+        if saved is None:
+            raise ValueError("Failed to save script draft")
+        return dict(saved)
+
+    async def get_active_draft(self, run_id: int) -> dict[str, Any] | None:
+        return await fetch_one(
+            """
+            SELECT *
+            FROM creator_script_drafts
+            WHERE run_id = $1
+            ORDER BY version DESC
+            LIMIT 1
+            """,
+            run_id,
+        )
+
+    async def list_draft_versions(self, run_id: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_script_drafts
+            WHERE run_id = $1
+            ORDER BY version DESC
+            """,
+            run_id,
+        )

--- a/packages/creator-service/creator_service/postgres_stage_review_storage.py
+++ b/packages/creator-service/creator_service/postgres_stage_review_storage.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .db import fetch_one
+
+
+class PostgresStageReviewStorage:
+    async def create_review(self, row: dict[str, Any]) -> dict[str, Any]:
+        saved = await fetch_one(
+            """
+            INSERT INTO creator_stage_reviews (
+                run_id,
+                stage_name,
+                review_status,
+                reviewer,
+                notes
+            )
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING *
+            """,
+            row.get("run_id"),
+            row.get("stage_name"),
+            row.get("review_status"),
+            row.get("reviewer"),
+            row.get("notes"),
+        )
+        if saved is None:
+            raise ValueError("Failed to create stage review")
+        return saved
+
+    async def get_latest_review(self, run_id: int, stage_name: str) -> dict[str, Any] | None:
+        return await fetch_one(
+            """
+            SELECT *
+            FROM creator_stage_reviews
+            WHERE run_id = $1 AND stage_name = $2
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            run_id,
+            stage_name,
+        )

--- a/packages/creator-service/creator_service/postgres_subtitle_storage.py
+++ b/packages/creator-service/creator_service/postgres_subtitle_storage.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .db import fetch_all, fetch_one
+
+
+class PostgresSubtitleStorage:
+    async def save_artifact(self, row: dict[str, Any]) -> dict[str, Any]:
+        metadata_json = row.get("metadata_json")
+        if isinstance(metadata_json, dict):
+            metadata_payload: str | None = json.dumps(metadata_json)
+        else:
+            metadata_payload = metadata_json
+
+        saved = await fetch_one(
+            """
+            INSERT INTO creator_artifacts (
+                run_id,
+                artifact_type,
+                scene_id,
+                file_path,
+                file_size_bytes,
+                mime_type,
+                metadata_json
+            )
+            VALUES ($1, 'subtitle', $2, $3, $4, $5, $6)
+            RETURNING *
+            """,
+            row.get("run_id"),
+            row.get("scene_id"),
+            row.get("file_path"),
+            row.get("file_size_bytes"),
+            row.get("mime_type"),
+            metadata_payload,
+        )
+        if saved is None:
+            raise ValueError("Failed to save subtitle artifact")
+        return saved
+
+    async def get_artifact(self, artifact_id: int) -> dict[str, Any] | None:
+        return await fetch_one(
+            "SELECT * FROM creator_artifacts WHERE id = $1 AND artifact_type = 'subtitle'",
+            artifact_id,
+        )
+
+    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND artifact_type = 'subtitle'
+            ORDER BY created_at DESC
+            """,
+            run_id,
+        )
+
+    async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
+        return await fetch_one(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND artifact_type = 'subtitle'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            run_id,
+        )

--- a/packages/creator-service/creator_service/postgres_visual_asset_storage.py
+++ b/packages/creator-service/creator_service/postgres_visual_asset_storage.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .db import fetch_all, fetch_one, get_pool
+
+
+class PostgresVisualAssetStorage:
+    async def save_asset(self, row: dict[str, Any]) -> dict[str, Any]:
+        run_id = row["run_id"]
+        scene_id = row["scene_id"]
+        is_active = bool(row.get("is_active", False))
+
+        pool = await get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock($1::int, hashtext($2))",
+                    run_id,
+                    scene_id,
+                )
+                version_row = await connection.fetchrow(
+                    """
+                    SELECT COALESCE(MAX(version), 0) + 1 AS next_version
+                    FROM creator_scene_assets
+                    WHERE run_id = $1 AND scene_id = $2
+                    """,
+                    run_id,
+                    scene_id,
+                )
+                next_version = int(version_row["next_version"]) if version_row is not None else 1
+
+                if is_active:
+                    await connection.execute(
+                        """
+                        UPDATE creator_scene_assets
+                        SET is_active = false
+                        WHERE run_id = $1 AND scene_id = $2 AND is_active = true
+                        """,
+                        run_id,
+                        scene_id,
+                    )
+
+                saved = await connection.fetchrow(
+                    """
+                    INSERT INTO creator_scene_assets (
+                        run_id,
+                        scene_id,
+                        version,
+                        asset_path,
+                        prompt_snapshot,
+                        model_used,
+                        provider,
+                        is_active
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    RETURNING *
+                    """,
+                    run_id,
+                    scene_id,
+                    next_version,
+                    row.get("asset_path"),
+                    row.get("prompt_snapshot"),
+                    row.get("model_used"),
+                    row.get("provider"),
+                    is_active,
+                )
+        if saved is None:
+            raise ValueError("Failed to save visual asset")
+        return dict(saved)
+
+    async def get_asset(self, asset_id: int) -> dict[str, Any] | None:
+        return await fetch_one("SELECT * FROM creator_scene_assets WHERE id = $1", asset_id)
+
+    async def list_assets_by_scene(self, run_id: int, scene_id: str) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_scene_assets
+            WHERE run_id = $1 AND scene_id = $2
+            ORDER BY version DESC
+            """,
+            run_id,
+            scene_id,
+        )
+
+    async def list_assets_by_run(self, run_id: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_scene_assets
+            WHERE run_id = $1
+            ORDER BY scene_id ASC, version DESC
+            """,
+            run_id,
+        )
+
+    async def set_active(self, run_id: int, scene_id: str, asset_id: int) -> bool:
+        pool = await get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock($1::int, hashtext($2))",
+                    run_id,
+                    scene_id,
+                )
+                await connection.execute(
+                    """
+                    UPDATE creator_scene_assets
+                    SET is_active = false
+                    WHERE run_id = $1 AND scene_id = $2
+                    """,
+                    run_id,
+                    scene_id,
+                )
+                target = await connection.fetchrow(
+                    """
+                    UPDATE creator_scene_assets
+                    SET is_active = true
+                    WHERE run_id = $1 AND scene_id = $2 AND id = $3
+                    RETURNING id
+                    """,
+                    run_id,
+                    scene_id,
+                    asset_id,
+                )
+        return target is not None
+
+    async def get_active_asset(self, run_id: int, scene_id: str) -> dict[str, Any] | None:
+        return await fetch_one(
+            """
+            SELECT *
+            FROM creator_scene_assets
+            WHERE run_id = $1 AND scene_id = $2 AND is_active = true
+            LIMIT 1
+            """,
+            run_id,
+            scene_id,
+        )

--- a/packages/creator-service/creator_service/postgres_visual_plan_storage.py
+++ b/packages/creator-service/creator_service/postgres_visual_plan_storage.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .db import fetch_all, fetch_one, get_pool
+
+
+class PostgresVisualPlanStorage:
+    async def save_plan(self, row: dict[str, Any]) -> dict[str, Any]:
+        run_id = row["run_id"]
+        pool = await get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock($1::int, $2::int)",
+                    6102,
+                    run_id,
+                )
+                await connection.fetch(
+                    "SELECT id FROM creator_visual_plans WHERE run_id = $1 FOR UPDATE",
+                    run_id,
+                )
+                version_row = await connection.fetchrow(
+                    "SELECT COALESCE(MAX(version), 0) + 1 AS next_version FROM creator_visual_plans WHERE run_id = $1",
+                    run_id,
+                )
+                next_version = int(version_row["next_version"]) if version_row is not None else 1
+                saved = await connection.fetchrow(
+                    """
+                    INSERT INTO creator_visual_plans (
+                        run_id,
+                        scenes_json,
+                        version
+                    )
+                    VALUES ($1, $2, $3)
+                    RETURNING *
+                    """,
+                    run_id,
+                    row.get("scenes_json"),
+                    next_version,
+                )
+        if saved is None:
+            raise ValueError("Failed to save visual plan")
+        return dict(saved)
+
+    async def get_active_plan(self, run_id: int) -> dict[str, Any] | None:
+        return await fetch_one(
+            """
+            SELECT *
+            FROM creator_visual_plans
+            WHERE run_id = $1
+            ORDER BY version DESC
+            LIMIT 1
+            """,
+            run_id,
+        )
+
+    async def list_plan_versions(self, run_id: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_visual_plans
+            WHERE run_id = $1
+            ORDER BY version DESC
+            """,
+            run_id,
+        )

--- a/packages/creator-service/creator_service/project_service.py
+++ b/packages/creator-service/creator_service/project_service.py
@@ -184,4 +184,14 @@ class ProjectService:
         return await self.db.count_projects()
 
 
-project_service = ProjectService()
+def _create_storage() -> ProjectStorageBackend:
+    import os
+
+    if os.getenv("DATABASE_URL"):
+        from .postgres_project_storage import PostgresProjectStorage
+
+        return PostgresProjectStorage()
+    return InMemoryProjectStorage()
+
+
+project_service = ProjectService(_create_storage())

--- a/packages/creator-service/creator_service/render_service.py
+++ b/packages/creator-service/creator_service/render_service.py
@@ -10,7 +10,6 @@ VisualAssetService and ScriptService.
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
@@ -237,4 +236,14 @@ class RenderService:
         return VideoArtifact.from_row(row)
 
 
-render_service = RenderService()
+def _create_storage() -> RenderStorageBackend:
+    import os
+
+    if os.getenv("DATABASE_URL"):
+        from .postgres_render_storage import PostgresRenderStorage
+
+        return PostgresRenderStorage()
+    return InMemoryRenderStorage()
+
+
+render_service = RenderService(_create_storage())

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -203,4 +203,14 @@ class RunService:
         return [PipelineRun.from_row(r) for r in rows]
 
 
-run_service = RunService(InMemoryRunStorage())
+def _create_storage() -> RunStorageBackend:
+    import os
+
+    if os.getenv("DATABASE_URL"):
+        from .postgres_run_storage import PostgresRunStorage
+
+        return PostgresRunStorage()
+    return InMemoryRunStorage()
+
+
+run_service = RunService(_create_storage())

--- a/packages/creator-service/creator_service/script_service.py
+++ b/packages/creator-service/creator_service/script_service.py
@@ -152,4 +152,14 @@ class ScriptService:
         )
 
 
-script_service = ScriptService()
+def _create_storage() -> ScriptStorageBackend:
+    import os
+
+    if os.getenv("DATABASE_URL"):
+        from .postgres_script_storage import PostgresScriptStorage
+
+        return PostgresScriptStorage()
+    return InMemoryScriptStorage()
+
+
+script_service = ScriptService(_create_storage())

--- a/packages/creator-service/creator_service/stage_review_service.py
+++ b/packages/creator-service/creator_service/stage_review_service.py
@@ -156,10 +156,10 @@ class StageReviewService:
             }
         )
 
-        # 5. Build domain model from the CAS result
-        from run_service import PipelineRun  # noqa: E402 — avoid circular at module level
-
-        return PipelineRun.from_row(row)
+        updated_run = await run_service.get_run(run_id)
+        if updated_run is None:
+            raise ValueError(f"Run {run_id} not found")
+        return updated_run
 
     async def get_latest_review(
         self, run_id: int, stage_name: str
@@ -168,4 +168,14 @@ class StageReviewService:
         return await self.storage.get_latest_review(run_id, stage_name)
 
 
-stage_review_service = StageReviewService(InMemoryStageReviewStorage())
+def _create_storage() -> StageReviewStorageBackend:
+    import os
+
+    if os.getenv("DATABASE_URL"):
+        from .postgres_stage_review_storage import PostgresStageReviewStorage
+
+        return PostgresStageReviewStorage()
+    return InMemoryStageReviewStorage()
+
+
+stage_review_service = StageReviewService(_create_storage())

--- a/packages/creator-service/creator_service/subtitle_service.py
+++ b/packages/creator-service/creator_service/subtitle_service.py
@@ -156,4 +156,14 @@ class SubtitleService:
         return SubtitleArtifact.from_row(row)
 
 
-subtitle_service = SubtitleService()
+def _create_storage() -> SubtitleStorageBackend:
+    import os
+
+    if os.getenv("DATABASE_URL"):
+        from .postgres_subtitle_storage import PostgresSubtitleStorage
+
+        return PostgresSubtitleStorage()
+    return InMemorySubtitleStorage()
+
+
+subtitle_service = SubtitleService(_create_storage())

--- a/packages/creator-service/creator_service/visual_asset_service.py
+++ b/packages/creator-service/creator_service/visual_asset_service.py
@@ -246,7 +246,9 @@ class VisualAssetService:
 
         # Re-fetch to get updated is_active state
         updated = await self.storage.get_asset(asset_id)
-        return self._row_to_asset(updated)  # type: ignore[arg-type]
+        if updated is None:
+            raise ValueError(f"Asset {asset_id} not found")
+        return self._row_to_asset(updated)
 
     # -- Reads --------------------------------------------------------------
 
@@ -297,4 +299,14 @@ class VisualAssetService:
         return VisualAsset.from_row(row)
 
 
-visual_asset_service = VisualAssetService()
+def _create_storage() -> VisualAssetStorageBackend:
+    import os
+
+    if os.getenv("DATABASE_URL"):
+        from .postgres_visual_asset_storage import PostgresVisualAssetStorage
+
+        return PostgresVisualAssetStorage()
+    return InMemoryVisualAssetStorage()
+
+
+visual_asset_service = VisualAssetService(_create_storage())

--- a/packages/creator-service/creator_service/visual_plan_service.py
+++ b/packages/creator-service/creator_service/visual_plan_service.py
@@ -267,4 +267,14 @@ class VisualPlanService:
         )
 
 
-visual_plan_service = VisualPlanService()
+def _create_storage() -> VisualPlanStorageBackend:
+    import os
+
+    if os.getenv("DATABASE_URL"):
+        from .postgres_visual_plan_storage import PostgresVisualPlanStorage
+
+        return PostgresVisualPlanStorage()
+    return InMemoryVisualPlanStorage()
+
+
+visual_plan_service = VisualPlanService(_create_storage())

--- a/packages/creator-service/pyproject.toml
+++ b/packages/creator-service/pyproject.toml
@@ -3,7 +3,7 @@ name = "creator-service"
 version = "0.1.0"
 description = "Service layer for short-form pipeline"
 requires-python = ">=3.10"
-dependencies = ["creator-domain>=0.1.0", "pydantic>=2.0"]
+dependencies = ["creator-domain>=0.1.0", "pydantic>=2.0", "asyncpg>=0.29.0"]
 
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
@@ -11,3 +11,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 include = ["creator_service", "creator_service.*"]
+
+[tool.basedpyright]
+typeCheckingMode = "basic"
+reportMissingTypeStubs = false
+reportUnknownMemberType = false
+extraPaths = ["../creator-domain"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,8 @@ members = [
 typeCheckingMode = "basic"
 reportMissingTypeStubs = false
 reportUnknownMemberType = false
+extraPaths = [
+  "packages/creator-domain",
+  "packages/creator-service",
+  "packages/creator-provider",
+]


### PR DESCRIPTION
## Summary

Implements PostgreSQL storage backends for all 9 creator-service Protocols, replacing in-memory stores when `DATABASE_URL` is set.

### Changes

**New files (12):**
- `packages/creator-service/creator_service/db.py` — Async connection pool using asyncpg with lazy init
- 8 Postgres storage backends (`postgres_*_storage.py`) matching their Protocol interfaces:
  - `PostgresProjectStorage`, `PostgresRunStorage` (atomic CAS via `WHERE current_stage = ANY`),
  - `PostgresScriptStorage`, `PostgresVisualPlanStorage` (advisory locks + `FOR UPDATE`),
  - `PostgresVisualAssetStorage` (deactivate+insert in single transaction),
  - `PostgresAudioStorage`, `PostgresSubtitleStorage`, `PostgresRenderStorage` (shared `creator_artifacts` table)
  - `PostgresStageReviewStorage`
- 2 Alembic migrations: `006_create_creator_script_drafts`, `007_create_creator_visual_plans`

**Modified files (11):**
- All 9 service files: Added `_create_storage()` factory that auto-selects Postgres vs InMemory based on `DATABASE_URL`
- `packages/creator-service/pyproject.toml`: Added `asyncpg>=0.29.0` dependency
- `pyproject.toml` (root): Added `extraPaths` for pyright cross-package resolution

**Bug fixes included:**
- Fixed circular import in `stage_review_service.py` (`from run_service import PipelineRun` → `await run_service.get_run()`)
- Removed `# type: ignore[arg-type]` in `visual_asset_service.py`, added proper None check
- Removed unused `import json` in `render_service.py`

### Design decisions
- Raw asyncpg (no ORM) — matches existing migration/query patterns
- `pg_advisory_xact_lock` for atomic version allocation (scripts, visual plans, visual assets)
- Audio/Subtitle/Video share `creator_artifacts` table, discriminated by `artifact_type`
- Factory pattern with lazy imports to avoid import-time DB dependencies

Closes #169