### PR TITLE
feat(provider): implement ElevenLabs and OpenAI TTS providers

### DIFF
--- a/packages/creator-provider/creator_provider/registry.py
+++ b/packages/creator-provider/creator_provider/registry.py
@@ -61,12 +61,16 @@ class ProviderRegistry:
         from creator_provider.llm.ollama_provider import OllamaProvider
         from creator_provider.llm.openai_provider import OpenAIProvider
         from creator_provider.stt.whisper_provider import WhisperSTTProvider
+        from creator_provider.tts.elevenlabs_provider import ElevenLabsProvider
+        from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
         from creator_provider.tts.qwen_tts_provider import QwenTTSProvider
 
         registry = cls()
         registry.register_provider("ollama", OllamaProvider)
         registry.register_provider("sd_local", SDLocalProvider)
         registry.register_provider("qwen_tts", QwenTTSProvider)
+        registry.register_provider("elevenlabs_tts", ElevenLabsProvider)
+        registry.register_provider("openai_tts", OpenAITTSProvider)
         registry.register_provider("whisper", WhisperSTTProvider)
         registry.register_provider("openai_llm", OpenAIProvider)
         registry.register_provider("anthropic_llm", AnthropicProvider)
@@ -102,6 +106,27 @@ class ProviderRegistry:
                 category=ProviderCategory.TTS,
                 requires_gpu=True,
                 is_local=True,
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="elevenlabs-multilingual-v2",
+                provider_type="elevenlabs_tts",
+                endpoint="https://api.elevenlabs.io",
+                category=ProviderCategory.TTS,
+                requires_gpu=False,
+                is_local=False,
+            )
+        )
+        registry.register_model(
+            ModelCatalogEntry(
+                model_key="openai-tts-1",
+                provider_type="openai_tts",
+                endpoint="https://api.openai.com",
+                category=ProviderCategory.TTS,
+                requires_gpu=False,
+                is_local=False,
+                default_params={"voice": "alloy"},
             )
         )
         registry.register_model(

--- a/packages/creator-provider/creator_provider/tts/__init__.py
+++ b/packages/creator-provider/creator_provider/tts/__init__.py
@@ -1,3 +1,5 @@
+from .elevenlabs_provider import ElevenLabsProvider
+from .openai_tts_provider import OpenAITTSProvider
 from .qwen_tts_provider import QwenTTSProvider
 
-__all__ = ["QwenTTSProvider"]
+__all__ = ["QwenTTSProvider", "ElevenLabsProvider", "OpenAITTSProvider"]

--- a/packages/creator-provider/creator_provider/tts/elevenlabs_provider.py
+++ b/packages/creator-provider/creator_provider/tts/elevenlabs_provider.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+import httpx
+
+from creator_provider.api_keys import resolve_api_key
+from creator_provider.base import AudioResult, TTSProvider
+
+
+class ElevenLabsProvider(TTSProvider):
+    def __init__(self, endpoint: str, model_key: str):
+        self.endpoint: str = endpoint.rstrip("/")
+        self.model_key: str = model_key
+        api_key = resolve_api_key("elevenlabs")
+        if api_key is None:
+            raise ValueError("API key for 'elevenlabs' not configured")
+        self.api_key: str = api_key
+
+    async def generate(
+        self,
+        text: str,
+        voice: str = "default",
+        params: dict[str, Any] | None = None,
+    ) -> AudioResult:
+        merged_params = dict(params or {})
+        voice_id = (
+            voice
+            if voice != "default"
+            else merged_params.get(
+                "voice_id",
+                os.getenv("ELEVENLABS_DEFAULT_VOICE", "21m00Tcm4TlvDq8ikWAM"),
+            )
+        )
+        model_id = merged_params.get("model_id", "eleven_multilingual_v2")
+        stability = merged_params.get("stability", 0.5)
+        similarity_boost = merged_params.get("similarity_boost", 0.75)
+        output_format = merged_params.get("output_format", "mp3_44100_128")
+
+        url = f"{self.endpoint}/v1/text-to-speech/{voice_id}"
+        headers = {
+            "xi-api-key": self.api_key,
+            "Content-Type": "application/json",
+            "Accept": "audio/mpeg",
+        }
+        payload = {
+            "text": text,
+            "model_id": model_id,
+            "voice_settings": {
+                "stability": stability,
+                "similarity_boost": similarity_boost,
+            },
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                response = await client.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    params={"output_format": output_format},
+                )
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"ElevenLabs API request failed: {exc}") from exc
+
+        audio_bytes = response.content
+        if not audio_bytes:
+            raise RuntimeError("ElevenLabs API returned empty response")
+
+        output_path_str = merged_params.get("output_path")
+        if output_path_str:
+            output_path = Path(str(output_path_str))
+        else:
+            with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
+                output_path = Path(tmp.name)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(audio_bytes)
+
+        duration = _estimate_mp3_duration(audio_bytes)
+        return AudioResult(
+            audio_path=str(output_path),
+            duration_seconds=duration,
+            model_key=self.model_key,
+        )
+
+
+def _estimate_mp3_duration(audio_bytes: bytes) -> float:
+    if len(audio_bytes) < 100:
+        return 0.0
+    bytes_per_second = 128 * 1000 / 8
+    return float(len(audio_bytes)) / float(bytes_per_second)

