### PR TITLE
feat: add exception handler, request logging, CI fixes, and real health checks (#174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
           node-version: "20"
       - name: Install Python dependencies
         run: python3 -m pip install -r apps/api/requirements.txt -r apps/worker-orchestrator/requirements.txt
+      - name: Install packages in editable mode
+        run: |
+          pip install -e packages/creator-domain
+          pip install -e packages/creator-provider
+          pip install -e packages/creator-service
       - name: Install Node dependencies
         run: npm --prefix apps/studio-web install
       - name: Lint Python
@@ -40,8 +45,18 @@ jobs:
           node-version: "20"
       - name: Install Python dependencies
         run: python3 -m pip install -r apps/api/requirements.txt -r apps/worker-orchestrator/requirements.txt
+      - name: Install packages in editable mode
+        run: |
+          pip install -e packages/creator-domain
+          pip install -e packages/creator-provider
+          pip install -e packages/creator-service
       - name: Install Node dependencies
         run: npm --prefix apps/studio-web install
+      - name: Test Packages
+        run: |
+          python3 -m pytest packages/creator-domain/tests/ -v
+          python3 -m pytest packages/creator-provider/tests/ -v
+          python3 -m pytest packages/creator-service/tests/ -v
       - name: Test API
         run: cd apps/api && python3 -m pytest tests/ -v
       - name: Test Worker

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -1,9 +1,13 @@
 """FastAPI entrypoint for shorts_api."""
-import os
 import logging
+import os
+import time
 
-from fastapi import FastAPI
+from creator_service.model_health_service import ModelHealthService
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.staticfiles import StaticFiles
 from creator_service.logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
@@ -31,6 +35,34 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        start = time.perf_counter()
+        response = await call_next(request)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        logger.info(
+            "%s %s %d %.1fms",
+            request.method,
+            request.url.path,
+            response.status_code,
+            elapsed_ms,
+        )
+        return response
+
+
+app.add_middleware(RequestLoggingMiddleware)
+model_health = ModelHealthService()
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error", "type": type(exc).__name__},
+    )
+
 app.include_router(models_router, prefix="/api/creator")
 app.include_router(projects_router, prefix="/api/creator")
 app.include_router(runs_router, prefix="/api/creator")
@@ -40,8 +72,21 @@ app.include_router(visual_plan_router, prefix="/api/creator")
 
 
 @app.get("/health")
-def health() -> dict[str, str]:
-    return {"status": "ok"}
+async def health() -> dict[str, object]:
+    results = await model_health.check_all()
+    all_healthy = all(r.status.value == "healthy" for r in results)
+    return {
+        "status": "ok" if all_healthy else "degraded",
+        "models": {
+            r.model_name: {
+                "status": r.status.value,
+                "endpoint": r.endpoint,
+                "response_time_ms": r.response_time_ms,
+                "error": r.error,
+            }
+            for r in results
+        },
+    }
 
 
 app.mount(

--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -7,7 +7,6 @@ from creator_service.model_health_service import ModelHealthService
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.staticfiles import StaticFiles
 from creator_service.logging_config import setup_json_logging
 from shorts_api.routes.creator_models import router as models_router
@@ -36,31 +35,34 @@ app.add_middleware(
 )
 
 
-class RequestLoggingMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        start = time.perf_counter()
+
+@app.middleware("http")
+async def request_logging_middleware(request: Request, call_next):
+    start = time.perf_counter()
+    status_code = 500
+    try:
         response = await call_next(request)
+        status_code = response.status_code
+        return response
+    finally:
         elapsed_ms = (time.perf_counter() - start) * 1000
         logger.info(
             "%s %s %d %.1fms",
             request.method,
             request.url.path,
-            response.status_code,
+            status_code,
             elapsed_ms,
         )
-        return response
 
 
-app.add_middleware(RequestLoggingMiddleware)
 model_health = ModelHealthService()
-
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
     return JSONResponse(
         status_code=500,
-        content={"detail": "Internal server error", "type": type(exc).__name__},
+        content={"detail": "Internal server error"},
     )
 
 app.include_router(models_router, prefix="/api/creator")

--- a/apps/api/src/shorts_api/routes/creator_assets.py
+++ b/apps/api/src/shorts_api/routes/creator_assets.py
@@ -1,1 +1,0 @@
-"""Placeholder for creator_assets."""

--- a/apps/api/src/shorts_api/routes/creator_audio.py
+++ b/apps/api/src/shorts_api/routes/creator_audio.py
@@ -1,1 +1,0 @@
-"""Placeholder for creator_audio."""

--- a/apps/api/src/shorts_api/routes/creator_render.py
+++ b/apps/api/src/shorts_api/routes/creator_render.py
@@ -1,1 +1,0 @@
-"""Placeholder for creator_render."""

--- a/apps/api/tests/test_creator_visual_plan.py
+++ b/apps/api/tests/test_creator_visual_plan.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Literal
 
 import pytest
-from models.visual_plan import VisualScene
+from creator_domain.models import VisualScene
 from pydantic import BaseModel
 from shorts_api.main import visual_plan_router
 
@@ -82,7 +82,7 @@ class StubVisualPlanService:
             raise ValueError(f"No active visual plan for run {run_id}")
 
         if expected_version is not None and active.version != expected_version:
-            from visual_plan_service import VersionConflictError
+            from creator_service.visual_plan_service import VersionConflictError
             raise VersionConflictError(run_id, expected_version, active.version)
 
         _patchable = {"prompt", "prompt_edited", "prompt_source", "style_tags", "mood", "composition"}
@@ -117,22 +117,24 @@ def _make_run(run_id: int, stage: str = "VISUAL_PLAN_REVIEW") -> StubPipelineRun
     )
 
 
