### PR TITLE
feat(studio-web): add media previews on ReviewPage and beautiful typography

### DIFF
--- a/apps/studio-web/index.html
+++ b/apps/studio-web/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>short-form-pipeline studio</title>
+    <!-- Pretendard (Korean-optimized variable font) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
+    <!-- Inter (Latin) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <!-- JetBrains Mono (code) -->
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/studio-web/src/__tests__/ReviewPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ReviewPage.test.tsx
@@ -181,9 +181,11 @@ describe("ReviewPage", () => {
     expect(screen.getByTestId("review-subtitle-section")).toBeTruthy();
     expect(screen.getByText("srt")).toBeTruthy();
 
-    // Video section
+    // Video section — video is now rendered as <video> element, no path text
     expect(screen.getByTestId("review-video-section")).toBeTruthy();
-    expect(screen.getByText(/output\.mp4/)).toBeTruthy();
+    const videoEl = screen.getByTestId("review-video-section").querySelector("video");
+    expect(videoEl).toBeTruthy();
+    expect(videoEl?.getAttribute("src")).toContain("output.mp4");
     expect(screen.getByText("shorts_default")).toBeTruthy();
   });
 

--- a/apps/studio-web/src/index.css
+++ b/apps/studio-web/src/index.css
@@ -1,0 +1,72 @@
+/* ============================================================
+   Global styles — short-form-pipeline studio
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family:
+    "Pretendard Variable",
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #111827;
+  background: #f8fafc;
+  line-height: 1.6;
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", "SF Mono", monospace;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img,
+video,
+audio {
+  max-width: 100%;
+  display: block;
+}
+
+/* Scrollbar (Webkit) */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #94a3b8;
+}

--- a/apps/studio-web/src/main.tsx
+++ b/apps/studio-web/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "./index.css";
 
 import App from "./App";
 

--- a/apps/studio-web/src/pages/ReviewPage.tsx
+++ b/apps/studio-web/src/pages/ReviewPage.tsx
@@ -236,11 +236,14 @@ export default function ReviewPage() {
       setSubtitleContent(null);
       return;
     }
+    setSubtitleContent(null); // reset before fetching
     const url = artifactUrl(preview.subtitle.path);
+    let cancelled = false;
     fetch(url)
       .then((res) => (res.ok ? res.text() : Promise.reject(res.status)))
-      .then((text) => setSubtitleContent(text))
-      .catch(() => setSubtitleContent("(Failed to load subtitle content)"));
+      .then((text) => { if (!cancelled) setSubtitleContent(text); })
+      .catch(() => { if (!cancelled) setSubtitleContent("(Failed to load subtitle content)"); });
+    return () => { cancelled = true; };
   }, [preview?.subtitle?.path]);
 
   // ---- render ----

--- a/apps/studio-web/src/pages/ReviewPage.tsx
+++ b/apps/studio-web/src/pages/ReviewPage.tsx
@@ -17,6 +17,12 @@ import PipelineStepper from "../components/creator/PipelineStepper";
 
 const API_BASE = "/api/creator";
 
