### PR TITLE
fix(ffmpeg): merge subtitle burn-in into single filter_complex graph (#172)

### DIFF
--- a/packages/creator-service/creator_service/ffmpeg_service.py
+++ b/packages/creator-service/creator_service/ffmpeg_service.py
@@ -16,8 +16,9 @@ class RenderInput:
 def _escape_subtitle_path(path: Path) -> str:
     """Escape special characters in subtitle path for FFmpeg filter syntax.
 
-    FFmpeg filter strings treat ':', "'", '\\', and ';' as syntax characters.
-    They must be escaped with a backslash so the path is interpreted literally.
+    FFmpeg filter strings treat ``\\``, ``:``, ``'``, ``;``, ``,``, ``[``,
+    and ``]`` as syntax characters.  They must be escaped with a backslash so
+    the path is interpreted literally.
     """
     s = str(path)
     # Order matters: escape backslashes first, then the rest.
@@ -25,6 +26,9 @@ def _escape_subtitle_path(path: Path) -> str:
     s = s.replace(":", "\\:")
     s = s.replace("'", "\\'")
     s = s.replace(";", "\\;")
+    s = s.replace(",", "\\,")
+    s = s.replace("[", "\\[")
+    s = s.replace("]", "\\]")
     return s
 
 

--- a/packages/creator-service/creator_service/ffmpeg_service.py
+++ b/packages/creator-service/creator_service/ffmpeg_service.py
@@ -13,56 +13,100 @@ class RenderInput:
     scene_durations: list[float]  # duration per scene in seconds
 
 
+def _escape_subtitle_path(path: Path) -> str:
+    """Escape special characters in subtitle path for FFmpeg filter syntax.
+
+    FFmpeg filter strings treat ':', "'", '\\', and ';' as syntax characters.
+    They must be escaped with a backslash so the path is interpreted literally.
+    """
+    s = str(path)
+    # Order matters: escape backslashes first, then the rest.
+    s = s.replace("\\", "\\\\")
+    s = s.replace(":", "\\:")
+    s = s.replace("'", "\\'")
+    s = s.replace(";", "\\;")
+    return s
+
+
 class FFmpegService:
     def __init__(self, profile: RenderProfile | None = None):
         self.profile = profile or RenderProfile.default()
 
     def build_command(self, input_data: RenderInput, output_path: Path) -> list[str]:
-        """Build FFmpeg command for rendering video from scenes."""
-        # This builds the actual FFmpeg command
-        # Ken Burns effect: use zoompan filter
-        # Subtitle burn-in: use subtitles filter
+        """Build FFmpeg command for rendering video from scenes.
+
+        All video filtering — scale/pad, concat, and optional subtitle
+        burn-in — is merged into a single ``-filter_complex`` graph so that
+        FFmpeg never receives conflicting ``-filter_complex`` and ``-vf``
+        flags.
+        """
         cmd = ["ffmpeg", "-y"]  # overwrite output
-        
-        # Build filter complex for image sequence with ken burns
-        filter_parts = []
-        for i, (img, dur) in enumerate(zip(input_data.image_paths, input_data.scene_durations)):
+
+        # --- inputs --------------------------------------------------------
+        filter_parts: list[str] = []
+        for i, (img, dur) in enumerate(
+            zip(input_data.image_paths, input_data.scene_durations),
+        ):
             cmd.extend(["-loop", "1", "-t", str(dur), "-i", str(img)])
-            # Scale + Ken Burns zoom
+            # Scale + pad each input to target resolution
             filter_parts.append(
-                f"[{i}:v]scale={self.profile.width}:{self.profile.height}:force_original_aspect_ratio=decrease,"
-                f"pad={self.profile.width}:{self.profile.height}:(ow-iw)/2:(oh-ih)/2,"
+                f"[{i}:v]scale={self.profile.width}:{self.profile.height}"
+                f":force_original_aspect_ratio=decrease,"
+                f"pad={self.profile.width}:{self.profile.height}"
+                f":(ow-iw)/2:(oh-ih)/2,"
                 f"setsar=1[v{i}]"
             )
-        
-        # Concat all scenes
-        concat_inputs = "".join(f"[v{i}]" for i in range(len(input_data.image_paths)))
-        filter_parts.append(f"{concat_inputs}concat=n={len(input_data.image_paths)}:v=1:a=0[vout]")
-        
+
+        # --- concat --------------------------------------------------------
+        concat_inputs = "".join(
+            f"[v{i}]" for i in range(len(input_data.image_paths))
+        )
+
+        # Determine whether we need a subtitle stage after concat.
+        need_subs = (
+            self.profile.burn_subtitles
+            and input_data.subtitle_path is not None
+        )
+
+        if need_subs:
+            # Concat → [vcat], then subtitle burn-in → [vout]
+            filter_parts.append(
+                f"{concat_inputs}concat="
+                f"n={len(input_data.image_paths)}:v=1:a=0[vcat]"
+            )
+            escaped = _escape_subtitle_path(input_data.subtitle_path)  # type: ignore[arg-type]
+            filter_parts.append(
+                f"[vcat]subtitles={escaped}"
+                f":force_style='FontSize={self.profile.subtitle_font_size}'[vout]"
+            )
+        else:
+            filter_parts.append(
+                f"{concat_inputs}concat="
+                f"n={len(input_data.image_paths)}:v=1:a=0[vout]"
+            )
+
         cmd.extend(["-filter_complex", ";".join(filter_parts)])
-        
-        # Add audio if present
+
+        # --- stream mapping ------------------------------------------------
         if input_data.audio_path:
             cmd.extend(["-i", str(input_data.audio_path)])
-            cmd.extend(["-map", "[vout]", "-map", f"{len(input_data.image_paths)}:a"])
+            cmd.extend(
+                ["-map", "[vout]", "-map", f"{len(input_data.image_paths)}:a"]
+            )
         else:
             cmd.extend(["-map", "[vout]"])
-        
-        # Codec settings
+
+        # --- codec settings ------------------------------------------------
         cmd.extend([
             "-c:v", self.profile.video_codec.value,
             "-crf", str(self.profile.crf),
             "-preset", self.profile.preset,
             "-r", str(self.profile.fps),
         ])
-        
+
         if input_data.audio_path:
             cmd.extend(["-c:a", self.profile.audio_codec.value])
-        
-        # Subtitle burn-in
-        if self.profile.burn_subtitles and input_data.subtitle_path:
-            cmd.extend(["-vf", f"subtitles={input_data.subtitle_path}:force_style='FontSize={self.profile.subtitle_font_size}'"])
-        
+
         cmd.append(str(output_path))
         return cmd
 

--- a/packages/creator-service/tests/test_render_profile.py
+++ b/packages/creator-service/tests/test_render_profile.py
@@ -120,7 +120,7 @@ class TestFFmpegService(unittest.TestCase):
         self.assertIn(self.profile.audio_codec.value, cmd)
 
     def test_build_command_with_subtitles(self):
-        """Test build_command includes subtitle filter."""
+        """Test build_command includes subtitle filter inside filter_complex."""
         input_data = RenderInput(
             image_paths=[Path("/tmp/img1.png")],
             audio_path=None,
@@ -128,15 +128,17 @@ class TestFFmpegService(unittest.TestCase):
             scene_durations=[5.0]
         )
         output_path = Path("/tmp/output.mp4")
-        
+
         cmd = self.service.build_command(input_data, output_path)
-        
-        # Verify subtitle filter is present
-        self.assertIn("-vf", cmd)
-        # Find the -vf value
-        vf_idx = cmd.index("-vf")
-        vf_filter = cmd[vf_idx + 1]
-        self.assertIn("subtitles", vf_filter)
+
+        # Subtitle filter must be inside -filter_complex, NOT a separate -vf
+        self.assertNotIn("-vf", cmd)
+        fc_idx = cmd.index("-filter_complex")
+        fc_value = cmd[fc_idx + 1]
+        self.assertIn("subtitles", fc_value)
+        # Intermediate label [vcat] feeds into subtitle filter → [vout]
+        self.assertIn("[vcat]", fc_value)
+        self.assertIn("[vout]", fc_value)
 
     def test_custom_profile(self):
         """Test FFmpegService with custom profile."""
@@ -209,6 +211,67 @@ class TestFFmpegService(unittest.TestCase):
             self.service.render(input_data, output_path)
         
         self.assertIn("FFmpeg render failed", str(cm.exception))
+
+    def test_build_command_without_subtitles_no_vcat(self):
+        """Without subtitles, concat goes directly to [vout] (no [vcat])."""
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png"), Path("/tmp/img2.png")],
+            audio_path=None,
+            subtitle_path=None,
+            scene_durations=[3.0, 4.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+
+        cmd = self.service.build_command(input_data, output_path)
+
+        self.assertNotIn("-vf", cmd)
+        fc_idx = cmd.index("-filter_complex")
+        fc_value = cmd[fc_idx + 1]
+        self.assertNotIn("[vcat]", fc_value)
+        self.assertIn("[vout]", fc_value)
+        self.assertNotIn("subtitles", fc_value)
+
+    def test_build_command_subtitle_path_escaping(self):
+        """Special characters in subtitle path are escaped for FFmpeg."""
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png")],
+            audio_path=None,
+            subtitle_path=Path("/data/project:1/subs file.srt"),
+            scene_durations=[5.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+
+        cmd = self.service.build_command(input_data, output_path)
+
+        fc_idx = cmd.index("-filter_complex")
+        fc_value = cmd[fc_idx + 1]
+        # Colon must be escaped
+        self.assertIn("\\:", fc_value)
+        # Original un-escaped colon should not appear in the subtitle part
+        self.assertNotIn("project:1", fc_value)
+
+    def test_build_command_with_audio_and_subtitles(self):
+        """Audio + subtitles: single filter_complex, correct stream mapping."""
+        input_data = RenderInput(
+            image_paths=[Path("/tmp/img1.png"), Path("/tmp/img2.png")],
+            audio_path=Path("/tmp/audio.wav"),
+            subtitle_path=Path("/tmp/subs.srt"),
+            scene_durations=[3.0, 4.0]
+        )
+        output_path = Path("/tmp/output.mp4")
+
+        cmd = self.service.build_command(input_data, output_path)
+
+        # No separate -vf
+        self.assertNotIn("-vf", cmd)
+        # filter_complex has both concat and subtitles
+        fc_idx = cmd.index("-filter_complex")
+        fc_value = cmd[fc_idx + 1]
+        self.assertIn("subtitles", fc_value)
+        self.assertIn("[vcat]", fc_value)
+        self.assertIn("[vout]", fc_value)
+        # Audio stream mapped
+        self.assertIn("-c:a", cmd)
 
 
 if __name__ == "__main__":

--- a/packages/creator-service/tests/test_render_profile.py
+++ b/packages/creator-service/tests/test_render_profile.py
@@ -236,7 +236,7 @@ class TestFFmpegService(unittest.TestCase):
         input_data = RenderInput(
             image_paths=[Path("/tmp/img1.png")],
             audio_path=None,
-            subtitle_path=Path("/data/project:1/subs file.srt"),
+            subtitle_path=Path("/data/project:1/subs,file[0].srt"),
             scene_durations=[5.0]
         )
         output_path = Path("/tmp/output.mp4")
@@ -249,6 +249,13 @@ class TestFFmpegService(unittest.TestCase):
         self.assertIn("\\:", fc_value)
         # Original un-escaped colon should not appear in the subtitle part
         self.assertNotIn("project:1", fc_value)
+        # Comma must be escaped
+        self.assertIn("\\,", fc_value)
+        self.assertNotIn("subs,file", fc_value)
+        # Square brackets must be escaped
+        self.assertIn("\\[", fc_value)
+        self.assertIn("\\]", fc_value)
+        self.assertNotIn("[0]", fc_value)
 
     def test_build_command_with_audio_and_subtitles(self):
         """Audio + subtitles: single filter_complex, correct stream mapping."""


### PR DESCRIPTION
## Summary
- Fixes Issue #172: FFmpeg `build_command()` was using both `-filter_complex` (concat) and `-vf` (subtitles) simultaneously, which FFmpeg doesn't allow
- Merges subtitle burn-in into the single `-filter_complex` graph: concat → `[vcat]` → subtitles → `[vout]`
- Adds `_escape_subtitle_path()` to properly escape `:`, `'`, `\`, `;` in subtitle file paths
- Without subtitles, concat goes directly to `[vout]` (no `[vcat]` intermediate)

## Changes
- `packages/creator-service/creator_service/ffmpeg_service.py` — Rewrote `build_command()` to use single filter_complex
- `packages/creator-service/tests/test_render_profile.py` — Updated subtitle test, added 3 new tests (no-subtitle, path escaping, audio+subtitles combined)

## Test Results
- 265 tests passing (158 service + 95 worker + 12 provider)

Closes #172