--- a/packages/creator-provider/creator_provider/tts/external_tts_provider.py
+++ b/packages/creator-provider/creator_provider/tts/external_tts_provider.py
@@ -1,1 +1,0 @@
-"""Placeholder for external_tts_provider."""

--- a/packages/creator-provider/creator_provider/tts/openai_tts_provider.py
+++ b/packages/creator-provider/creator_provider/tts/openai_tts_provider.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+from typing import Any
+
+import httpx
+
+from creator_provider.api_keys import resolve_api_key
+from creator_provider.base import AudioResult, TTSProvider
+
+
+class OpenAITTSProvider(TTSProvider):
+    def __init__(self, endpoint: str, model_key: str):
+        self.endpoint: str = endpoint.rstrip("/")
+        self.model_key: str = model_key
+        api_key = resolve_api_key("openai")
+        if api_key is None:
+            raise ValueError("API key for 'openai' not configured")
+        self.api_key: str = api_key
+
+    async def generate(
+        self,
+        text: str,
+        voice: str = "default",
+        params: dict[str, Any] | None = None,
+    ) -> AudioResult:
+        merged_params = dict(params or {})
+        voice_name = voice if voice != "default" else merged_params.get("voice", "alloy")
+        model = merged_params.get("model", "tts-1")
+        response_format = merged_params.get("response_format", "mp3")
+        speed = merged_params.get("speed", 1.0)
+        timeout = float(merged_params.get("timeout", 120.0))
+
+        url = f"{self.endpoint}/v1/audio/speech"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": model,
+            "input": text,
+            "voice": voice_name,
+            "response_format": response_format,
+            "speed": speed,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(url, json=payload, headers=headers)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"OpenAI TTS API request failed: {exc}") from exc
+
+        audio_bytes = response.content
+        if not audio_bytes:
+            raise RuntimeError("OpenAI TTS API returned empty response")
+
+        output_path_str = merged_params.get("output_path")
+        if output_path_str:
+            output_path = Path(str(output_path_str))
+        else:
+            with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
+                output_path = Path(tmp.name)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(audio_bytes)
+
+        duration = _estimate_mp3_duration(audio_bytes)
+        return AudioResult(
+            audio_path=str(output_path),
+            duration_seconds=duration,
+            model_key=self.model_key,
+        )
+
+
+def _estimate_mp3_duration(audio_bytes: bytes) -> float:
+    if len(audio_bytes) < 100:
+        return 0.0
+    bytes_per_second = 128 * 1000 / 8
+    return float(len(audio_bytes)) / float(bytes_per_second)