-def _make_scene(scene_id: str = "scene-1", index: int = 0) -> dict[str, Any]:
-    return {
-        "scene_id": scene_id,
-        "section_id": "sec-1",
-        "scene_index": index,
-        "section_type": "narration",
-        "original_text": "Sample narration text",
-        "prompt": "A person explaining something",
-        "prompt_edited": False,
-        "prompt_source": "auto_generated",
-        "style_tags": ["cinematic"],
-        "mood": "neutral",
-        "composition": "medium-shot",
-        "generation_status": "pending",
-        "latest_asset_id": None,
-    }
+def _make_scene(scene_id: str = "scene-1", index: int = 0) -> VisualScene:
+    return VisualScene.model_validate(
+        {
+            "scene_id": scene_id,
+            "section_id": "sec-1",
+            "scene_index": index,
+            "section_type": "narration",
+            "original_text": "Sample narration text",
+            "prompt": "A person explaining something",
+            "prompt_edited": False,
+            "prompt_source": "auto_generated",
+            "style_tags": ["cinematic"],
+            "mood": "neutral",
+            "composition": "medium-shot",
+            "generation_status": "pending",
+            "latest_asset_id": None,
+        }
+    )
 
 
 @pytest.fixture
@@ -233,7 +235,7 @@ async def test_replace_visual_plan_success(client, stub_visual_plan_services):
     scene = _make_scene("scene-new")
     response = await client.put(
         "/api/creator/runs/20/visual-plan",
-        json={"scenes": [scene]},
+        json={"scenes": [scene.model_dump(mode="json")]},
     )
 
     assert response.status_code == 200
