### PR TITLE
fix: resolve runtime issues discovered during E2E pipeline testing (#189)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ POSTGRES_PORT=5432
 POSTGRES_DB=short_form_pipeline
 POSTGRES_USER=short_form_user
 POSTGRES_PASSWORD=short_form_password
+DATABASE_URL=postgresql://short_form_user:short_form_password@postgres:5432/short_form_pipeline
 
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/apps/worker-orchestrator/Dockerfile
+++ b/apps/worker-orchestrator/Dockerfile
@@ -13,6 +13,7 @@ RUN pip install --no-cache-dir --prefix=/install -r requirements.txt \
 FROM python:3.12-slim AS runtime
 WORKDIR /app
 COPY --from=builder /install /usr/local
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
 COPY apps/worker-orchestrator/tasks ./tasks
 COPY apps/worker-orchestrator/celery_app.py ./celery_app.py
 CMD ["celery", "-A", "celery_app.celery_app", "worker", "--loglevel=info"]

--- a/apps/worker-orchestrator/celery_app.py
+++ b/apps/worker-orchestrator/celery_app.py
@@ -11,7 +11,7 @@ from creator_service.logging_config import setup_json_logging
 
 redis_url = os.getenv("REDIS_URL", "redis://redis:6379/0")
 
-celery_app = Celery("worker-orchestrator", broker=redis_url, backend=redis_url)
+celery_app = Celery("worker-orchestrator", broker=redis_url, backend=redis_url, include=["tasks.generate_script", "tasks.generate_visual_plan", "tasks.generate_scene_image", "tasks.generate_audio", "tasks.generate_subtitles", "tasks.render_video"])
 celery_app.conf.task_default_queue = "creator"
 
 

--- a/apps/worker-orchestrator/tasks/generate_scene_image.py
+++ b/apps/worker-orchestrator/tasks/generate_scene_image.py
@@ -182,15 +182,15 @@ def generate_scene_image(
                 try:
                     # Generate image via provider.
                     params = dict(entry.default_params or {})
+                    # Direct provider to write to the artifact directory
+                    # instead of a temp file.
+                    target_path = str(asset_dir / f"{target_scene.scene_id}.png")
+                    params["output_path"] = target_path
                     image_result = await provider.generate(effective_prompt, params)
 
-                    # Determine asset path — provider returns image_path,
-                    # or we construct one.
-                    if hasattr(image_result, "image_path") and image_result.image_path:
-                        asset_path = image_result.image_path
-                    else:
-                        # Fallback: store in our artifacts directory.
-                        asset_path = str(asset_dir / f"{target_scene.scene_id}.png")
+                    # Use the artifact path — guaranteed to be in our
+                    # persistent storage, not a temp directory.
+                    asset_path = target_path
 
                     # Save as visual asset via service.
                     asset = await _visual_asset_service.create_asset(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,15 @@ services:
       - "8000:8000"
     volumes:
       - ./apps/api/src:/app/src
+      - ./apps/worker-orchestrator/tasks:/app/tasks
+      - ./apps/worker-orchestrator/celery_app.py:/app/celery_app.py
+      - ./packages/creator-service/creator_service:/usr/local/lib/python3.12/site-packages/creator_service
+      - ./packages/creator-provider/creator_provider:/usr/local/lib/python3.12/site-packages/creator_provider
       - ./data/artifacts:/app/data/artifacts
     env_file:
       - .env
+    environment:
+      PYTHONPATH: /app/src:/app
     depends_on:
       postgres:
         condition: service_healthy
@@ -56,6 +62,8 @@ services:
     volumes:
       - ./apps/worker-orchestrator/tasks:/app/tasks
       - ./apps/worker-orchestrator/celery_app.py:/app/celery_app.py
+      - ./packages/creator-service/creator_service:/usr/local/lib/python3.12/site-packages/creator_service
+      - ./packages/creator-provider/creator_provider:/usr/local/lib/python3.12/site-packages/creator_provider
       - ./data/artifacts:/app/data/artifacts
     env_file:
       - .env

--- a/packages/creator-provider/creator_provider/image/sd_local_provider.py
+++ b/packages/creator-provider/creator_provider/image/sd_local_provider.py
@@ -17,21 +17,21 @@ class SDLocalProvider(ImageProvider):
 
     async def generate(self, prompt: str, params: dict[str, Any] | None = None) -> ImageResult:
         merged_params: dict[str, Any] = dict(params or {})
-        width = int(merged_params.get("width", 720))
-        height = int(merged_params.get("height", 1280))
+        width = int(merged_params.get("width", 512))
+        height = int(merged_params.get("height", 768))
 
         payload: dict[str, Any] = {
             "prompt": prompt,
             "width": width,
             "height": height,
-            "steps": 20,
+            "steps": 15,
             "cfg_scale": 7,
         }
         payload.update(merged_params)
 
         url = f"{self.endpoint}/sdapi/v1/txt2img"
         try:
-            async with httpx.AsyncClient(timeout=120.0) as client:
+            async with httpx.AsyncClient(timeout=600.0) as client:
                 response = await client.post(url, json=payload)
                 response.raise_for_status()
         except httpx.HTTPError as exc:

--- a/packages/creator-provider/creator_provider/llm/ollama_provider.py
+++ b/packages/creator-provider/creator_provider/llm/ollama_provider.py
@@ -10,18 +10,25 @@ from creator_provider.base import LLMProvider
 class OllamaProvider(LLMProvider):
     def __init__(self, endpoint: str, model_key: str):
         self.endpoint = endpoint.rstrip("/")
-        self.model_key = model_key
+        # model_key is our internal catalog key (e.g. "qwen3-4b").
+        # Ollama expects the actual model tag (e.g. "qwen3:4b").
+        # Convert dashes to colons for Ollama compatibility.
+        self.model_name = model_key.replace("-", ":", 1)
 
     async def generate(self, prompt: str, params: dict[str, Any] | None = None) -> str:
+        # Use the /api/chat endpoint with think=false to disable Qwen3's
+        # extended thinking mode, which is far too slow on consumer GPUs.
         payload: dict[str, Any] = {
-            "model": self.model_key,
-            "prompt": prompt,
+            "model": self.model_name,
+            "messages": [{"role": "user", "content": prompt}],
             "stream": False,
+            "think": False,
+            "options": {"num_predict": 2048},
         }
         if params:
             payload.update(params)
 
-        url = f"{self.endpoint}/api/generate"
+        url = f"{self.endpoint}/api/chat"
         try:
             async with httpx.AsyncClient(timeout=300.0) as client:
                 response = await client.post(
@@ -34,4 +41,4 @@ class OllamaProvider(LLMProvider):
             raise RuntimeError(f"Failed to connect to Ollama provider at {url}: {exc}") from exc
 
         data = response.json()
-        return str(data["response"])
+        return str(data.get("message", {}).get("content", ""))

--- a/packages/creator-service/creator_service/db.py
+++ b/packages/creator-service/creator_service/db.py
@@ -2,28 +2,50 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 from typing import Any
 
 import asyncpg
 
+# Pool singleton with event-loop awareness.
+# Celery workers call asyncio.run() per task, creating a new event loop each
+# time.  A pool created on a previous loop is stale and unusable.  We track
+# which loop owns the current pool and transparently recreate it when the
+# loop changes.
 _pool: asyncpg.Pool | None = None
-_pool_lock = asyncio.Lock()
+_pool_loop: asyncio.AbstractEventLoop | None = None
+_pool_thread_lock = threading.Lock()
 
 
 async def get_pool() -> asyncpg.Pool:
-    global _pool
-    if _pool is not None:
+    global _pool, _pool_loop
+    current_loop = asyncio.get_running_loop()
+
+    # Fast path – pool exists and belongs to the current loop.
+    if _pool is not None and _pool_loop is current_loop:
         return _pool
 
-    async with _pool_lock:
-        if _pool is not None:
+    # Slow path – need to create (or recreate) the pool.
+    with _pool_thread_lock:
+        # Double-check after acquiring lock.
+        if _pool is not None and _pool_loop is current_loop:
             return _pool
+
+        # Close stale pool from a previous event loop (best-effort).
+        if _pool is not None:
+            try:
+                await asyncio.wait_for(_pool.close(), timeout=2.0)
+            except Exception:
+                pass  # Old loop may already be gone; nothing we can do.
+            _pool = None
+            _pool_loop = None
 
         database_url = os.getenv("DATABASE_URL")
         if not database_url:
             raise RuntimeError("DATABASE_URL is required for Postgres storage")
 
         _pool = await asyncpg.create_pool(database_url, min_size=2, max_size=10)
+        _pool_loop = current_loop
         return _pool
 
 


### PR DESCRIPTION
## Summary

All critical runtime issues discovered during full E2E pipeline testing (script → visual plan → images → audio → subtitles → render → FINAL_REVIEW) on a local GTX 1660 SUPER setup.

## Changes

### asyncpg Event-Loop Fix (`db.py`)
- Celery workers call `asyncio.run()` per task, creating a new event loop each time
- The old pool/lock bound to previous loops caused `RuntimeError: got Future attached to a different loop`
- Fixed with loop-aware pool management using `threading.Lock` + `_pool_loop` tracking

### Ollama Provider Fixes (`ollama_provider.py`)
- **Model name mapping**: Registry uses `qwen3-4b` (dash) but Ollama expects `qwen3:4b` (colon) — added `.replace("-", ":", 1)`
- **Chat endpoint**: Switch from `/api/generate` to `/api/chat` with `think=false` to disable Qwen3's extended thinking mode (300s+ on consumer GPU → ~30s)
- **Response parsing**: Updated to extract `message.content` from chat response format

### Stable Diffusion Defaults (`sd_local_provider.py`)
- Reduced resolution from 720x1280 → 512x768 (GTX 1660 SUPER 6GB VRAM constraint)
- Reduced steps from 20 → 15 (83s generation time vs 5min+ timeout)
- Increased HTTP timeout from 120s → 600s for safety margin

### Celery Task Registration (`celery_app.py`)
- Added explicit `include=[...]` for all 6 task modules so Celery discovers them at startup

### Image Artifact Path (`generate_scene_image.py`)
- Pass `output_path` param to SD provider → writes directly to `data/artifacts/{run_id}/scenes/`
- Previously wrote to `/tmp` which is ephemeral inside the container

### Docker Compose Mounts (`docker-compose.yml`)
- Mount `creator_service` and `creator_provider` packages into both API and worker containers for live code sync
- Add `PYTHONPATH=/app/src:/app` to API environment

### Worker Dockerfile
- Install `ffmpeg` in runtime stage — required by `FFmpegService.render()` for video rendering

### Environment Template (`.env.example`)
- Added `DATABASE_URL` template for asyncpg direct connections

## Testing

Full E2E pipeline validated end-to-end:
- ✅ Script generation (222s with qwen3:4b)
- ✅ Visual plan generation (218s)
- ✅ Image generation (83.8s, 512x768)
- ✅ Audio/TTS (17.6s, Qwen3-TTS)
- ✅ Subtitles/STT (Whisper large-v3)
- ✅ Video render (19.4s, 1080x1920, H.264)
- ✅ Pipeline advanced to FINAL_REVIEW
- ✅ Studio-web frontend shows all 6 stages complete