### PR TITLE
feat(provider): implement DALL-E 3, Stability AI, and Google Imagen image providers

### DIFF
--- a/packages/creator-provider/creator_provider/image/__init__.py
+++ b/packages/creator-provider/creator_provider/image/__init__.py
@@ -1,3 +1,6 @@
 from .sd_local_provider import SDLocalProvider
+from .dalle_provider import DalleProvider
+from .stability_provider import StabilityProvider
+from .imagen_provider import ImagenProvider
 
-__all__ = ["SDLocalProvider"]
+__all__ = ["SDLocalProvider", "DalleProvider", "StabilityProvider", "ImagenProvider"]

--- a/packages/creator-provider/creator_provider/image/dalle_provider.py
+++ b/packages/creator-provider/creator_provider/image/dalle_provider.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+import tempfile
+from typing import Any
+
+import httpx
+
+from creator_provider.api_keys import resolve_api_key
+from creator_provider.base import ImageProvider, ImageResult
+
+
+class DalleProvider(ImageProvider):
+
+    def __init__(self, endpoint: str, model_key: str):
+        self.endpoint = endpoint.rstrip("/")
+        self.model_key = model_key
+        self.api_key = resolve_api_key("openai")
+
+    async def generate(self, prompt: str, params: dict[str, Any] | None = None) -> ImageResult:
+        merged = dict(params or {})
+        width = int(merged.get("width", 1024))
+        height = int(merged.get("height", 1792))
+        size = f"{width}x{height}"
+        timeout = float(merged.get("timeout", 120.0))
+
+        payload = {
+            "model": self.model_key,
+            "prompt": prompt,
+            "n": 1,
+            "size": size,
+            "response_format": "b64_json",
+        }
+
+        url = f"{self.endpoint}/v1/images/generations"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(url, json=payload, headers=headers)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"DALL-E API request failed: {exc}") from exc
+
+        data = response.json()
+        images = data.get("data", [])
+        if not images:
+            raise RuntimeError("DALL-E API returned no images")
+
+        image_b64 = images[0].get("b64_json", "")
+        if not image_b64:
+            raise RuntimeError("DALL-E API returned empty image data")
+
+        image_bytes = base64.b64decode(image_b64)
+
+        output_path_str = merged.get("output_path")
+        if output_path_str:
+            output_path = Path(str(output_path_str))
+        else:
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+                output_path = Path(tmp.name)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(image_bytes)
+
+        return ImageResult(
+            image_path=str(output_path),
+            width=width,
+            height=height,
+            model_key=self.model_key,
+        )

--- a/packages/creator-provider/creator_provider/image/imagen_provider.py
+++ b/packages/creator-provider/creator_provider/image/imagen_provider.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+import tempfile
+from typing import Any
+
+import httpx
+
+from creator_provider.api_keys import resolve_api_key
+from creator_provider.base import ImageProvider, ImageResult
+
+
+class ImagenProvider(ImageProvider):
+    def __init__(self, endpoint: str, model_key: str):
+        self.endpoint = endpoint.rstrip("/")
+        self.model_key = model_key
+        self.api_key = resolve_api_key("google")
+
+    async def generate(self, prompt: str, params: dict[str, Any] | None = None) -> ImageResult:
+        merged = dict(params or {})
+        width = int(merged.get("width", 1024))
+        height = int(merged.get("height", 1792))
+        timeout = float(merged.get("timeout", 120.0))
+
+        url = (
+            f"{self.endpoint}/v1beta/models/{self.model_key}"
+            f":generateImages?key={self.api_key}"
+        )
+        payload = {
+            "prompt": prompt,
+            "config": {
+                "numberOfImages": 1,
+            },
+        }
+        headers = {"Content-Type": "application/json"}
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(url, json=payload, headers=headers)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"Imagen API request failed: {exc}") from exc
+
+        data = response.json()
+        images = data.get("generatedImages", [])
+        if not images:
+            raise RuntimeError("Imagen API returned no images")
+
+        image_b64 = images[0].get("image", {}).get("imageBytes", "")
+        if not image_b64:
+            raise RuntimeError("Imagen API returned empty image data")
+
+        image_bytes = base64.b64decode(image_b64)
+
+        output_path_str = merged.get("output_path")
+        if output_path_str:
+            output_path = Path(str(output_path_str))
+        else:
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+                output_path = Path(tmp.name)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(image_bytes)
+
+        return ImageResult(
+            image_path=str(output_path),
+            width=width,
+            height=height,
+            model_key=self.model_key,
+        )