+/** Convert API artifact path → browser-accessible URL via Vite proxy. */
+function artifactUrl(path: string): string {
+  const match = path.match(/data\/artifacts\/(.*)/);
+  return match ? `/artifacts/${match[1]}` : `/artifacts/${path}`;
+}
+
 // --------------- types ---------------
 
 interface RunDetail {
@@ -141,7 +147,7 @@ const previewBoxStyle: React.CSSProperties = {
   background: "#f9fafb",
   borderRadius: 6,
   fontSize: 13,
-  fontFamily: "monospace",
+  fontFamily: '"JetBrains Mono", "Fira Code", "Cascadia Code", "SF Mono", monospace',
   whiteSpace: "pre-wrap",
   overflowX: "auto",
   maxHeight: 300,
@@ -161,6 +167,7 @@ export default function ReviewPage() {
   const [assets, setAssets] = useState<Record<string, { asset_path: string; model_used: string; is_active: boolean }[]>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [subtitleContent, setSubtitleContent] = useState<string | null>(null);
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
@@ -222,6 +229,19 @@ export default function ReviewPage() {
       fetchAll();
     }
   }, [numericRunId, fetchAll]);
+
+  // Fetch subtitle content when preview is available
+  useEffect(() => {
+    if (!preview?.subtitle?.path) {
+      setSubtitleContent(null);
+      return;
+    }
+    const url = artifactUrl(preview.subtitle.path);
+    fetch(url)
+      .then((res) => (res.ok ? res.text() : Promise.reject(res.status)))
+      .then((text) => setSubtitleContent(text))
+      .catch(() => setSubtitleContent("(Failed to load subtitle content)"));
+  }, [preview?.subtitle?.path]);
 
   // ---- render ----
 
@@ -353,30 +373,48 @@ export default function ReviewPage() {
             <h3 style={sectionTitle}>Visual Assets</h3>
             <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
           </div>
-          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             {Object.entries(assets).map(([sceneId, sceneAssets]) => (
               <div key={sceneId}>
-                <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 4 }}>{sceneId}</div>
-                {sceneAssets.map((asset, idx) => (
-                  <div
-                    key={idx}
-                    style={{
-                      padding: 8,
-                      background: asset.is_active ? "#f0fdf4" : "#f9fafb",
-                      borderRadius: 4,
-                      border: asset.is_active ? "1px solid #bbf7d0" : "1px solid #e5e7eb",
-                      marginBottom: 4,
-                    }}
-                  >
-                    <span style={{ fontSize: 13 }}>{asset.asset_path}</span>
-                    <span style={metaStyle}> &middot; Model: {asset.model_used}</span>
-                    {asset.is_active && (
-                      <span style={{ fontSize: 11, color: "#166534", fontWeight: 600, marginLeft: 8 }}>
-                        ACTIVE
-                      </span>
-                    )}
-                  </div>
-                ))}
+                <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 8 }}>{sceneId}</div>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8 }}>
+                  {sceneAssets.map((asset, idx) => (
+                    <div
+                      key={idx}
+                      style={{
+                        background: asset.is_active ? "#f0fdf4" : "#f9fafb",
+                        borderRadius: 6,
+                        border: asset.is_active ? "1px solid #bbf7d0" : "1px solid #e5e7eb",
+                        overflow: "hidden",
+                      }}
+                    >
+                      <img
+                        src={artifactUrl(asset.asset_path)}
+                        alt={`${sceneId} asset ${idx + 1}`}
+                        style={{
+                          width: "100%",
+                          aspectRatio: "9 / 16",
+                          objectFit: "cover",
+                          display: "block",
+                          background: "#e5e7eb",
+                        }}
+                      />
+                      <div style={{ padding: "6px 8px" }}>
+                        <div style={{ fontSize: 11, color: "#374151", wordBreak: "break-all" }}>
+                          {asset.asset_path.split("/").pop()}
+                        </div>
+                        <div style={{ display: "flex", alignItems: "center", gap: 4, marginTop: 2 }}>
+                          <span style={metaStyle}>Model: {asset.model_used}</span>
+                          {asset.is_active && (
+                            <span style={{ fontSize: 10, color: "#166534", fontWeight: 600, background: "#dcfce7", padding: "1px 5px", borderRadius: 3 }}>
+                              ACTIVE
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
             ))}
           </div>
@@ -390,10 +428,14 @@ export default function ReviewPage() {
             <h3 style={sectionTitle}>Audio</h3>
             <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
           </div>
+          <audio
+            controls
+            style={{ width: "100%", marginBottom: 8, borderRadius: 6 }}
+            src={artifactUrl(preview.audio.path)}
+          />
           <div style={{ fontSize: 13 }}>
-            <div><strong>Path:</strong> {preview.audio.path}</div>
             <div><strong>Model:</strong> {preview.audio.model_used}</div>
-            <div style={metaStyle}>Created: {preview.audio.created_at}</div>
+            <div style={metaStyle}>Created: {new Date(preview.audio.created_at).toLocaleString()}</div>
           </div>
         </div>
       )}
@@ -405,10 +447,16 @@ export default function ReviewPage() {
             <h3 style={sectionTitle}>Subtitles</h3>
             <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
           </div>
-          <div style={{ fontSize: 13 }}>
-            <div><strong>Path:</strong> {preview.subtitle.path}</div>
+          {subtitleContent !== null ? (
+            <div style={previewBoxStyle}>{subtitleContent}</div>
+          ) : (
+            <div style={{ fontSize: 13, color: "#6b7280", fontStyle: "italic" }}>
+              Loading subtitle content…
+            </div>
+          )}
+          <div style={{ fontSize: 13, marginTop: 8 }}>
             <div><strong>Format:</strong> {preview.subtitle.format}</div>
-            <div style={metaStyle}>Created: {preview.subtitle.created_at}</div>
+            <div style={metaStyle}>Created: {new Date(preview.subtitle.created_at).toLocaleString()}</div>
           </div>
         </div>
       )}
@@ -420,10 +468,20 @@ export default function ReviewPage() {
             <h3 style={sectionTitle}>Rendered Video</h3>
             <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
           </div>
+          <video
+            controls
+            style={{
+              width: "100%",
+              maxHeight: 640,
+              borderRadius: 6,
+              background: "#000",
+              marginBottom: 8,
+            }}
+            src={artifactUrl(preview.video.path)}
+          />
           <div style={{ fontSize: 13 }}>
-            <div><strong>Path:</strong> {preview.video.path}</div>
             <div><strong>Profile:</strong> {preview.video.render_profile ?? "default"}</div>
-            <div style={metaStyle}>Created: {preview.video.created_at}</div>
+            <div style={metaStyle}>Created: {new Date(preview.video.created_at).toLocaleString()}</div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- **ReviewPage media previews**: Visual assets now render as image thumbnails in a responsive grid (9:16 aspect ratio). Audio and video sections embed native `<audio>` and `<video>` players with controls. Subtitle section fetches and displays actual SRT file content.
- **Beautiful typography**: Added Pretendard Variable (Korean-optimized), Inter (Latin), and JetBrains Mono (code) fonts via CDN. Created global `index.css` with font stack, CSS reset, and scrollbar styling.
- **Test update**: Updated video section test assertion to check `<video>` element `src` attribute instead of text content (10/10 tests pass).

## Changes

| File | Change |
|------|--------|
| `apps/studio-web/index.html` | Added Pretendard, Inter, JetBrains Mono CDN links |
| `apps/studio-web/src/index.css` | **NEW** — Global CSS reset, font stack, scrollbar styling |
| `apps/studio-web/src/main.tsx` | Added `import "./index.css"` |
| `apps/studio-web/src/pages/ReviewPage.tsx` | `artifactUrl()` helper, `<img>` grid for assets, `<audio>`/`<video>` players, subtitle content fetch+display |
| `apps/studio-web/src/__tests__/ReviewPage.test.tsx` | Video section assertion updated for `<video>` element |

## Testing

- All 10 ReviewPage tests pass ✅
- No LSP diagnostics on any changed file ✅