--- a/packages/creator-provider/tests/test_external_tts_providers.py
+++ b/packages/creator-provider/tests/test_external_tts_providers.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import httpx
+import pytest
+
+
+class TestElevenLabsProvider:
+    def test_constructor_sets_attributes(self):
+        with mock.patch.dict(os.environ, {"ELEVENLABS_API_KEY": "el-test"}):
+            from creator_provider.tts.elevenlabs_provider import ElevenLabsProvider
+
+            provider = ElevenLabsProvider(
+                endpoint="https://api.elevenlabs.io",
+                model_key="elevenlabs-multilingual-v2",
+            )
+            assert provider.endpoint == "https://api.elevenlabs.io"
+            assert provider.model_key == "elevenlabs-multilingual-v2"
+            assert provider.api_key == "el-test"
+
+    def test_missing_api_key_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            from creator_provider.tts.elevenlabs_provider import ElevenLabsProvider
+
+            with pytest.raises(ValueError, match="not configured"):
+                ElevenLabsProvider(
+                    endpoint="https://api.elevenlabs.io",
+                    model_key="elevenlabs-multilingual-v2",
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self, tmp_path: Path):
+        audio_bytes = b"a" * 32000
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.content = audio_bytes
+
+        output_path = tmp_path / "nested" / "elevenlabs.mp3"
+        with mock.patch.dict(os.environ, {"ELEVENLABS_API_KEY": "el-test"}):
+            from creator_provider.tts.elevenlabs_provider import ElevenLabsProvider
+
+            provider = ElevenLabsProvider(
+                endpoint="https://api.elevenlabs.io",
+                model_key="elevenlabs-multilingual-v2",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
+                result = await provider.generate(
+                    "test text",
+                    params={"output_path": str(output_path)},
+                )
+
+        mock_post.assert_called_once()
+        assert output_path.exists()
+        assert output_path.read_bytes() == audio_bytes
+        assert result.audio_path == str(output_path)
+        assert result.duration_seconds > 0
+        assert result.model_key == "elevenlabs-multilingual-v2"
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error_raises_runtime_error(self):
+        request = httpx.Request("POST", "https://api.elevenlabs.io/v1/text-to-speech/test")
+        response = httpx.Response(401, request=request)
+        status_error = httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = status_error
+
+        with mock.patch.dict(os.environ, {"ELEVENLABS_API_KEY": "el-test"}):
+            from creator_provider.tts.elevenlabs_provider import ElevenLabsProvider
+
+            provider = ElevenLabsProvider(
+                endpoint="https://api.elevenlabs.io",
+                model_key="elevenlabs-multilingual-v2",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="ElevenLabs API request failed"):
+                    await provider.generate("test text")
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_response_raises(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.content = b""
+
+        with mock.patch.dict(os.environ, {"ELEVENLABS_API_KEY": "el-test"}):
+            from creator_provider.tts.elevenlabs_provider import ElevenLabsProvider
+
+            provider = ElevenLabsProvider(
+                endpoint="https://api.elevenlabs.io",
+                model_key="elevenlabs-multilingual-v2",
+            )
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="empty response"):
+                    await provider.generate("test text")
+
+
+class TestOpenAITTSProvider:
+    def test_constructor_sets_attributes(self):
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
+
+            provider = OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")
+            assert provider.endpoint == "https://api.openai.com"
+            assert provider.model_key == "openai-tts-1"
+            assert provider.api_key == "sk-test"
+
+    def test_missing_api_key_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
+
+            with pytest.raises(ValueError, match="not configured"):
+                OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self, tmp_path: Path):
+        audio_bytes = b"b" * 32000
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.content = audio_bytes
+
+        output_path = tmp_path / "nested" / "openai.mp3"
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
+
+            provider = OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
+                result = await provider.generate(
+                    "test text",
+                    params={"output_path": str(output_path)},
+                )
+
+        mock_post.assert_called_once()
+        assert output_path.exists()
+        assert output_path.read_bytes() == audio_bytes
+        assert result.audio_path == str(output_path)
+        assert result.duration_seconds > 0
+        assert result.model_key == "openai-tts-1"
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error_raises_runtime_error(self):
+        request = httpx.Request("POST", "https://api.openai.com/v1/audio/speech")
+        response = httpx.Response(500, request=request)
+        status_error = httpx.HTTPStatusError("Server error", request=request, response=response)
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = status_error
+
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
+
+            provider = OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="OpenAI TTS API request failed"):
+                    await provider.generate("test text")
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_response_raises(self):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.content = b""
+
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+            from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
+
+            provider = OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")
+            with mock.patch("httpx.AsyncClient.post", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="empty response"):
+                    await provider.generate("test text")