--- a/packages/creator-provider/creator_provider/image/stability_provider.py
+++ b/packages/creator-provider/creator_provider/image/stability_provider.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+from typing import Any
+
+import httpx
+
+from creator_provider.api_keys import resolve_api_key
+from creator_provider.base import ImageProvider, ImageResult
+
+
+class StabilityProvider(ImageProvider):
+    def __init__(self, endpoint: str, model_key: str):
+        self.endpoint = endpoint.rstrip("/")
+        self.model_key = model_key
+        self.api_key = resolve_api_key("stability")
+
+    async def generate(self, prompt: str, params: dict[str, Any] | None = None) -> ImageResult:
+        merged = dict(params or {})
+        aspect_ratio = str(merged.get("aspect_ratio", "9:16"))
+        output_format = str(merged.get("output_format", "png"))
+        timeout = float(merged.get("timeout", 120.0))
+
+        width, height = self._parse_aspect_ratio(aspect_ratio)
+
+        url = f"{self.endpoint}/v2beta/stable-image/generate/sd3"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "image/*",
+        }
+
+        form_data = {
+            "prompt": prompt,
+            "output_format": output_format,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(url, data=form_data, headers=headers)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"Stability AI API request failed: {exc}") from exc
+
+        image_bytes = response.content
+        if not image_bytes:
+            raise RuntimeError("Stability AI API returned empty response")
+
+        output_path_str = merged.get("output_path")
+        if output_path_str:
+            output_path = Path(str(output_path_str))
+        else:
+            with tempfile.NamedTemporaryFile(suffix=f".{output_format}", delete=False) as tmp:
+                output_path = Path(tmp.name)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(image_bytes)
+
+        return ImageResult(
+            image_path=str(output_path),
+            width=width,
+            height=height,
+            model_key=self.model_key,
+        )
+
+    @staticmethod
+    def _parse_aspect_ratio(ratio: str) -> tuple[int, int]:
+        ratio_map = {
+            "9:16": (576, 1024),
+            "16:9": (1024, 576),
+            "1:1": (1024, 1024),
+            "3:2": (1024, 683),
+            "2:3": (683, 1024),
+        }
+        return ratio_map.get(ratio, (1024, 1024))

--- a/packages/creator-provider/creator_provider/registry.py
+++ b/packages/creator-provider/creator_provider/registry.py
@@ -52,7 +52,10 @@ class ProviderRegistry:
 
     @classmethod
     def create_default(cls) -> "ProviderRegistry":
+        from creator_provider.image.dalle_provider import DalleProvider
+        from creator_provider.image.imagen_provider import ImagenProvider
         from creator_provider.image.sd_local_provider import SDLocalProvider
+        from creator_provider.image.stability_provider import StabilityProvider
         from creator_provider.llm.anthropic_provider import AnthropicProvider
         from creator_provider.llm.gemini_provider import GeminiProvider
         from creator_provider.llm.ollama_provider import OllamaProvider
@@ -68,6 +71,9 @@ class ProviderRegistry:
         registry.register_provider("openai_llm", OpenAIProvider)
         registry.register_provider("anthropic_llm", AnthropicProvider)
         registry.register_provider("gemini_llm", GeminiProvider)
