### PR TITLE
feat(settings): add API key settings page and enhanced ModelSelector

### DIFF
--- a/apps/api/src/shorts_api/main.py
+++ b/apps/api/src/shorts_api/main.py
@@ -13,6 +13,7 @@ from shorts_api.routes.creator_models import router as models_router
 from shorts_api.routes.creator_projects import router as projects_router
 from shorts_api.routes.creator_runs import router as runs_router
 from shorts_api.routes.creator_script import router as script_router, run_script_router
+from shorts_api.routes.creator_settings import router as settings_router
 from shorts_api.routes.creator_visual_plan import router as visual_plan_router
 
 # Configure structured JSON logging
@@ -58,7 +59,7 @@ async def request_logging_middleware(request: Request, call_next):
 model_health = ModelHealthService()
 
 @app.exception_handler(Exception)
-async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+async def global_exception_handler(request: Request, _exc: Exception) -> JSONResponse:
     logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
     return JSONResponse(
         status_code=500,
@@ -71,6 +72,7 @@ app.include_router(runs_router, prefix="/api/creator")
 app.include_router(script_router, prefix="/api/creator")
 app.include_router(run_script_router, prefix="/api/creator")
 app.include_router(visual_plan_router, prefix="/api/creator")
+app.include_router(settings_router, prefix="/api/creator")
 
 
 @app.get("/health")

--- a/apps/api/src/shorts_api/routes/creator_settings.py
+++ b/apps/api/src/shorts_api/routes/creator_settings.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(tags=["settings"])
+
+_PROVIDER_ENV_MAP: dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "stability": "STABILITY_API_KEY",
+    "elevenlabs": "ELEVENLABS_API_KEY",
+}
+
+_PROVIDER_LABELS: dict[str, str] = {
+    "openai": "OpenAI",
+    "anthropic": "Anthropic",
+    "google": "Google (Gemini / Imagen)",
+    "stability": "Stability AI",
+    "elevenlabs": "ElevenLabs",
+}
+
+_ENV_FILE = Path(os.getenv("ENV_FILE_PATH", "/data/GitHub/short-form-pipeline/.env"))
+
+
+class ApiKeyUpdate(BaseModel):
+    provider: str
+    api_key: str
+
+
+class ApiKeyStatus(BaseModel):
+    provider: str
+    label: str
+    configured: bool
+    masked: str
+
+
+def _mask_key(key: str) -> str:
+    if not key or len(key) < 8:
+        return "••••" if key else ""
+    return "••••" + key[-4:]
+
+
+def _read_env_file() -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not _ENV_FILE.exists():
+        return result
+    for line in _ENV_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            k, _, v = line.partition("=")
+            result[k.strip()] = v.strip().strip('"').strip("'")
+    return result
+
+
+def _write_env_file(updates: dict[str, str]) -> None:
+    lines: list[str] = []
+    updated_keys: set[str] = set()
+
+    if _ENV_FILE.exists():
+        for line in _ENV_FILE.read_text().splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#") and "=" in stripped:
+                k, _, _ = stripped.partition("=")
+                k = k.strip()
+                if k in updates:
+                    lines.append(f"{k}={updates[k]}")
+                    updated_keys.add(k)
+                    continue
+            lines.append(line)
+
+    for k, v in updates.items():
+        if k not in updated_keys:
+            lines.append(f"{k}={v}")
+
+    _ENV_FILE.write_text("\n".join(lines) + "\n")
+
+
+@router.get("/settings/api-keys")
+async def list_api_keys() -> list[ApiKeyStatus]:
+    env_data = _read_env_file()
+    result: list[ApiKeyStatus] = []
+    for provider, env_var in _PROVIDER_ENV_MAP.items():
+        value = env_data.get(env_var, "") or os.getenv(env_var, "")
+        value = value.strip()
+        result.append(
+            ApiKeyStatus(
+                provider=provider,
+                label=_PROVIDER_LABELS.get(provider, provider.title()),
+                configured=bool(value),
+                masked=_mask_key(value),
+            )
+        )
+    return result
+
+
+@router.post("/settings/api-keys")
+async def update_api_key(body: ApiKeyUpdate) -> ApiKeyStatus:
+    provider = body.provider.lower()
+    env_var = _PROVIDER_ENV_MAP.get(provider)
+    if env_var is None:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=400, detail=f"Unknown provider: {provider}")
+
+    _write_env_file({env_var: body.api_key})
+
+    os.environ[env_var] = body.api_key
+
+    return ApiKeyStatus(
+        provider=provider,
+        label=_PROVIDER_LABELS.get(provider, provider.title()),
+        configured=bool(body.api_key.strip()),
+        masked=_mask_key(body.api_key),
+    )