--- a/packages/creator-provider/tests/test_registry.py
+++ b/packages/creator-provider/tests/test_registry.py
@@ -70,10 +70,12 @@ class ProviderRegistryTests(unittest.TestCase):
     def test_create_default_returns_registry_with_default_entries(self) -> None:
         registry = ProviderRegistry.create_default()
 
-        self.assertEqual(len(registry.list_models()), 10)
+        self.assertEqual(len(registry.list_models()), 12)
         self.assertEqual(registry.resolve("qwen3-4b").category, ProviderCategory.LLM)
         self.assertEqual(registry.resolve("sd15").category, ProviderCategory.IMAGE)
         self.assertEqual(registry.resolve("qwen3-tts").category, ProviderCategory.TTS)
+        self.assertEqual(registry.resolve("elevenlabs-multilingual-v2").category, ProviderCategory.TTS)
+        self.assertEqual(registry.resolve("openai-tts-1").category, ProviderCategory.TTS)
         self.assertEqual(registry.resolve("whisper-small").category, ProviderCategory.STT)
         self.assertEqual(registry.resolve("gpt-4o-mini").category, ProviderCategory.LLM)
         self.assertEqual(registry.resolve("claude-sonnet-4-20250514").category, ProviderCategory.LLM)

--- a/packages/creator-service/creator_service/model_catalog_service.py
+++ b/packages/creator-service/creator_service/model_catalog_service.py
@@ -42,6 +42,8 @@ class ModelCatalogService:
         "sd15": "Stable Diffusion 1.5",
         "sd-2.1": "Stable Diffusion 2.1",
         "qwen3-tts": "Qwen3 TTS",
+        "elevenlabs-multilingual-v2": "ElevenLabs Multilingual v2",
+        "openai-tts-1": "OpenAI TTS-1",
         "whisper-small": "Whisper Small",
         "gpt-4o-mini": "GPT-4o Mini",
         "claude-sonnet-4-20250514": "Claude Sonnet",


### PR DESCRIPTION
## Summary

- Implements **ElevenLabs TTS** provider (`elevenlabs_tts`) via ElevenLabs REST API (Multilingual v2)
- Implements **OpenAI TTS** provider (`openai_tts`) via OpenAI Audio Speech API (TTS-1)
- Registers both providers + 2 models in `ProviderRegistry` (total: 12 models)
- Adds model catalog labels: "ElevenLabs Multilingual v2", "OpenAI TTS-1"
- Removes placeholder `external_tts_provider.py`
- 78 tests pass (10 new TTS provider tests)

Closes #199, Closes #200

## Changes

### New Files
- `packages/creator-provider/creator_provider/tts/elevenlabs_provider.py`
- `packages/creator-provider/creator_provider/tts/openai_tts_provider.py`
- `packages/creator-provider/tests/test_external_tts_providers.py`

### Modified Files
- `packages/creator-provider/creator_provider/tts/__init__.py` — export new providers
- `packages/creator-provider/creator_provider/registry.py` — register 2 TTS provider types + models
- `packages/creator-service/creator_service/model_catalog_service.py` — add display labels
- `packages/creator-provider/tests/test_registry.py` — update model count to 12

### Deleted Files
- `packages/creator-provider/creator_provider/tts/external_tts_provider.py` — placeholder removed

## Testing
All providers use httpx (no SDK dependencies). MP3 duration estimated via bitrate calculation. Tests mock HTTP calls and env vars.