@@ -257,12 +259,12 @@ async def test_replace_visual_plan_version_increment(client, stub_visual_plan_se
 
     await client.put(
         "/api/creator/runs/21/visual-plan",
-        json={"scenes": [scene1]},
+        json={"scenes": [scene1.model_dump(mode="json")]},
     )
 
     response = await client.put(
         "/api/creator/runs/21/visual-plan",
-        json={"scenes": [scene2]},
+        json={"scenes": [scene2.model_dump(mode="json")]},
     )
 
     assert response.status_code == 200
@@ -278,7 +280,7 @@ async def test_replace_visual_plan_run_not_found(client, stub_visual_plan_servic
     scene = _make_scene()
     response = await client.put(
         "/api/creator/runs/999/visual-plan",
-        json={"scenes": [scene]},
+        json={"scenes": [scene.model_dump(mode="json")]},
     )
 
     assert response.status_code == 404
@@ -326,7 +328,7 @@ async def test_replace_visual_plan_multiple_scenes(client, stub_visual_plan_serv
     scenes = [_make_scene(f"scene-{i}", i) for i in range(3)]
     response = await client.put(
         "/api/creator/runs/24/visual-plan",
-        json={"scenes": scenes},
+        json={"scenes": [scene.model_dump(mode="json") for scene in scenes]},
     )
 
     assert response.status_code == 200

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -4,7 +4,8 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_health_returns_ok(client):
-    """Test that /health endpoint returns 200 with ok status."""
     response = await client.get("/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    body = response.json()
+    assert body["status"] in {"ok", "degraded"}
+    assert isinstance(body["models"], dict)

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -1,11 +1,78 @@
 """Tests for health endpoint."""
+from unittest.mock import AsyncMock, patch
+
 import pytest
+from creator_service.model_health_service import ModelHealthResult, ModelStatus
 
 
 @pytest.mark.asyncio
-async def test_health_returns_ok(client):
-    response = await client.get("/health")
+async def test_health_returns_ok_when_all_healthy(client):
+    mock_results = [
+        ModelHealthResult(
+            model_name="ollama",
+            endpoint="http://ollama:11434",
+            status=ModelStatus.HEALTHY,
+            response_time_ms=12.3,
+            error=None,
+        ),
+        ModelHealthResult(
+            model_name="stable-diffusion",
+            endpoint="http://stable-diffusion:7860",
+            status=ModelStatus.HEALTHY,
+            response_time_ms=45.6,
+            error=None,
+        ),
+    ]
+    with patch("shorts_api.main.model_health") as mock_health:
+        mock_health.check_all = AsyncMock(return_value=mock_results)
+        response = await client.get("/health")
+
     assert response.status_code == 200
     body = response.json()
-    assert body["status"] in {"ok", "degraded"}
-    assert isinstance(body["models"], dict)
+    assert body == {
+        "status": "ok",
+        "models": {
+            "ollama": {
+                "status": "healthy",
+                "endpoint": "http://ollama:11434",
+                "response_time_ms": 12.3,
+                "error": None,
+            },
+            "stable-diffusion": {
+                "status": "healthy",
+                "endpoint": "http://stable-diffusion:7860",
+                "response_time_ms": 45.6,
+                "error": None,
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_health_returns_degraded_when_model_unhealthy(client):
+    mock_results = [
+        ModelHealthResult(
+            model_name="ollama",
+            endpoint="http://ollama:11434",
+            status=ModelStatus.HEALTHY,
+            response_time_ms=10.0,
+            error=None,
+        ),
+        ModelHealthResult(
+            model_name="stable-diffusion",
+            endpoint="http://stable-diffusion:7860",
+            status=ModelStatus.UNHEALTHY,
+            response_time_ms=5000.0,
+            error="Connection refused",
+        ),
+    ]
+    with patch("shorts_api.main.model_health") as mock_health:
+        mock_health.check_all = AsyncMock(return_value=mock_results)
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "degraded"
+    assert body["models"]["ollama"]["status"] == "healthy"
+    assert body["models"]["stable-diffusion"]["status"] == "unhealthy"
+    assert body["models"]["stable-diffusion"]["error"] == "Connection refused"

--- a/packages/creator-service/creator_service/model_health_service.py
+++ b/packages/creator-service/creator_service/model_health_service.py
@@ -1,8 +1,12 @@
 """Model health check service for monitoring model serving containers."""
 
+import asyncio
 from dataclasses import dataclass
 from enum import Enum
 import os
+import time
+
+import httpx
 
 
 class ModelStatus(Enum):
@@ -60,16 +64,29 @@ class ModelHealthService:
         
         health_path = self.health_paths.get(model_name, "/")
         url = f"{endpoint}{health_path}"
-        
-        # TODO: Implement actual HTTP call using httpx
-        # In production: async with httpx.AsyncClient() as client: ...
-        # For now, return placeholder result
-        return ModelHealthResult(
-            model_name=model_name,
-            endpoint=endpoint,
-            status=ModelStatus.UNKNOWN,
-            error="Health check not yet implemented"
-        )
+
+        start = time.perf_counter()
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            return ModelHealthResult(
+                model_name=model_name,
+                endpoint=endpoint,
+                status=ModelStatus.HEALTHY,
+                response_time_ms=elapsed_ms,
+            )
+        except httpx.HTTPError as exc:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            return ModelHealthResult(
+                model_name=model_name,
+                endpoint=endpoint,
+                status=ModelStatus.UNHEALTHY,
+                response_time_ms=elapsed_ms,
+                error=str(exc),
+            )
 
     async def check_all(self) -> list[ModelHealthResult]:
         """Check health of all model containers.
@@ -77,8 +94,6 @@ class ModelHealthService:
         Returns:
             List of ModelHealthResult for each model container
         """
-        results = []
-        for name in self.endpoints:
-            result = await self.check_model(name)
-            results.append(result)
-        return results
+        return await asyncio.gather(
+            *(self.check_model(name) for name in self.endpoints)
+        )

--- a/packages/creator-service/pyproject.toml
+++ b/packages/creator-service/pyproject.toml
@@ -3,7 +3,7 @@ name = "creator-service"
 version = "0.1.0"
 description = "Service layer for short-form pipeline"
 requires-python = ">=3.10"
-dependencies = ["creator-domain>=0.1.0", "pydantic>=2.0", "asyncpg>=0.29.0"]
+dependencies = ["creator-domain>=0.1.0", "pydantic>=2.0", "asyncpg>=0.29.0", "httpx>=0.27.0"]
 
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]

--- a/packages/creator-service/tests/test_model_health.py
+++ b/packages/creator-service/tests/test_model_health.py
@@ -1,5 +1,8 @@
 """Unit tests for model health service."""
 
+from unittest.mock import AsyncMock, patch
+
+import httpx
 import pytest
 from creator_service.model_health_service import (
     ModelHealthService,
@@ -42,13 +45,54 @@ class TestModelHealthService:
         assert service.endpoints["stable-diffusion"] == "http://custom-sd:7860"
 
     @pytest.mark.asyncio
-    async def test_check_model_returns_result_with_correct_model_name(self, health_service):
-        """Test check_model returns result with correct model_name."""
-        result = await health_service.check_model("ollama")
-        
+    async def test_check_model_returns_healthy_on_2xx_response(self, health_service):
+        response = httpx.Response(200, request=httpx.Request("GET", "http://ollama:11434/api/tags"))
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=response)
+        mock_context = AsyncMock()
+        mock_context.__aenter__.return_value = mock_client
+
+        with patch("creator_service.model_health_service.httpx.AsyncClient", return_value=mock_context):
+            result = await health_service.check_model("ollama")
+
         assert isinstance(result, ModelHealthResult)
         assert result.model_name == "ollama"
         assert result.endpoint == "http://ollama:11434"
+        assert result.status == ModelStatus.HEALTHY
+        assert result.response_time_ms is not None
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_check_model_returns_unhealthy_on_connect_error(self, health_service):
+        request = httpx.Request("GET", "http://ollama:11434/api/tags")
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection failed", request=request))
+        mock_context = AsyncMock()
+        mock_context.__aenter__.return_value = mock_client
+
+        with patch("creator_service.model_health_service.httpx.AsyncClient", return_value=mock_context):
+            result = await health_service.check_model("ollama")
+
+        assert result.model_name == "ollama"
+        assert result.endpoint == "http://ollama:11434"
+        assert result.status == ModelStatus.UNHEALTHY
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_check_model_returns_unhealthy_on_timeout(self, health_service):
+        request = httpx.Request("GET", "http://ollama:11434/api/tags")
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ReadTimeout("Request timed out", request=request))
+        mock_context = AsyncMock()
+        mock_context.__aenter__.return_value = mock_client
+
+        with patch("creator_service.model_health_service.httpx.AsyncClient", return_value=mock_context):
+            result = await health_service.check_model("ollama")
+
+        assert result.model_name == "ollama"
+        assert result.endpoint == "http://ollama:11434"
+        assert result.status == ModelStatus.UNHEALTHY
+        assert result.error is not None
 
     @pytest.mark.asyncio
     async def test_check_model_returns_unknown_for_invalid_model(self, health_service):
@@ -62,7 +106,16 @@ class TestModelHealthService:
     @pytest.mark.asyncio
     async def test_check_all_returns_results_for_all_models(self, health_service):
         """Test check_all returns results for all 4 models."""
-        results = await health_service.check_all()
+        async def mock_check_model(model_name: str) -> ModelHealthResult:
+            return ModelHealthResult(
+                model_name=model_name,
+                endpoint=health_service.endpoints[model_name],
+                status=ModelStatus.HEALTHY,
+                response_time_ms=1.0,
+            )
+
+        with patch.object(health_service, "check_model", side_effect=mock_check_model):
+            results = await health_service.check_all()
         
         assert isinstance(results, list)
         assert len(results) == 4
@@ -74,7 +127,16 @@ class TestModelHealthService:
     @pytest.mark.asyncio
     async def test_check_all_returns_model_health_results(self, health_service):
         """Test check_all returns ModelHealthResult instances."""
-        results = await health_service.check_all()
+        async def mock_check_model(model_name: str) -> ModelHealthResult:
+            return ModelHealthResult(
+                model_name=model_name,
+                endpoint=health_service.endpoints[model_name],
+                status=ModelStatus.HEALTHY,
+                response_time_ms=1.0,
+            )
+
+        with patch.object(health_service, "check_model", side_effect=mock_check_model):
+            results = await health_service.check_all()
         
         for result in results:
             assert isinstance(result, ModelHealthResult)


### PR DESCRIPTION
## Summary
- add API operational hardening with global exception handling, request logging middleware, and model-backed `/health` response
- implement real async HTTP model health checks with parallel execution and expand creator-service coverage for healthy, connection, and timeout scenarios
- update CI to install and test shared packages, remove dead placeholder routes, and fix existing API test imports uncovered during full-suite runs

## Validation
- python3 -m pytest packages/creator-domain/tests/ -v
- python3 -m pytest packages/creator-provider/tests/ -v
- python3 -m pytest packages/creator-service/tests/ -v
- python3 -m pytest apps/api/tests/ -v
- python3 -m pytest apps/worker-orchestrator/tests/ -v