### PR TITLE
feat(provider): implement OpenAI, Anthropic, and Gemini LLM providers

### DIFF
--- a/packages/creator-provider/creator_provider/llm/__init__.py
+++ b/packages/creator-provider/creator_provider/llm/__init__.py
@@ -1,3 +1,6 @@
 from .ollama_provider import OllamaProvider
+from .openai_provider import OpenAIProvider
+from .anthropic_provider import AnthropicProvider
+from .gemini_provider import GeminiProvider
 
-__all__ = ["OllamaProvider"]
+__all__ = ["OllamaProvider", "OpenAIProvider", "AnthropicProvider", "GeminiProvider"]

--- a/packages/creator-provider/creator_provider/llm/anthropic_provider.py
+++ b/packages/creator-provider/creator_provider/llm/anthropic_provider.py
@@ -8,13 +8,15 @@ from creator_provider.api_keys import resolve_api_key
 from creator_provider.base import LLMProvider
 
 
-class OpenAIProvider(LLMProvider):
+class AnthropicProvider(LLMProvider):
+    _API_VERSION = "2023-06-01"
+
     def __init__(self, endpoint: str, model_key: str):
         self.endpoint: str = endpoint.rstrip("/")
         self.model_key: str = model_key
-        api_key = resolve_api_key("openai")
+        api_key = resolve_api_key("anthropic")
         if api_key is None:
-            raise ValueError("API key for 'openai' not configured")
+            raise ValueError("API key for 'anthropic' not configured")
         self.api_key: str = api_key
 
     async def generate(self, prompt: str, params: dict[str, Any] | None = None) -> str:
@@ -23,13 +25,14 @@ class OpenAIProvider(LLMProvider):
 
         payload = {
             "model": self.model_key,
-            "messages": [{"role": "user", "content": prompt}],
             "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": prompt}],
         }
 
-        url = f"{self.endpoint}/v1/chat/completions"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
+        url = f"{self.endpoint}/v1/messages"
+        headers: dict[str, str] = {
+            "x-api-key": self.api_key,
+            "anthropic-version": self._API_VERSION,
             "Content-Type": "application/json",
         }
 
@@ -38,10 +41,10 @@ class OpenAIProvider(LLMProvider):
                 response = await client.post(url, json=payload, headers=headers)
                 response.raise_for_status()
         except httpx.HTTPError as exc:
-            raise RuntimeError(f"OpenAI API request failed: {exc}") from exc
+            raise RuntimeError(f"Anthropic API request failed: {exc}") from exc
 
         data = response.json()
-        choices = data.get("choices", [])
-        if not choices:
-            raise RuntimeError("OpenAI API returned no choices")
-        return str(choices[0].get("message", {}).get("content", ""))
+        content_blocks = data.get("content", [])
+        if not content_blocks:
+            raise RuntimeError("Anthropic API returned no content blocks")
+        return "".join(block.get("text", "") for block in content_blocks if block.get("type") == "text")

--- a/packages/creator-provider/creator_provider/llm/gemini_provider.py
+++ b/packages/creator-provider/creator_provider/llm/gemini_provider.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from creator_provider.api_keys import resolve_api_key
+from creator_provider.base import LLMProvider
+
+
+class GeminiProvider(LLMProvider):
+    def __init__(self, endpoint: str, model_key: str):
+        self.endpoint: str = endpoint.rstrip("/")
+        self.model_key: str = model_key
+        api_key = resolve_api_key("google")
+        if api_key is None:
+            raise ValueError("API key for 'google' not configured")
+        self.api_key: str = api_key
+
+    async def generate(self, prompt: str, params: dict[str, Any] | None = None) -> str:
+        timeout = (params or {}).get("timeout", 120.0)
+        max_tokens = (params or {}).get("max_tokens", 2048)
+
+        url = (
+            f"{self.endpoint}/v1beta/models/{self.model_key}"
+            f":generateContent?key={self.api_key}"
+        )
+        payload = {
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {
+                "maxOutputTokens": max_tokens,
+            },
+        }
+        headers = {"Content-Type": "application/json"}
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(url, json=payload, headers=headers)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"Gemini API request failed: {exc}") from exc
+
+        data = response.json()
+        candidates = data.get("candidates", [])
+        if not candidates:
+            raise RuntimeError("Gemini API returned no candidates")
+        parts = candidates[0].get("content", {}).get("parts", [])
+        return "".join(part.get("text", "") for part in parts)