+        registry.register_provider("openai_image", DalleProvider)
+        registry.register_provider("stability_image", StabilityProvider)
+        registry.register_provider("google_image", ImagenProvider)
         registry.register_model(
             ModelCatalogEntry(
                 model_key="qwen3-4b",
@@ -136,6 +142,39 @@ class ProviderRegistry:
                 category=ProviderCategory.LLM,
                 requires_gpu=False,
                 is_local=False,
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="dall-e-3",
+                provider_type="openai_image",
+                endpoint="https://api.openai.com",
+                category=ProviderCategory.IMAGE,
+                requires_gpu=False,
+                is_local=False,
+                default_params={"width": 1024, "height": 1792},
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="sd3-medium",
+                provider_type="stability_image",
+                endpoint="https://api.stability.ai",
+                category=ProviderCategory.IMAGE,
+                requires_gpu=False,
+                is_local=False,
+                default_params={"aspect_ratio": "9:16"},
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="imagen-3",
+                provider_type="google_image",
+                endpoint="https://generativelanguage.googleapis.com",
+                category=ProviderCategory.IMAGE,
+                requires_gpu=False,
+                is_local=False,
+                default_params={"width": 1024, "height": 1792},
             )
         )
         return registry

--- a/packages/creator-provider/tests/test_external_image_providers.py
+++ b/packages/creator-provider/tests/test_external_image_providers.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+from unittest import mock
+
+import httpx
+import pytest
+
+
+class TestDalleProvider:
+    def test_constructor_sets_attributes(self):
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.image.dalle_provider import DalleProvider
+
+            provider = DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3")
+            assert provider.endpoint == "https://api.openai.com"
+            assert provider.model_key == "dall-e-3"
+            assert provider.api_key == "sk-test"
+
+    def test_missing_api_key_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            from creator_provider.image.dalle_provider import DalleProvider
+
+            with pytest.raises(ValueError, match="not configured"):
+                DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3")
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self, tmp_path: Path):
+        image_bytes = b"dalle-image-bytes"
+        encoded = base64.b64encode(image_bytes).decode("utf-8")
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {"data": [{"b64_json": encoded}]}
+
+        output_path = tmp_path / "nested" / "dalle.png"
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.image.dalle_provider import DalleProvider
+
+            provider = DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3")
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
+                result = await provider.generate(
+                    "test prompt",
+                    {"width": 640, "height": 960, "output_path": str(output_path)},
+                )
+
+        mock_post.assert_called_once()
+        assert output_path.exists()
+        assert output_path.read_bytes() == image_bytes
+        assert result.image_path == str(output_path)
+        assert result.width == 640
+        assert result.height == 960
+        assert result.model_key == "dall-e-3"
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error_raises_runtime_error(self):
+        request = httpx.Request("POST", "https://api.openai.com/v1/images/generations")
+        response = httpx.Response(401, request=request)
+        status_error = httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = status_error
+
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.image.dalle_provider import DalleProvider
+
+            provider = DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3")
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="DALL-E API request failed"):
+                    await provider.generate("test prompt")
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_response_raises(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {"data": []}
+
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.image.dalle_provider import DalleProvider
+
+            provider = DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3")
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="no images"):
+                    await provider.generate("test prompt")
+
+
+class TestStabilityProvider:
+    def test_constructor_sets_attributes(self):
+        with mock.patch.dict(os.environ, {"STABILITY_API_KEY": "st-test"}):
+            from creator_provider.image.stability_provider import StabilityProvider
+
+            provider = StabilityProvider(
+                endpoint="https://api.stability.ai",
+                model_key="sd3-medium",
+            )
+            assert provider.endpoint == "https://api.stability.ai"
+            assert provider.model_key == "sd3-medium"
+            assert provider.api_key == "st-test"
+
+    def test_missing_api_key_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            from creator_provider.image.stability_provider import StabilityProvider
+
+            with pytest.raises(ValueError, match="not configured"):
+                StabilityProvider(endpoint="https://api.stability.ai", model_key="sd3-medium")
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self, tmp_path: Path):
+        image_bytes = b"stability-image-bytes"
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.content = image_bytes
+
+        output_path = tmp_path / "nested" / "stability.webp"
+        with mock.patch.dict(os.environ, {"STABILITY_API_KEY": "st-test"}):
+            from creator_provider.image.stability_provider import StabilityProvider
+
+            provider = StabilityProvider(
+                endpoint="https://api.stability.ai",
+                model_key="sd3-medium",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
+                result = await provider.generate(
+                    "test prompt",
+                    {
+                        "aspect_ratio": "16:9",
+                        "output_format": "webp",
+                        "output_path": str(output_path),
+                    },
+                )
+
+        mock_post.assert_called_once()
+        assert output_path.exists()
+        assert output_path.read_bytes() == image_bytes
+        assert result.image_path == str(output_path)
+        assert result.width == 1024
+        assert result.height == 576
+        assert result.model_key == "sd3-medium"
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error_raises_runtime_error(self):
+        request = httpx.Request("POST", "https://api.stability.ai/v2beta/stable-image/generate/sd3")
+        response = httpx.Response(500, request=request)
+        status_error = httpx.HTTPStatusError("Server error", request=request, response=response)
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = status_error
+
+        with mock.patch.dict(os.environ, {"STABILITY_API_KEY": "st-test"}):
+            from creator_provider.image.stability_provider import StabilityProvider
+
+            provider = StabilityProvider(
+                endpoint="https://api.stability.ai",
+                model_key="sd3-medium",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="Stability AI API request failed"):
+                    await provider.generate("test prompt")
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_response_raises(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.content = b""
+
+        with mock.patch.dict(os.environ, {"STABILITY_API_KEY": "st-test"}):
+            from creator_provider.image.stability_provider import StabilityProvider
+
+            provider = StabilityProvider(
+                endpoint="https://api.stability.ai",
+                model_key="sd3-medium",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="empty response"):
+                    await provider.generate("test prompt")
+
+
+class TestImagenProvider:
+    def test_constructor_sets_attributes(self):
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+            from creator_provider.image.imagen_provider import ImagenProvider
+
+            provider = ImagenProvider(
+                endpoint="https://generativelanguage.googleapis.com",
+                model_key="imagen-3",
+            )
+            assert provider.endpoint == "https://generativelanguage.googleapis.com"
+            assert provider.model_key == "imagen-3"
+            assert provider.api_key == "gk-test"
+
+    def test_missing_api_key_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            from creator_provider.image.imagen_provider import ImagenProvider
+
+            with pytest.raises(ValueError, match="not configured"):
+                ImagenProvider(
+                    endpoint="https://generativelanguage.googleapis.com",
+                    model_key="imagen-3",
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self, tmp_path: Path):
+        image_bytes = b"imagen-image-bytes"
+        encoded = base64.b64encode(image_bytes).decode("utf-8")
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {
+            "generatedImages": [{"image": {"imageBytes": encoded}}],
+        }
+
+        output_path = tmp_path / "nested" / "imagen.png"
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+            from creator_provider.image.imagen_provider import ImagenProvider
+
+            provider = ImagenProvider(
+                endpoint="https://generativelanguage.googleapis.com",
+                model_key="imagen-3",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
+                result = await provider.generate(
+                    "test prompt",
+                    {"width": 1024, "height": 1536, "output_path": str(output_path)},
+                )
+
+        mock_post.assert_called_once()
+        assert output_path.exists()
+        assert output_path.read_bytes() == image_bytes
+        assert result.image_path == str(output_path)
+        assert result.width == 1024
+        assert result.height == 1536
+        assert result.model_key == "imagen-3"
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error_raises_runtime_error(self):
+        request = httpx.Request(
+            "POST",
+            "https://generativelanguage.googleapis.com/v1beta/models/imagen-3:generateImages",
+        )
+        response = httpx.Response(401, request=request)
+        status_error = httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = status_error
+
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+            from creator_provider.image.imagen_provider import ImagenProvider
+
+            provider = ImagenProvider(
+                endpoint="https://generativelanguage.googleapis.com",
+                model_key="imagen-3",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="Imagen API request failed"):
+                    await provider.generate("test prompt")
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_response_raises(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.json.return_value = {"generatedImages": []}
+
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+            from creator_provider.image.imagen_provider import ImagenProvider
+
+            provider = ImagenProvider(
+                endpoint="https://generativelanguage.googleapis.com",
+                model_key="imagen-3",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="no images"):
+                    await provider.generate("test prompt")

--- a/packages/creator-provider/tests/test_registry.py
+++ b/packages/creator-provider/tests/test_registry.py
@@ -70,7 +70,7 @@ class ProviderRegistryTests(unittest.TestCase):
     def test_create_default_returns_registry_with_default_entries(self) -> None:
         registry = ProviderRegistry.create_default()
 
-        self.assertEqual(len(registry.list_models()), 7)
+        self.assertEqual(len(registry.list_models()), 10)
         self.assertEqual(registry.resolve("qwen3-4b").category, ProviderCategory.LLM)
         self.assertEqual(registry.resolve("sd15").category, ProviderCategory.IMAGE)
         self.assertEqual(registry.resolve("qwen3-tts").category, ProviderCategory.TTS)
@@ -78,6 +78,9 @@ class ProviderRegistryTests(unittest.TestCase):
         self.assertEqual(registry.resolve("gpt-4o-mini").category, ProviderCategory.LLM)
         self.assertEqual(registry.resolve("claude-sonnet-4-20250514").category, ProviderCategory.LLM)
         self.assertEqual(registry.resolve("gemini-2.0-flash").category, ProviderCategory.LLM)
+        self.assertEqual(registry.resolve("dall-e-3").category, ProviderCategory.IMAGE)
+        self.assertEqual(registry.resolve("sd3-medium").category, ProviderCategory.IMAGE)
+        self.assertEqual(registry.resolve("imagen-3").category, ProviderCategory.IMAGE)
 
     def test_get_provider_raises_key_error_for_unregistered_provider_type(self) -> None:
         registry = ProviderRegistry()

--- a/packages/creator-service/creator_service/model_catalog_service.py
+++ b/packages/creator-service/creator_service/model_catalog_service.py
@@ -46,6 +46,9 @@ class ModelCatalogService:
         "gpt-4o-mini": "GPT-4o Mini",
         "claude-sonnet-4-20250514": "Claude Sonnet",
         "gemini-2.0-flash": "Gemini 2.0 Flash",
+        "dall-e-3": "DALL-E 3",
+        "sd3-medium": "Stability SD3",
+        "imagen-3": "Imagen 3",
         "llama-3.1-8b": "Llama 3.1 8B",
     }
 


### PR DESCRIPTION
## Summary

- Implements **DALL-E 3** image provider (`openai_image`) via OpenAI Images API
- Implements **Stability AI SD3** image provider (`stability_image`) via Stability REST API  
- Implements **Google Imagen 3** image provider (`google_image`) via Generative Language API
- Registers all 3 providers + 3 models in `ProviderRegistry` (total: 10 models)
- Adds model catalog labels: "DALL-E 3", "Stability SD3", "Imagen 3"
- 68 tests pass (15 new image provider tests)

Closes #196, Closes #197, Closes #198

## Changes

### New Files
- `packages/creator-provider/creator_provider/image/dalle_provider.py`
- `packages/creator-provider/creator_provider/image/stability_provider.py`
- `packages/creator-provider/creator_provider/image/imagen_provider.py`
- `packages/creator-provider/tests/test_external_image_providers.py`

### Modified Files
- `packages/creator-provider/creator_provider/image/__init__.py` — export new providers
- `packages/creator-provider/creator_provider/registry.py` — register 3 image provider types + models
- `packages/creator-service/creator_service/model_catalog_service.py` — add display labels
- `packages/creator-provider/tests/test_registry.py` — update model count to 10

## Testing
All providers use httpx (no SDK dependencies). Tests mock HTTP calls and env vars.