--- a/apps/studio-web/src/App.tsx
+++ b/apps/studio-web/src/App.tsx
@@ -7,6 +7,7 @@ import OpsPage from "./pages/OpsPage";
 import ProjectPage from "./pages/ProjectPage";
 import ReviewPage from "./pages/ReviewPage";
 import RunsPage from "./pages/RunsPage";
+import SettingsPage from "./pages/SettingsPage";
 
 export default function App() {
   return (
@@ -22,6 +23,7 @@ export default function App() {
           <Route path="/ops/library" element={<LibraryPage />} />
 
           <Route path="/ops" element={<OpsPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
 
           <Route path="*" element={<Navigate replace to="/create" />} />
         </Route>

--- a/apps/studio-web/src/components/creator/ModelSelector.tsx
+++ b/apps/studio-web/src/components/creator/ModelSelector.tsx
@@ -18,6 +18,13 @@ interface ModelsResponse {
   stt_models: ModelEntry[];
 }
 
+interface ApiKeyStatus {
+  provider: string;
+  label: string;
+  configured: boolean;
+  masked: string;
+}
+
 /** Category metadata for rendering. */
 interface CategoryMeta {
   responseKey: keyof ModelsResponse;
@@ -32,6 +39,17 @@ const CATEGORY_MAP: Record<string, CategoryMeta> = {
 };
 
 const ALL_CATEGORIES = Object.keys(CATEGORY_MAP);
+
+const PROVIDER_TYPE_MAP: Record<string, string> = {
+  openai_llm: "openai",
+  openai_image: "openai",
+  openai_tts: "openai",
+  anthropic_llm: "anthropic",
+  gemini_llm: "google",
+  google_image: "google",
+  stability_image: "stability",
+  elevenlabs_tts: "elevenlabs",
+};
 
 export interface ModelSelectorProps {
   /** Explicit selection map: category → model key. Enables controlled mode. */
@@ -60,12 +78,17 @@ export default function ModelSelector({
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [localSelection, setLocalSelection] = useState<Record<string, string>>({});
+  const [defaultsVersion, setDefaultsVersion] = useState(0);
+  const [configuredProviders, setConfiguredProviders] = useState<Record<string, boolean>>({});
 
   const visibleCategories = categories ?? ALL_CATEGORIES;
 
   // Stable ref for onSelectionChange to avoid effect re-fires when callback identity changes
   const onChangeRef = useRef(onSelectionChange);
   onChangeRef.current = onSelectionChange;
+
+  const localSelectionRef = useRef(localSelection);
+  localSelectionRef.current = localSelection;
 
   // Ref to stage newly-computed defaults for notification in a follow-up effect.
   // Keeping notification out of the setLocalSelection updater keeps it pure.
@@ -79,13 +102,30 @@ export default function ModelSelector({
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(`${apiBase}/api/creator/models`);
-        if (!res.ok) {
-          throw new Error(`Failed to fetch models: ${res.status}`);
+        const [modelsRes, apiKeysRes] = await Promise.all([
+          fetch(`${apiBase}/api/creator/models`),
+          fetch(`${apiBase}/api/creator/settings/api-keys`),
+        ]);
+
+        if (!modelsRes.ok) {
+          throw new Error(`Failed to fetch models: ${modelsRes.status}`);
         }
-        const json: ModelsResponse = await res.json();
+        const json: ModelsResponse = await modelsRes.json();
+
+        let providerStatus: Record<string, boolean> = {};
+        if (apiKeysRes.ok) {
+          const apiKeysJson = await apiKeysRes.json();
+          if (Array.isArray(apiKeysJson)) {
+            providerStatus = (apiKeysJson as ApiKeyStatus[]).reduce<Record<string, boolean>>((acc, item) => {
+              acc[item.provider] = item.configured;
+              return acc;
+            }, {});
+          }
+        }
+
         if (!cancelled) {
           setData(json);
+          setConfiguredProviders(providerStatus);
         }
       } catch (err) {
         if (!cancelled) {
@@ -115,38 +155,35 @@ export default function ModelSelector({
     if (!data || selectedModels) return;
 
     const cats = categoriesKey.split(",");
-    setLocalSelection((prev) => {
-      const next = { ...prev };
-      const newDefaults: Array<[string, string]> = [];
+    const prev = localSelectionRef.current;
+    const next = { ...prev };
+    const newDefaults: Array<[string, string]> = [];
 
-      for (const cat of cats) {
-        // Skip categories that already have a selection whose model still exists
-        if (next[cat]) {
-          const meta = CATEGORY_MAP[cat];
-          if (meta) {
-            const models = data[meta.responseKey];
-            const stillExists = models.some((m) => m.key === next[cat]);
-            if (stillExists) continue;
-          }
-        }
-
+    for (const cat of cats) {
+      if (next[cat]) {
         const meta = CATEGORY_MAP[cat];
-        if (!meta) continue;
-        const models = data[meta.responseKey];
-        const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
-        if (firstAvailable) {
-          next[cat] = firstAvailable.key;
-          newDefaults.push([cat, firstAvailable.key]);
+        if (meta) {
+          const models = data[meta.responseKey];
+          const stillExists = models.some((m) => m.key === next[cat]);
+          if (stillExists) continue;
         }
       }
 
-      // If nothing changed, return prev to avoid unnecessary re-render
-      if (newDefaults.length === 0) return prev;
+      const meta = CATEGORY_MAP[cat];
+      if (!meta) continue;
+      const models = data[meta.responseKey];
+      const firstAvailable = models.find((m) => m.status === "available") ?? models[0];
+      if (firstAvailable) {
+        next[cat] = firstAvailable.key;
+        newDefaults.push([cat, firstAvailable.key]);
+      }
+    }
 
-      // Stage defaults for notification in Effect 3
+    if (newDefaults.length > 0) {
       pendingDefaultsRef.current = newDefaults;
-      return next;
-    });
+      setLocalSelection(next);
+      setDefaultsVersion((prevVersion) => prevVersion + 1);
+    }
   }, [data, categoriesKey, selectedModels]);
 
   // Effect 3: Notify parent of newly-computed defaults after state has settled.
@@ -162,7 +199,7 @@ export default function ModelSelector({
         cb(cat, key);
       }
     }
-  }, [localSelection]);
+  }, [defaultsVersion]);
 
   const handleSelect = useCallback(
     (category: string, modelKey: string) => {
@@ -193,7 +230,7 @@ export default function ModelSelector({
       {visibleCategories.map((cat) => {
         const meta = CATEGORY_MAP[cat];
         if (!meta) return null;
-        const models = data[meta.responseKey];
+        const models = [...data[meta.responseKey]].sort((a, b) => Number(a.is_local) === Number(b.is_local) ? 0 : (a.is_local ? -1 : 1));
         const groupName = `model-${cat}`;
 
         return (
@@ -206,6 +243,8 @@ export default function ModelSelector({
                 {models.map((model) => {
                   const isSelected = activeSelection[cat] === model.key;
                   const inputId = `${groupName}-${model.key}`;
+                  const mappedProvider = PROVIDER_TYPE_MAP[model.provider_type];
+                  const needsApiKeyWarning = !model.is_local && Boolean(mappedProvider) && !configuredProviders[mappedProvider];
                   return (
                     <label
                       key={model.key}
@@ -235,9 +274,18 @@ export default function ModelSelector({
                       <span style={STATUS_STYLES[model.status] ?? STATUS_STYLES.unknown}>
                         {model.status}
                       </span>
-                      {model.is_local && (
-                        <span style={{ fontSize: 10, color: "#666", background: "#eee", borderRadius: 3, padding: "1px 4px" }}>
-                          local
+                      {model.is_local ? (
+                        <span style={{ fontSize: 10, color: "#1f2937", background: "#e5e7eb", borderRadius: 3, padding: "1px 4px" }}>
+                          Local
+                        </span>
+                      ) : (
+                        <span style={{ fontSize: 10, color: "#1d4ed8", background: "#dbeafe", borderRadius: 3, padding: "1px 4px" }}>
+                          Remote
+                        </span>
+                      )}
+                      {needsApiKeyWarning && (
+                        <span style={{ fontSize: 11, color: "#c2410c", fontWeight: 500 }}>
+                          ⚠ API key required
                         </span>
                       )}
                     </label>

--- a/apps/studio-web/src/components/layout/AppShell.tsx
+++ b/apps/studio-web/src/components/layout/AppShell.tsx
@@ -5,7 +5,10 @@ const CREATOR_LINKS = [
   { to: "/runs", label: "Projects" },
 ];
 
-const OPS_LINKS = [{ to: "/ops", label: "Ops" }];
+const OPS_LINKS = [
+  { to: "/ops", label: "Ops" },
+  { to: "/settings", label: "Settings" },
+];
 
 export default function AppShell() {
   const location = useLocation();
@@ -20,6 +23,7 @@ export default function AppShell() {
       );
     }
     if (path === "/ops") return location.pathname.startsWith("/ops");
+    if (path === "/settings") return location.pathname === "/settings";
     return false;
   };
 

--- a/apps/studio-web/src/pages/SettingsPage.tsx
+++ b/apps/studio-web/src/pages/SettingsPage.tsx
@@ -1,0 +1,271 @@
+import { useCallback, useEffect, useState } from "react";
+
+interface ApiKeyStatus {
+  provider: string;
+  label: string;
+  configured: boolean;
+  masked: string;
+}
+
+const PROVIDERS: Array<{ provider: string; label: string }> = [
+  { provider: "openai", label: "OpenAI" },
+  { provider: "anthropic", label: "Anthropic" },
+  { provider: "google", label: "Google (Gemini / Imagen)" },
+  { provider: "stability", label: "Stability AI" },
+  { provider: "elevenlabs", label: "ElevenLabs" },
+];
+
+const STATUS_BADGE_STYLE: Record<"configured" | "missing", React.CSSProperties> = {
+  configured: {
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "2px 8px",
+    borderRadius: 999,
+    background: "#dcfce7",
+    color: "#166534",
+    fontSize: 12,
+    fontWeight: 600,
+    lineHeight: 1.5,
+  },
+  missing: {
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "2px 8px",
+    borderRadius: 999,
+    background: "#f3f4f6",
+    color: "#4b5563",
+    fontSize: 12,
+    fontWeight: 600,
+    lineHeight: 1.5,
+  },
+};
+
+export default function SettingsPage() {
+  const [apiKeys, setApiKeys] = useState<ApiKeyStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingProvider, setEditingProvider] = useState<string | null>(null);
+  const [draftKey, setDraftKey] = useState("");
+  const [savingProvider, setSavingProvider] = useState<string | null>(null);
+
+  const fetchApiKeys = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/creator/settings/api-keys");
+      if (!res.ok) {
+        throw new Error(`Failed to load API keys (${res.status})`);
+      }
+      const json = (await res.json()) as ApiKeyStatus[];
+      const byProvider = new Map(json.map((entry) => [entry.provider, entry]));
+      const normalized = PROVIDERS.map(({ provider, label }) => {
+        const found = byProvider.get(provider);
+        return {
+          provider,
+          label,
+          configured: found?.configured ?? false,
+          masked: found?.masked ?? "",
+        };
+      });
+      setApiKeys(normalized);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setApiKeys(
+        PROVIDERS.map(({ provider, label }) => ({
+          provider,
+          label,
+          configured: false,
+          masked: "",
+        })),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchApiKeys();
+  }, [fetchApiKeys]);
+
+  const handleEdit = useCallback((provider: string) => {
+    setEditingProvider(provider);
+    setDraftKey("");
+    setError(null);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setEditingProvider(null);
+    setDraftKey("");
+  }, []);
+
+  const handleSave = useCallback(async (provider: string) => {
+    setSavingProvider(provider);
+    setError(null);
+    try {
+      const res = await fetch("/api/creator/settings/api-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider, api_key: draftKey }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null) as { detail?: string } | null;
+        throw new Error(body?.detail ?? `Failed to save API key (${res.status})`);
+      }
+      setEditingProvider(null);
+      setDraftKey("");
+      await fetchApiKeys();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setSavingProvider(null);
+    }
+  }, [draftKey, fetchApiKeys]);
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: 24 }}>
+      <h1 style={{ fontSize: 24, fontWeight: 700, margin: "0 0 8px" }}>Settings</h1>
+      <p style={{ margin: "0 0 24px", color: "#6b7280", fontSize: 14 }}>
+        Configure remote provider credentials used by model-backed generation.
+      </p>
+
+      <section style={{ border: "1px solid #e5e7eb", borderRadius: 8, background: "#fff" }}>
+        <div style={{ padding: "16px 20px", borderBottom: "1px solid #e5e7eb" }}>
+          <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600 }}>API Keys</h2>
+        </div>
+
+        {loading ? (
+          <div style={{ padding: 20, fontSize: 14, color: "#6b7280" }}>Loading API key status...</div>
+        ) : (
+          <div>
+            {apiKeys.map((entry, index) => {
+              const isEditing = editingProvider === entry.provider;
+              const isSaving = savingProvider === entry.provider;
+              return (
+                <div
+                  key={entry.provider}
+                  style={{
+                    padding: 20,
+                    borderBottom: index < apiKeys.length - 1 ? "1px solid #f3f4f6" : "none",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: isEditing ? 12 : 0 }}>
+                    <div style={{ minWidth: 220 }}>
+                      <div style={{ fontSize: 14, fontWeight: 600, color: "#111827" }}>{entry.label}</div>
+                      <div
+                        style={{
+                          fontSize: 13,
+                          color: entry.configured ? "#111827" : "#6b7280",
+                          marginTop: 4,
+                          fontFamily: "'JetBrains Mono', monospace",
+                        }}
+                      >
+                        {entry.configured ? entry.masked : "Not configured"}
+                      </div>
+                    </div>
+
+                    <span style={entry.configured ? STATUS_BADGE_STYLE.configured : STATUS_BADGE_STYLE.missing}>
+                      {entry.configured ? "Configured" : "Not configured"}
+                    </span>
+
+                    <div style={{ flex: 1 }} />
+
+                    {!isEditing && (
+                      <button
+                        type="button"
+                        onClick={() => handleEdit(entry.provider)}
+                        style={{
+                          border: "1px solid #d1d5db",
+                          borderRadius: 6,
+                          background: "#fff",
+                          color: "#111827",
+                          padding: "6px 12px",
+                          fontSize: 13,
+                          fontWeight: 500,
+                          cursor: "pointer",
+                        }}
+                      >
+                        Edit
+                      </button>
+                    )}
+                  </div>
+
+                  {isEditing && (
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <input
+                        type="password"
+                        value={draftKey}
+                        onChange={(e) => setDraftKey(e.target.value)}
+                        placeholder={`Enter ${entry.label} API key`}
+                        autoComplete="off"
+                        style={{
+                          flex: 1,
+                          minWidth: 260,
+                          padding: "8px 10px",
+                          border: "1px solid #d1d5db",
+                          borderRadius: 6,
+                          fontSize: 13,
+                          boxSizing: "border-box",
+                        }}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => void handleSave(entry.provider)}
+                        disabled={isSaving}
+                        style={{
+                          border: "1px solid #2563eb",
+                          borderRadius: 6,
+                          background: isSaving ? "#93c5fd" : "#3b82f6",
+                          color: "#fff",
+                          padding: "8px 12px",
+                          fontSize: 13,
+                          fontWeight: 600,
+                          cursor: isSaving ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        {isSaving ? "Saving..." : "Save"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleCancel}
+                        disabled={isSaving}
+                        style={{
+                          border: "1px solid #d1d5db",
+                          borderRadius: 6,
+                          background: "#fff",
+                          color: "#374151",
+                          padding: "8px 12px",
+                          fontSize: 13,
+                          fontWeight: 500,
+                          cursor: isSaving ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {error && (
+        <div
+          role="alert"
+          style={{
+            marginTop: 16,
+            border: "1px solid #fecaca",
+            borderRadius: 8,
+            background: "#fef2f2",
+            color: "#b91c1c",
+            padding: "10px 12px",
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds **Settings page** (`/settings`) for managing external API keys (OpenAI, Anthropic, Google, Stability AI, ElevenLabs)
- Adds backend **API key CRUD routes** (`GET/POST /api/creator/settings/api-keys`) with masked key display and .env file persistence
- **Enhances ModelSelector** with Local/Remote badges and ⚠️ "API key required" warnings for unconfigured remote providers
- Adds Settings nav link in AppShell

Closes #201

## Changes

### New Files
- `apps/api/src/shorts_api/routes/creator_settings.py` — Backend API key management
- `apps/studio-web/src/pages/SettingsPage.tsx` — Settings UI page

### Modified Files
- `apps/api/src/shorts_api/main.py` — Register settings router
- `apps/studio-web/src/App.tsx` — Add /settings route
- `apps/studio-web/src/components/layout/AppShell.tsx` — Add Settings nav link
- `apps/studio-web/src/components/creator/ModelSelector.tsx` — Local/Remote badges, API key warnings, sorted models

## Testing
- 78 provider tests pass
- ModelSelector and AppShell component tests pass
- Pre-existing TS errors in unrelated test files (not introduced by this PR)