--- a/packages/creator-provider/creator_provider/registry.py
+++ b/packages/creator-provider/creator_provider/registry.py
@@ -53,7 +53,10 @@ class ProviderRegistry:
     @classmethod
     def create_default(cls) -> "ProviderRegistry":
         from creator_provider.image.sd_local_provider import SDLocalProvider
+        from creator_provider.llm.anthropic_provider import AnthropicProvider
+        from creator_provider.llm.gemini_provider import GeminiProvider
         from creator_provider.llm.ollama_provider import OllamaProvider
+        from creator_provider.llm.openai_provider import OpenAIProvider
         from creator_provider.stt.whisper_provider import WhisperSTTProvider
         from creator_provider.tts.qwen_tts_provider import QwenTTSProvider
 
@@ -62,6 +65,9 @@ class ProviderRegistry:
         registry.register_provider("sd_local", SDLocalProvider)
         registry.register_provider("qwen_tts", QwenTTSProvider)
         registry.register_provider("whisper", WhisperSTTProvider)
+        registry.register_provider("openai_llm", OpenAIProvider)
+        registry.register_provider("anthropic_llm", AnthropicProvider)
+        registry.register_provider("gemini_llm", GeminiProvider)
         registry.register_model(
             ModelCatalogEntry(
                 model_key="qwen3-4b",
@@ -100,6 +106,36 @@ class ProviderRegistry:
                 category=ProviderCategory.STT,
                 requires_gpu=True,
                 is_local=True,
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="gpt-4o-mini",
+                provider_type="openai_llm",
+                endpoint="https://api.openai.com",
+                category=ProviderCategory.LLM,
+                requires_gpu=False,
+                is_local=False,
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="claude-sonnet-4-20250514",
+                provider_type="anthropic_llm",
+                endpoint="https://api.anthropic.com",
+                category=ProviderCategory.LLM,
+                requires_gpu=False,
+                is_local=False,
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="gemini-2.0-flash",
+                provider_type="gemini_llm",
+                endpoint="https://generativelanguage.googleapis.com",
+                category=ProviderCategory.LLM,
+                requires_gpu=False,
+                is_local=False,
             )
         )
         return registry

