### PR TITLE
fix(tasks): correct task-provider interface mismatches and standardize artifact paths (#171)

### DIFF
--- a/apps/worker-orchestrator/tasks/generate_audio.py
+++ b/apps/worker-orchestrator/tasks/generate_audio.py
@@ -131,9 +131,9 @@ def generate_audio(
             gpu_lock_acquired_at = _utc_now_iso()
 
         audio_path = f"{_ARTIFACT_ROOT}/{run_id}/audio/audio.wav"
-        os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 
         try:
+            os.makedirs(os.path.dirname(audio_path), exist_ok=True)
             # 5. Generate audio via provider.
             params = dict(entry.default_params or {})
             params["output_path"] = audio_path

--- a/apps/worker-orchestrator/tasks/generate_audio.py
+++ b/apps/worker-orchestrator/tasks/generate_audio.py
@@ -33,10 +33,11 @@ from creator_service.script_service import script_service as _script_service
 logger = logging.getLogger(__name__)
 
 _ALLOWED_STAGES = frozenset({RunStage.VISUAL_ASSET_REVIEW, RunStage.AUDIO_GENERATING})
+_ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
 
 # Stages where writing SUBTITLE_GENERATING or FAILED is safe — the run
 # hasn't advanced past audio generation.
-_SAFE_STAGES = frozenset({RunStage.VISUAL_ASSET_REVIEW.value, RunStage.AUDIO_GENERATING.value})
+_SAFE_STAGES = frozenset({RunStage.VISUAL_ASSET_REVIEW, RunStage.AUDIO_GENERATING})
 
 
 class _StageGuardError(ValueError):
@@ -93,7 +94,7 @@ def generate_audio(
         if current not in _ALLOWED_STAGES:
             raise _StageGuardError(
                 f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+                f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
             )
 
         # 2. Fetch approved script draft.
@@ -129,14 +130,14 @@ def generate_audio(
             lock_acquired = True
             gpu_lock_acquired_at = _utc_now_iso()
 
-        audio_path = f"data/artifacts/{run_id}/audio/audio.wav"
+        audio_path = f"{_ARTIFACT_ROOT}/{run_id}/audio/audio.wav"
+        os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 
         try:
             # 5. Generate audio via provider.
             params = dict(entry.default_params or {})
-            params["voice"] = voice
             params["output_path"] = audio_path
-            await provider.generate(script_text, params)
+            await provider.generate(script_text, voice=voice, params=params)
 
             # 6. Save audio artifact via service.
             artifact = await _audio_service.create_artifact(
@@ -151,7 +152,7 @@ def generate_audio(
             applied, _ = await _run_service.storage.conditional_update_run(
                 run_id,
                 {
-                    "current_stage": RunStage.SUBTITLE_GENERATING.value,
+                    "current_stage": RunStage.SUBTITLE_GENERATING,
                     "status": "running",
                 },
                 expected_stages=_SAFE_STAGES,
@@ -201,7 +202,7 @@ def generate_audio(
                 _run_service.storage.conditional_update_run(
                     run_id,
                     {
-                        "current_stage": RunStage.FAILED.value,
+                        "current_stage": RunStage.FAILED,
                         "status": "failed",
                     },
                     expected_stages=_SAFE_STAGES,

--- a/apps/worker-orchestrator/tasks/generate_scene_image.py
+++ b/apps/worker-orchestrator/tasks/generate_scene_image.py
@@ -40,10 +40,10 @@ _ALLOWED_STAGES = frozenset({RunStage.VISUAL_PLAN_REVIEW, RunStage.VISUAL_ASSET_
 
 # Stages where writing VISUAL_ASSET_REVIEW or FAILED is safe — the run
 # hasn't advanced past image generation.
-_SAFE_STAGES = frozenset({RunStage.VISUAL_PLAN_REVIEW.value, RunStage.VISUAL_ASSET_GENERATING.value})
+_SAFE_STAGES = frozenset({RunStage.VISUAL_PLAN_REVIEW, RunStage.VISUAL_ASSET_GENERATING})
 
 # Base directory for artifact storage (relative to project root).
-_ARTIFACTS_BASE = os.getenv("ARTIFACTS_BASE", "data/artifacts")
+_ARTIFACTS_BASE = os.getenv("ARTIFACT_ROOT", "data/artifacts")
 
 
 class _StageGuardError(ValueError):
@@ -113,7 +113,7 @@ def generate_scene_image(
         if current not in _ALLOWED_STAGES:
             raise _StageGuardError(
                 f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+                f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
             )
 
         # 2. Fetch active visual plan.
@@ -252,7 +252,7 @@ def generate_scene_image(
                 applied, _ = await _run_service.storage.conditional_update_run(
                     run_id,
                     {
-                        "current_stage": RunStage.FAILED.value,
+                        "current_stage": RunStage.FAILED,
                         "status": "failed",
                     },
                     expected_stages=_SAFE_STAGES,
@@ -271,7 +271,7 @@ def generate_scene_image(
             applied, _ = await _run_service.storage.conditional_update_run(
                 run_id,
                 {
-                    "current_stage": RunStage.VISUAL_ASSET_REVIEW.value,
+                    "current_stage": RunStage.VISUAL_ASSET_REVIEW,
                     "status": "running",
                 },
                 expected_stages=_SAFE_STAGES,
@@ -314,7 +314,7 @@ def generate_scene_image(
                 _run_service.storage.conditional_update_run(
                     run_id,
                     {
-                        "current_stage": RunStage.FAILED.value,
+                        "current_stage": RunStage.FAILED,
                         "status": "failed",
                     },
                     expected_stages=_SAFE_STAGES,

--- a/apps/worker-orchestrator/tasks/generate_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_subtitles.py
@@ -1,7 +1,7 @@
 """Celery task for run-level subtitle generation via subtitle providers.
 
 Consumes an approved script draft AND optionally audio artifact timing data
-and generates a single subtitle artifact for the run (SRT format).
+and generates a single subtitle artifact for the run (SRT/VTT format).
 
 Key design decisions:
 - Subtitle generation is all-or-nothing for a run (no partial scene-level success).
@@ -34,10 +34,11 @@ from creator_service.subtitle_service import subtitle_service as _subtitle_servi
 logger = logging.getLogger(__name__)
 
 _ALLOWED_STAGES = frozenset({RunStage.AUDIO_GENERATING, RunStage.SUBTITLE_GENERATING})
+_ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
 
 # Stages where writing RENDER_GENERATING or FAILED is safe — the run
 # hasn't advanced past subtitle generation.
-_SAFE_STAGES = frozenset({RunStage.AUDIO_GENERATING.value, RunStage.SUBTITLE_GENERATING.value})
+_SAFE_STAGES = frozenset({RunStage.AUDIO_GENERATING, RunStage.SUBTITLE_GENERATING})
 
 
 class _StageGuardError(ValueError):
@@ -94,7 +95,7 @@ def generate_subtitles(
         if current not in _ALLOWED_STAGES:
             raise _StageGuardError(
                 f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+                f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
             )
 
         # 2. Fetch approved script draft.
@@ -134,16 +135,17 @@ def generate_subtitles(
             lock_acquired = True
             gpu_lock_acquired_at = _utc_now_iso()
 
-        subtitle_path = f"data/artifacts/{run_id}/subtitles/subtitles.{subtitle_format}"
+        subtitle_path = f"{_ARTIFACT_ROOT}/{run_id}/subtitles/subtitles.{subtitle_format}"
+        os.makedirs(os.path.dirname(subtitle_path), exist_ok=True)
 
         try:
             # 6. Generate subtitles via provider.
             params = dict(entry.default_params or {})
             params["format"] = subtitle_format
             params["output_path"] = subtitle_path
-            if audio_path:
-                params["audio_path"] = audio_path
-            await provider.generate(script_text, params)
+            if not audio_path:
+                raise RuntimeError(f"No audio artifact found for run {run_id}; cannot transcribe")
+            await provider.transcribe(audio_path, params=params)
 
             # 7. Save subtitle artifact via service.
             artifact = await _subtitle_service.create_artifact(
@@ -158,7 +160,7 @@ def generate_subtitles(
             applied, _ = await _run_service.storage.conditional_update_run(
                 run_id,
                 {
-                    "current_stage": RunStage.RENDER_GENERATING.value,
+                    "current_stage": RunStage.RENDER_GENERATING,
                     "status": "running",
                 },
                 expected_stages=_SAFE_STAGES,
@@ -209,7 +211,7 @@ def generate_subtitles(
                 _run_service.storage.conditional_update_run(
                     run_id,
                     {
-                        "current_stage": RunStage.FAILED.value,
+                        "current_stage": RunStage.FAILED,
                         "status": "failed",
                     },
                     expected_stages=_SAFE_STAGES,

--- a/apps/worker-orchestrator/tasks/generate_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_subtitles.py
@@ -136,9 +136,9 @@ def generate_subtitles(
             gpu_lock_acquired_at = _utc_now_iso()
 
         subtitle_path = f"{_ARTIFACT_ROOT}/{run_id}/subtitles/subtitles.{subtitle_format}"
-        os.makedirs(os.path.dirname(subtitle_path), exist_ok=True)
 
         try:
+            os.makedirs(os.path.dirname(subtitle_path), exist_ok=True)
             # 6. Generate subtitles via provider.
             params = dict(entry.default_params or {})
             params["format"] = subtitle_format

--- a/apps/worker-orchestrator/tasks/render_video.py
+++ b/apps/worker-orchestrator/tasks/render_video.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Callable
 
 from celery_app import celery_app
 from creator_domain.models.stage import RunStage
@@ -24,14 +26,15 @@ from creator_service.visual_asset_service import visual_asset_service as _visual
 logger = logging.getLogger(__name__)
 
 _ALLOWED_STAGES = frozenset({RunStage.RENDER_GENERATING})
-_SAFE_STAGES = frozenset({RunStage.RENDER_GENERATING.value})
+_SAFE_STAGES = frozenset({RunStage.RENDER_GENERATING})
+_ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
 
 
 class _StageGuardError(ValueError):
     pass
 
 # Map profile name → RenderProfile constructor
-_PROFILE_REGISTRY: dict[str, object] = {
+_PROFILE_REGISTRY: dict[str, Callable[[], RenderProfile]] = {
     "shorts_default": RenderProfile.default,
     "high_quality": RenderProfile.high_quality,
     "fast_preview": RenderProfile.fast_preview,
@@ -69,7 +72,7 @@ def render_video(
         if current not in _ALLOWED_STAGES:
             raise _StageGuardError(
                 f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
+                f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
             )
 
         manifest = await _render_service.build_render_manifest(
@@ -98,7 +101,7 @@ def render_video(
             scene_durations=scene_durations,
         )
 
-        output_path = f"data/artifacts/{run_id}/render/output.mp4"
+        output_path = f"{_ARTIFACT_ROOT}/{run_id}/render/output.mp4"
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
         resolved_profile = _resolve_profile(render_profile)
         ffmpeg = FFmpegService(profile=resolved_profile)
@@ -113,7 +116,7 @@ def render_video(
         applied, _ = await _run_service.storage.conditional_update_run(
             run_id,
             {
-                "current_stage": RunStage.FINAL_REVIEW.value,
+                "current_stage": RunStage.FINAL_REVIEW,
                 "status": "running",
             },
             expected_stages=_SAFE_STAGES,
@@ -152,7 +155,7 @@ def render_video(
                 _run_service.storage.conditional_update_run(
                     run_id,
                     {
-                        "current_stage": RunStage.FAILED.value,
+                        "current_stage": RunStage.FAILED,
                         "status": "failed",
                     },
                     expected_stages=_SAFE_STAGES,

--- a/apps/worker-orchestrator/tests/test_generate_audio.py
+++ b/apps/worker-orchestrator/tests/test_generate_audio.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from tasks import generate_audio as generate_audio_module
+
+
+@dataclass
+class FakeEntry:
+    provider_type: str = "piper"
+    endpoint: str = "http://piper:5000"
+    requires_gpu: bool = True
+    default_params: dict[str, object] | None = None
+
+
+class FakeProvider:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    async def generate(
+        self,
+        text: str,
+        voice: str = "default",
+        params: dict[str, object] | None = None,
+    ) -> None:
+        self.calls.append((text, voice, params))
+        if self.error is not None:
+            raise self.error
+
+
+class FakeStorage:
+    def __init__(self, runs: dict[int, dict[str, object]] | None = None) -> None:
+        self._runs: dict[int, dict[str, object]] = runs or {}
+        self.calls: list[tuple[int, dict[str, object]]] = []
+        self.cas_calls: list[tuple[int, dict[str, object], frozenset[str]]] = []
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        return self._runs.get(run_id)
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self.cas_calls.append((run_id, updates, expected_stages))
+        row = self._runs.get(run_id)
+        if row is None:
+            return False, None
+        if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        self.calls.append((run_id, updates))
+        row.update(updates)
+        self._runs[run_id] = row
+        return True, dict(row)
+
+
+def _make_storage(run_id: int = 101, stage: str = "VISUAL_ASSET_REVIEW") -> FakeStorage:
+    run_row: dict[str, object] = {"id": run_id, "current_stage": stage}
+    return FakeStorage(runs={run_id: run_row})
+
+
+@dataclass
+class FakeSection:
+    text: str = "Section text"
+    display_text: str | None = None
+
+
+@dataclass
+class FakeScriptDraft:
+    markdown_content: str | None = None
+    structured_script: list[FakeSection] | None = None
+
+
+class FakeScriptService:
+    def __init__(self, draft: FakeScriptDraft | None = None) -> None:
+        self.draft = draft
+
+    async def get_active_draft(self, _run_id: int) -> FakeScriptDraft | None:
+        return self.draft
+
+
+@dataclass
+class FakeAudioArtifact:
+    id: int
+    path: str
+
+
+class FakeAudioService:
+    def __init__(self, artifact_id: int = 1) -> None:
+        self.artifact_id = artifact_id
+        self.calls: list[dict[str, object]] = []
+
+    async def create_artifact(
+        self,
+        run_id: int,
+        path: str,
+        *,
+        model_used: str | None = None,
+        provider_type: str | None = None,
+        voice: str | None = None,
+    ) -> FakeAudioArtifact:
+        call_data = {
+            "run_id": run_id,
+            "path": path,
+            "model_used": model_used,
+            "provider_type": provider_type,
+            "voice": voice,
+        }
+        self.calls.append(call_data)
+        return FakeAudioArtifact(id=self.artifact_id, path=path)
+
+
+class FakeRegistry:
+    def __init__(self, entry: FakeEntry, provider: FakeProvider) -> None:
+        self.entry = entry
+        self.provider = provider
+
+    def resolve(self, _model_key: str) -> FakeEntry:
+        return self.entry
+
+    def get_provider(self, _model_key: str) -> FakeProvider:
+        return self.provider
+
+
+def _patch_registry(monkeypatch: pytest.MonkeyPatch, registry: FakeRegistry) -> None:
+    class _ProviderRegistry:
+        @staticmethod
+        def create_default() -> FakeRegistry:
+            return registry
+
+    monkeypatch.setattr(generate_audio_module, "ProviderRegistry", _ProviderRegistry)
+
+
+def _patch_redis(monkeypatch: pytest.MonkeyPatch, redis_client: object) -> None:
+    redis_stub = SimpleNamespace(Redis=SimpleNamespace(from_url=lambda _: redis_client))
+    monkeypatch.setattr(generate_audio_module, "redis", redis_stub)
+
+
+def _patch_services(
+    monkeypatch: pytest.MonkeyPatch,
+    script_service: FakeScriptService,
+    audio_service: FakeAudioService,
+    storage: FakeStorage,
+) -> None:
+    monkeypatch.setattr(generate_audio_module, "_script_service", script_service)
+    monkeypatch.setattr(generate_audio_module, "_audio_service", audio_service)
+    monkeypatch.setattr(generate_audio_module, "_run_service", SimpleNamespace(storage=storage))
+
+
+def _invoke_task(**kwargs: Any) -> dict[str, object]:
+    task = generate_audio_module.generate_audio
+    run_callable = getattr(task, "run", task)
+    return run_callable(**kwargs)
+
+
+def test_generate_audio_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False, default_params={"temperature": 0.2})
+    _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Hello world script"))
+    audio_service = FakeAudioService(artifact_id=33)
+    storage = _make_storage(run_id=101, stage="VISUAL_ASSET_REVIEW")
+    _patch_services(monkeypatch, script_service, audio_service, storage)
+
+    result = _invoke_task(run_id=101, tts_model="piper", voice="en_US-lessac-medium")
+
+    assert result["status"] == "success"
+    assert result["audio_artifact_id"] == 33
+    assert result["provider_type"] == "piper"
+    assert result["endpoint"] == "http://piper:5000"
+    assert result["audio_path"] == "data/artifacts/101/audio/audio.wav"
+
+    assert provider.calls == [
+        (
+            "Hello world script",
+            "en_US-lessac-medium",
+            {
+                "temperature": 0.2,
+                "output_path": "data/artifacts/101/audio/audio.wav",
+            },
+        )
+    ]
+    params = provider.calls[0][2]
+    assert params is not None
+    assert "voice" not in params
+
+    assert audio_service.calls == [
+        {
+            "run_id": 101,
+            "path": "data/artifacts/101/audio/audio.wav",
+            "model_used": "piper",
+            "provider_type": "piper",
+            "voice": "en_US-lessac-medium",
+        }
+    ]
+    assert storage.calls == [(101, {"current_stage": "SUBTITLE_GENERATING", "status": "running"})]
+    assert storage.cas_calls[0][2] == frozenset({"VISUAL_ASSET_REVIEW", "AUDIO_GENERATING"})
+
+
+def test_generate_audio_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Any"))
+    audio_service = FakeAudioService()
+    storage = FakeStorage()
+    _patch_services(monkeypatch, script_service, audio_service, storage)
+
+    with pytest.raises(ValueError, match="Run 999 not found"):
+        _invoke_task(run_id=999)
+
+    assert provider.calls == []
+    assert storage.calls == []
+    assert audio_service.calls == []
+
+
+def test_generate_audio_wrong_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Any"))
+    audio_service = FakeAudioService()
+    storage = _make_storage(run_id=102, stage="SCRIPT_REVIEW")
+    _patch_services(monkeypatch, script_service, audio_service, storage)
+
+    with pytest.raises(ValueError, match="expected one of"):
+        _invoke_task(run_id=102)
+
+    assert provider.calls == []
+    assert storage.calls == []
+    assert audio_service.calls == []
+
+
+def test_generate_audio_no_script(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=None)
+    audio_service = FakeAudioService()
+    storage = _make_storage(run_id=103, stage="VISUAL_ASSET_REVIEW")
+    _patch_services(monkeypatch, script_service, audio_service, storage)
+
+    with pytest.raises(ValueError, match="No script draft found"):
+        _invoke_task(run_id=103)
+
+    assert provider.calls == []
+    assert storage.calls == []
+    assert audio_service.calls == []
+
+
+def test_generate_audio_provider_failure_marks_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider(error=RuntimeError("audio provider failed"))
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Some script"))
+    audio_service = FakeAudioService()
+    storage = _make_storage(run_id=104, stage="VISUAL_ASSET_REVIEW")
+    _patch_services(monkeypatch, script_service, audio_service, storage)
+
+    with pytest.raises(RuntimeError, match="audio provider failed"):
+        _invoke_task(run_id=104)
+
+    assert audio_service.calls == []
+    assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
+    assert storage.cas_calls[0][2] == frozenset({"VISUAL_ASSET_REVIEW", "AUDIO_GENERATING"})
+
+
+def test_generate_audio_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=True)
+    _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
+
+    redis_client = object()
+    _patch_redis(monkeypatch, redis_client)
+
+    lock_calls: list[str] = []
+    release_calls: list[str] = []
+    monkeypatch.setattr(generate_audio_module, "acquire_gpu_lock", lambda _, task_id: lock_calls.append(task_id))
+    monkeypatch.setattr(generate_audio_module, "release_gpu_lock", lambda _, task_id: release_calls.append(task_id))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Lock script"))
+    audio_service = FakeAudioService(artifact_id=61)
+    storage = _make_storage(run_id=105, stage="VISUAL_ASSET_REVIEW")
+    _patch_services(monkeypatch, script_service, audio_service, storage)
+
+    result = _invoke_task(run_id=105)
+
+    assert result["status"] == "success"
+    assert result["gpu_lock_acquired_at"] is not None
+    assert result["gpu_lock_released_at"] is not None
+    assert lock_calls == ["run-105"]
+    assert release_calls == ["run-105"]
+
+
+def test_generate_audio_without_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
+
+    monkeypatch.setattr(generate_audio_module, "acquire_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+    monkeypatch.setattr(generate_audio_module, "release_gpu_lock", lambda *_: (_ for _ in ()).throw(RuntimeError("unexpected")))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="No lock script"))
+    audio_service = FakeAudioService(artifact_id=71)
+    storage = _make_storage(run_id=106, stage="AUDIO_GENERATING")
+    _patch_services(monkeypatch, script_service, audio_service, storage)
+
+    result = _invoke_task(run_id=106, voice="custom-voice")
+
+    assert result["status"] == "success"
+    assert result["gpu_lock_acquired_at"] is None
+    assert result["gpu_lock_released_at"] is None
+    assert provider.calls[0][1] == "custom-voice"
+
+
+class _CASSkipStorage(FakeStorage):
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self.cas_calls.append((run_id, updates, expected_stages))
+        row = self._runs.get(run_id)
+        return False, dict(row) if row else None
+
+
+def test_generate_audio_cas_skip_on_stage_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
+
+    script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Narration text"))
+    audio_service = FakeAudioService(artifact_id=50)
+
+    run_row: dict[str, object] = {"id": 107, "current_stage": "VISUAL_ASSET_REVIEW"}
+    storage = _CASSkipStorage(runs={107: run_row})
+    _patch_services(monkeypatch, script_service, audio_service, storage)
+
+    result = _invoke_task(run_id=107)
+
+    assert result["status"] == "success"
+    assert result["audio_artifact_id"] == 50
+    assert len(provider.calls) == 1
+    assert len(audio_service.calls) == 1
+    assert len(storage.cas_calls) == 1
+    assert storage.cas_calls[0][1] == {"current_stage": "SUBTITLE_GENERATING", "status": "running"}
+    assert storage.calls == []

--- a/apps/worker-orchestrator/tests/test_generate_subtitles.py
+++ b/apps/worker-orchestrator/tests/test_generate_subtitles.py
@@ -21,8 +21,8 @@ class FakeProvider:
         self.error = error
         self.calls: list[tuple[str, dict[str, object] | None]] = []
 
-    async def generate(self, script_text: str, params: dict[str, object] | None = None) -> None:
-        self.calls.append((script_text, params))
+    async def transcribe(self, audio_path: str, params: dict[str, object] | None = None) -> None:
+        self.calls.append((audio_path, params))
         if self.error is not None:
             raise self.error
 
@@ -182,7 +182,7 @@ def test_generate_subtitles_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(generate_subtitles_module, "release_gpu_lock", lambda _, task_id: release_calls.append(task_id))
 
     script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Hello world script"))
-    audio_service = FakeAudioService(artifact=None)
+    audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="data/artifacts/101/audio/audio.wav"))
     subtitle_service = FakeSubtitleService(artifact_id=33)
     storage = _make_storage(run_id=101, stage="AUDIO_GENERATING")
     _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
@@ -196,14 +196,14 @@ def test_generate_subtitles_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result["gpu_lock_acquired_at"] is not None
     assert result["gpu_lock_released_at"] is not None
     assert result["subtitle_path"] == "data/artifacts/101/subtitles/subtitles.srt"
-    assert result["audio_path"] is None
+    assert result["audio_path"] == "data/artifacts/101/audio/audio.wav"
 
     assert lock_calls == ["run-101"]
     assert release_calls == ["run-101"]
 
     assert provider.calls == [
         (
-            "Hello world script",
+            "data/artifacts/101/audio/audio.wav",
             {
                 "temperature": 0.1,
                 "format": "srt",
@@ -283,7 +283,7 @@ def test_generate_subtitles_provider_failure_marks_failed(monkeypatch: pytest.Mo
     _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
 
     script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Some script"))
-    audio_service = FakeAudioService(artifact=None)
+    audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="data/artifacts/104/audio/audio.wav"))
     subtitle_service = FakeSubtitleService()
     storage = _make_storage(run_id=104, stage="AUDIO_GENERATING")
     _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
@@ -310,9 +310,9 @@ def test_generate_subtitles_with_audio_path(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert result["status"] == "success"
     assert result["audio_path"] == "data/artifacts/105/audio/audio.wav"
+    assert provider.calls[0][0] == "data/artifacts/105/audio/audio.wav"
     params = provider.calls[0][1]
     assert params is not None
-    assert params["audio_path"] == "data/artifacts/105/audio/audio.wav"
     assert params["format"] == "vtt"
     assert params["output_path"] == "data/artifacts/105/subtitles/subtitles.vtt"
 
@@ -327,15 +327,12 @@ def test_generate_subtitles_without_audio(monkeypatch: pytest.MonkeyPatch) -> No
     storage = _make_storage(run_id=106, stage="SUBTITLE_GENERATING")
     _patch_services(monkeypatch, script_service, audio_service, subtitle_service, storage)
 
-    result = _invoke_task(run_id=106)
+    with pytest.raises(RuntimeError, match="No audio artifact found for run 106; cannot transcribe"):
+        _invoke_task(run_id=106)
 
-    assert result["status"] == "success"
-    assert result["audio_path"] is None
-    params = provider.calls[0][1]
-    assert params is not None
-    assert "audio_path" not in params
-    assert params["format"] == "srt"
-    assert params["output_path"] == "data/artifacts/106/subtitles/subtitles.srt"
+    assert provider.calls == []
+    assert subtitle_service.calls == []
+    assert storage.calls == [(106, {"current_stage": "FAILED", "status": "failed"})]
 
 
 class _CASSkipStorage(FakeStorage):
@@ -365,7 +362,7 @@ def test_generate_subtitles_cas_skip_on_stage_change(monkeypatch: pytest.MonkeyP
     _patch_registry(monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider))
 
     script_service = FakeScriptService(draft=FakeScriptDraft(markdown_content="Narration text"))
-    audio_service = FakeAudioService(artifact=None)
+    audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="data/artifacts/107/audio/audio.wav"))
     subtitle_service = FakeSubtitleService(artifact_id=50)
 
     # Storage starts at AUDIO_GENERATING (passes stage guard) but CAS always rejects.


### PR DESCRIPTION
## Summary
- Fix TTS call signature in generate_audio: pass `voice` as keyword arg, not positionally in params dict
- Fix STT call in generate_subtitles: `provider.generate()` → `provider.transcribe(audio_path, params=params)` with audio requirement enforced
- Add `os.makedirs` before all artifact writes to prevent missing directory errors
- Standardize `ARTIFACT_ROOT` env var across all 4 worker tasks (was `ARTIFACTS_BASE` in scene_image, hardcoded in others)
- Clean up StrEnum usage: remove unnecessary `.value` calls
- Add comprehensive test suite for generate_audio task (8 tests)
- Update generate_subtitles tests for new STT contract

All 262 tests passing (95 worker + 12 provider + 155 service).

Closes #171