### PR TITLE
fix(studio-web): extract scenes from visual-assets response wrapper

### DIFF
--- a/apps/studio-web/src/__tests__/ReviewPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ReviewPage.test.tsx
@@ -96,8 +96,8 @@ function mockFetchAll(
     }
     // GET /runs/:id/visual-assets
     if (url.includes("/visual-assets")) {
-      if (!opts.assets) return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.assets) } as Response);
+      if (!opts.assets) return Promise.resolve({ ok: true, json: () => Promise.resolve({ run_id: run?.id ?? 0, scenes: {}, total_scenes: 0, total_assets: 0 }) } as Response);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ run_id: run?.id ?? 0, scenes: opts.assets, total_scenes: Object.keys(opts.assets).length, total_assets: Object.values(opts.assets).flat().length }) } as Response);
     }
     // GET /runs/:id/visual-plan
     if (url.includes("/visual-plan")) {
@@ -250,5 +250,25 @@ describe("ReviewPage", () => {
       expect(screen.getByTestId("review-audio-section")).toBeTruthy();
     });
     expect(screen.getByText("qwen3-tts")).toBeTruthy();
+  });
+
+  it("handles wrapped visual-assets response with scenes field (regression)", async () => {
+    // The /visual-assets endpoint returns { run_id, scenes, total_scenes, total_assets }
+    // NOT a raw Record<string, Asset[]>. Verify ReviewPage correctly extracts .scenes.
+    mockFetchAll(MOCK_RUN_FINAL_REVIEW, {
+      script: MOCK_SCRIPT,
+      scenes: MOCK_SCENES,
+      assets: MOCK_ASSETS,
+      preview: MOCK_PREVIEW,
+    });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("review-assets-section")).toBeTruthy();
+    });
+
+    // Assets from wrapped response should render correctly
+    expect(screen.getByText(/scene-0\.png/)).toBeTruthy();
+    expect(screen.getByText(/scene-1\.png/)).toBeTruthy();
   });
 });

--- a/apps/studio-web/src/pages/ReviewPage.tsx
+++ b/apps/studio-web/src/pages/ReviewPage.tsx
@@ -199,7 +199,7 @@ export default function ReviewPage() {
         const assetsRes = await fetch(`${API_BASE}/runs/${numericRunId}/visual-assets`);
         if (assetsRes.ok) {
           const assetsData = await assetsRes.json();
-          setAssets(assetsData.scenes ?? assetsData);
+          setAssets(assetsData.scenes ?? {});
         }
       }
 

--- a/apps/studio-web/src/pages/ReviewPage.tsx
+++ b/apps/studio-web/src/pages/ReviewPage.tsx
@@ -198,7 +198,8 @@ export default function ReviewPage() {
       if (POST_VISUAL_ASSET_STAGES.has(stage)) {
         const assetsRes = await fetch(`${API_BASE}/runs/${numericRunId}/visual-assets`);
         if (assetsRes.ok) {
-          setAssets(await assetsRes.json());
+          const assetsData = await assetsRes.json();
+          setAssets(assetsData.scenes ?? assetsData);
         }
       }
 


### PR DESCRIPTION
## Summary

- **Bug**: ReviewPage crashed with `TypeError: sceneAssets.map is not a function` because the `/api/creator/runs/{id}/visual-assets` API returns `{ run_id, scenes: {...}, total_scenes, total_assets }` but `setAssets()` was receiving the entire wrapper object instead of extracting the `scenes` property.
- **Fix**: Extract `.scenes` from the API response before setting state: `setAssets(assetsData.scenes ?? assetsData)`.
- **Verified**: Review Page now renders all sections (Script, Visual Plan, Visual Assets, Audio, Subtitles, Video) with zero console errors.

## Changes

- `apps/studio-web/src/pages/ReviewPage.tsx` — Line 201: Parse response wrapper and extract `scenes` field.

## Testing

- Manually verified in browser at `http://192.168.31.158:5174` — Review Page renders correctly for Run ID=1.