### PR TITLE
fix(api): wire frontend to backend with proxy, CORS, and missing endpoints (#173)

### DIFF
--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -1,7 +1,10 @@
 """FastAPI entrypoint for shorts_api."""
+import os
 import logging
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.staticfiles import StaticFiles
 from creator_service.logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
 from shorts_api.routes.creator_projects import router as projects_router
@@ -14,6 +17,20 @@ setup_json_logging(service_name="api", level="INFO")
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="short-form-pipeline API")
+
+cors_origins_env = os.getenv("CORS_ORIGINS")
+cors_origins = [
+    origin.strip() for origin in cors_origins_env.split(",") if origin.strip()
+] if cors_origins_env else ["http://localhost:5173"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(models_router, prefix="/api/creator")
 app.include_router(projects_router, prefix="/api/creator")
 app.include_router(runs_router, prefix="/api/creator")
@@ -25,3 +42,10 @@ app.include_router(visual_plan_router, prefix="/api/creator")
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+app.mount(
+    "/artifacts",
+    StaticFiles(directory=os.getenv("ARTIFACT_ROOT", "data/artifacts"), check_dir=False),
+    name="artifacts",
+)

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -93,6 +93,11 @@ class ApproveVisualPlanRequest(BaseModel):
     notes: str | None = None
 
 
+class ApproveVisualAssetsRequest(BaseModel):
+    reviewer: str = "agent"
+    notes: str | None = None
+
+
 class GenerateScriptRequest(BaseModel):
     model_key: str = "qwen3-4b"
     instructions: str | None = None
@@ -187,6 +192,28 @@ async def approve_visual_plan(run_id: int, request: ApproveVisualPlanRequest) ->
             run_id=run_id,
             stage_name="VISUAL_PLAN_REVIEW",
             target_stage="VISUAL_ASSET_GENERATING",
+            reviewer=request.reviewer,
+            notes=request.notes,
+        )
+    except ValueError as exc:
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        if "conflict" in detail.lower():
+            raise HTTPException(status_code=409, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
+
+    return updated_run.model_dump(mode="json")
+
+
+@router.post("/runs/{run_id}/approve-visual-assets")
+async def approve_visual_assets(run_id: int, request: ApproveVisualAssetsRequest) -> dict[str, object]:
+    try:
+        updated_run = await stage_review_service.approve_and_advance(
+            run_service=run_service,
+            run_id=run_id,
+            stage_name="VISUAL_ASSET_REVIEW",
+            target_stage="AUDIO_GENERATING",
             reviewer=request.reviewer,
             notes=request.notes,
         )

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -84,8 +84,8 @@ async def get_script(run_id: int) -> dict[str, object]:
 
     return {
         "run_id": run_id,
-        "markdown": draft.markdown_content,
-        "structured_sections": [
+        "script": draft.markdown_content,
+        "structured_script": [
             section.model_dump(mode="json")
             for section in (draft.structured_script or [])
         ],

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -72,6 +72,27 @@ async def get_script_markdown(run_id: int) -> dict[str, object]:
     }
 
 
+@run_script_router.get("")
+async def get_script(run_id: int) -> dict[str, object]:
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    draft = await script_service.get_active_draft(run_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="No script draft found for this run")
+
+    return {
+        "run_id": run_id,
+        "markdown": draft.markdown_content,
+        "structured_sections": [
+            section.model_dump(mode="json")
+            for section in (draft.structured_script or [])
+        ],
+        "version": draft.version,
+    }
+
+
 @run_script_router.get("/structured")
 async def get_script_structured(run_id: int) -> dict[str, object]:
     run = await run_service.get_run(run_id)

--- a/apps/studio-web/vite.config.ts
+++ b/apps/studio-web/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
       "/api": {
         target: "http://api:8000",
       },
+      "/artifacts": {
+        target: "http://api:8000",
+      },
     },
   },
 });

--- a/apps/studio-web/vite.config.ts
+++ b/apps/studio-web/vite.config.ts
@@ -4,5 +4,10 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://api:8000",
+      },
+    },
   },
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - "8000:8000"
     volumes:
       - ./apps/api/src:/app/src
+      - ./data/artifacts:/app/data/artifacts
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
## Summary

- Add Vite dev proxy `/api` → `http://api:8000` for frontend dev server
- Add `POST /runs/{run_id}/approve-visual-assets` endpoint (VISUAL_ASSET_REVIEW → AUDIO_GENERATING)
- Add `GET /runs/{run_id}/script` endpoint returning markdown + structured script
- Add CORS middleware with configurable `CORS_ORIGINS` env var
- Mount StaticFiles at `/artifacts` for direct artifact serving
- Add artifacts volume mount to API service in docker-compose.yml

Closes #173