--- a/packages/creator-provider/tests/test_external_llm_providers.py
+++ b/packages/creator-provider/tests/test_external_llm_providers.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import httpx
+import pytest
+
+
+class TestOpenAIProvider:
+    def test_constructor_sets_attributes(self):
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.llm.openai_provider import OpenAIProvider
+
+            provider = OpenAIProvider(endpoint="https://api.openai.com", model_key="gpt-4o-mini")
+            assert provider.endpoint == "https://api.openai.com"
+            assert provider.model_key == "gpt-4o-mini"
+            assert provider.api_key == "sk-test"
+
+    def test_missing_api_key_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            from creator_provider.llm.openai_provider import OpenAIProvider
+
+            with pytest.raises(ValueError, match="not configured"):
+                OpenAIProvider(endpoint="https://api.openai.com", model_key="gpt-4o-mini")
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Hello world"}}],
+        }
+
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.llm.openai_provider import OpenAIProvider
+
+            provider = OpenAIProvider(endpoint="https://api.openai.com", model_key="gpt-4o-mini")
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
+                result = await provider.generate("test prompt")
+                assert result == "Hello world"
+                mock_post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error_raises_runtime_error(self):
+        request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        response = httpx.Response(401, request=request)
+        status_error = httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = status_error
+
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.llm.openai_provider import OpenAIProvider
+
+            provider = OpenAIProvider(endpoint="https://api.openai.com", model_key="gpt-4o-mini")
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="OpenAI API request failed"):
+                    await provider.generate("test prompt")
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_choices_raises(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {"choices": []}
+
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.llm.openai_provider import OpenAIProvider
+
+            provider = OpenAIProvider(endpoint="https://api.openai.com", model_key="gpt-4o-mini")
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="no choices"):
+                    await provider.generate("test prompt")
+
+
+class TestAnthropicProvider:
+    def test_constructor_sets_attributes(self):
+        with mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "ak-test"}):
+            from creator_provider.llm.anthropic_provider import AnthropicProvider
+
+            provider = AnthropicProvider(
+                endpoint="https://api.anthropic.com",
+                model_key="claude-sonnet-4-20250514",
+            )
+            assert provider.endpoint == "https://api.anthropic.com"
+            assert provider.model_key == "claude-sonnet-4-20250514"
+            assert provider.api_key == "ak-test"
+
+    def test_missing_api_key_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            from creator_provider.llm.anthropic_provider import AnthropicProvider
+
+            with pytest.raises(ValueError, match="not configured"):
+                AnthropicProvider(
+                    endpoint="https://api.anthropic.com",
+                    model_key="claude-sonnet-4-20250514",
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {
+            "content": [{"type": "text", "text": "Hello from Claude"}],
+        }
+
+        with mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "ak-test"}):
+            from creator_provider.llm.anthropic_provider import AnthropicProvider
+
+            provider = AnthropicProvider(
+                endpoint="https://api.anthropic.com",
+                model_key="claude-sonnet-4-20250514",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                result = await provider.generate("test prompt")
+                assert result == "Hello from Claude"
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error_raises_runtime_error(self):
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        response = httpx.Response(401, request=request)
+        status_error = httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = status_error
+
+        with mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "ak-test"}):
+            from creator_provider.llm.anthropic_provider import AnthropicProvider
+
+            provider = AnthropicProvider(
+                endpoint="https://api.anthropic.com",
+                model_key="claude-sonnet-4-20250514",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="Anthropic API request failed"):
+                    await provider.generate("test prompt")
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_content_raises(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {"content": []}
+
+        with mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "ak-test"}):
+            from creator_provider.llm.anthropic_provider import AnthropicProvider
+
+            provider = AnthropicProvider(
+                endpoint="https://api.anthropic.com",
+                model_key="claude-sonnet-4-20250514",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="no content blocks"):
+                    await provider.generate("test prompt")
+
+
+class TestGeminiProvider:
+    def test_constructor_sets_attributes(self):
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+            from creator_provider.llm.gemini_provider import GeminiProvider
+
+            provider = GeminiProvider(
+                endpoint="https://generativelanguage.googleapis.com",
+                model_key="gemini-2.0-flash",
+            )
+            assert provider.endpoint == "https://generativelanguage.googleapis.com"
+            assert provider.model_key == "gemini-2.0-flash"
+            assert provider.api_key == "gk-test"
+
+    def test_missing_api_key_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            from creator_provider.llm.gemini_provider import GeminiProvider
+
+            with pytest.raises(ValueError, match="not configured"):
+                GeminiProvider(
+                    endpoint="https://generativelanguage.googleapis.com",
+                    model_key="gemini-2.0-flash",
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {
+            "candidates": [{"content": {"parts": [{"text": "Hello from Gemini"}]}}],
+        }
+
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+            from creator_provider.llm.gemini_provider import GeminiProvider
+
+            provider = GeminiProvider(
+                endpoint="https://generativelanguage.googleapis.com",
+                model_key="gemini-2.0-flash",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                result = await provider.generate("test prompt")
+                assert result == "Hello from Gemini"
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error_raises_runtime_error(self):
+        request = httpx.Request(
+            "POST",
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+        )
+        response = httpx.Response(401, request=request)
+        status_error = httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = status_error
+
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+            from creator_provider.llm.gemini_provider import GeminiProvider
+
+            provider = GeminiProvider(
+                endpoint="https://generativelanguage.googleapis.com",
+                model_key="gemini-2.0-flash",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="Gemini API request failed"):
+                    await provider.generate("test prompt")
+
+    @pytest.mark.asyncio
+    async def test_generate_no_candidates_raises(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {"candidates": []}
+
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+            from creator_provider.llm.gemini_provider import GeminiProvider
+
+            provider = GeminiProvider(
+                endpoint="https://generativelanguage.googleapis.com",
+                model_key="gemini-2.0-flash",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="no candidates"):
+                    await provider.generate("test prompt")

--- a/packages/creator-provider/tests/test_registry.py
+++ b/packages/creator-provider/tests/test_registry.py
@@ -70,11 +70,14 @@ class ProviderRegistryTests(unittest.TestCase):
     def test_create_default_returns_registry_with_default_entries(self) -> None:
         registry = ProviderRegistry.create_default()
 
-        self.assertEqual(len(registry.list_models()), 4)
+        self.assertEqual(len(registry.list_models()), 7)
         self.assertEqual(registry.resolve("qwen3-4b").category, ProviderCategory.LLM)
         self.assertEqual(registry.resolve("sd15").category, ProviderCategory.IMAGE)
         self.assertEqual(registry.resolve("qwen3-tts").category, ProviderCategory.TTS)
         self.assertEqual(registry.resolve("whisper-small").category, ProviderCategory.STT)
+        self.assertEqual(registry.resolve("gpt-4o-mini").category, ProviderCategory.LLM)
+        self.assertEqual(registry.resolve("claude-sonnet-4-20250514").category, ProviderCategory.LLM)
+        self.assertEqual(registry.resolve("gemini-2.0-flash").category, ProviderCategory.LLM)
 
     def test_get_provider_raises_key_error_for_unregistered_provider_type(self) -> None:
         registry = ProviderRegistry()

--- a/packages/creator-service/creator_service/model_catalog_service.py
+++ b/packages/creator-service/creator_service/model_catalog_service.py
@@ -44,6 +44,8 @@ class ModelCatalogService:
         "qwen3-tts": "Qwen3 TTS",
         "whisper-small": "Whisper Small",
         "gpt-4o-mini": "GPT-4o Mini",
+        "claude-sonnet-4-20250514": "Claude Sonnet",
+        "gemini-2.0-flash": "Gemini 2.0 Flash",
         "llama-3.1-8b": "Llama 3.1 8B",
     }
 


### PR DESCRIPTION
## Summary
- Add OpenAI GPT-4o Mini provider using httpx Chat Completions API
- Add Anthropic Claude Sonnet provider using httpx Messages API
- Add Google Gemini 2.0 Flash provider using httpx REST API
- All three registered in `ProviderRegistry.create_default()` with `requires_gpu=False`, `is_local=False`
- Model catalog labels added for frontend display

## Files Changed
- `packages/creator-provider/creator_provider/llm/openai_provider.py` — OpenAI provider
- `packages/creator-provider/creator_provider/llm/anthropic_provider.py` — Anthropic provider
- `packages/creator-provider/creator_provider/llm/gemini_provider.py` — Gemini provider
- `packages/creator-provider/creator_provider/llm/__init__.py` — Updated exports
- `packages/creator-provider/creator_provider/registry.py` — New provider types + model entries
- `packages/creator-service/creator_service/model_catalog_service.py` — Labels
- `packages/creator-provider/tests/test_external_llm_providers.py` — **NEW**: 15 tests
- `packages/creator-provider/tests/test_registry.py` — Updated model count

## Testing
- `pytest packages/creator-provider/tests/ -v` → 53 passed

Closes #193, closes #194, closes #195