### PR TITLE
feat(image): add SD tuning controls for image generation quality

### DIFF
--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -1,4 +1,6 @@
 """Routes for creator run management."""
+from typing import Any
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from creator_service.audio_service import audio_service
@@ -355,10 +357,15 @@ async def generate_visual_plan_trigger(run_id: int, request: GenerateVisualPlanR
 
 class GenerateVisualAssetsRequest(BaseModel):
     model_key: str = "sd15"
-
+    image_params: dict[str, Any] | None = None
 
 def dispatch_generate_scene_image(
-    run_id: int, model_key: str, scene_id: str | None, prompt_override: str | None, is_active: bool
+    run_id: int,
+    model_key: str,
+    scene_id: str | None,
+    prompt_override: str | None,
+    is_active: bool,
+    image_params: dict[str, Any] | None = None,
 ) -> str:
     """Dispatch generate_scene_image Celery task. Returns task id.
 
@@ -370,6 +377,7 @@ def dispatch_generate_scene_image(
     result = tasks.generate_scene_image.delay(
         run_id, scene_id=scene_id, model_key=model_key,
         prompt_override=prompt_override, is_active=is_active,
+        image_params=image_params,
     )
     return str(result.id)
 
@@ -417,6 +425,7 @@ async def generate_visual_assets_trigger(
             scene_id=None,  # all scenes
             prompt_override=None,
             is_active=True,
+            image_params=request.image_params,
         )
     except Exception:
         # Best-effort rollback: restore original stage so run isn't stuck
@@ -440,6 +449,11 @@ async def generate_visual_assets_trigger(
 class RegenerateSceneImageRequest(BaseModel):
     model_key: str = "sd15"
     prompt_override: str | None = None
+    image_params: dict[str, Any] | None = None
+
+class GenerateSceneImageRequest(BaseModel):
+    model_key: str = "sd15"
+    image_params: dict[str, Any] | None = None
 
 
 @router.post(
@@ -447,9 +461,10 @@ class RegenerateSceneImageRequest(BaseModel):
     status_code=202,
 )
 async def generate_scene_image_endpoint(
-    run_id: int, scene_id: str
+    run_id: int, scene_id: str, request: GenerateSceneImageRequest | None = None
 ) -> dict[str, object]:
     """Generate an image for a single scene that hasn't been generated yet."""
+    effective_request = request or GenerateSceneImageRequest()
     # 1. Check run exists
     run = await run_service.get_run(run_id)
     if run is None:
@@ -468,10 +483,11 @@ async def generate_scene_image_endpoint(
     try:
         task_id = dispatch_generate_scene_image(
             run_id=run_id,
-            model_key="sd15",
+            model_key=effective_request.model_key,
             scene_id=scene_id,
             prompt_override=None,
             is_active=True,
+            image_params=effective_request.image_params,
         )
     except Exception:
         raise HTTPException(
@@ -485,7 +501,6 @@ async def generate_scene_image_endpoint(
         "scene_id": scene_id,
         "current_stage": run.current_stage,
     }
-
 
 @router.post(
     "/runs/{run_id}/visual-plan/scenes/{scene_id}/regenerate-image",
@@ -521,6 +536,7 @@ async def regenerate_scene_image_endpoint(
             scene_id=scene_id,
             prompt_override=request.prompt_override,
             is_active=False,  # regenerated assets are inactive until selected
+            image_params=request.image_params,
         )
     except Exception:
         raise HTTPException(

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -70,6 +70,21 @@ const FINAL_REVIEW_STAGES = new Set(["FINAL_REVIEW"]);
 // Stages where editing is allowed (not generating)
 const EDITABLE_STAGES = new Set(["SCRIPT_REVIEW", "VISUAL_PLAN_REVIEW"]);
 
+// SD quality presets for image generation tuning
+const SD_QUALITY_PRESETS: Record<
+  string,
+  { steps: number; cfg_scale: number; sampler_name: string; label: string; description: string }
+> = {
+  fast: { steps: 15, cfg_scale: 5, sampler_name: "Euler a", label: "⚡ Fast Preview", description: "Quick preview, lower quality (15 steps)" },
+  balanced: { steps: 25, cfg_scale: 7, sampler_name: "DPM++ 2M Karras", label: "⚖️ Balanced", description: "Good quality/speed balance (25 steps)" },
+  high: { steps: 40, cfg_scale: 8, sampler_name: "DPM++ 2M Karras", label: "✨ High Quality", description: "Best quality, slower (40 steps)" },
+};
+
+const SD_SAMPLERS = [
+  "DPM++ 2M Karras", "DPM++ SDE Karras", "DPM++ 2M SDE Karras",
+  "DPM++ 2M", "DPM++ SDE", "DPM++ 2S a Karras",
+  "Euler a", "Euler", "DDIM", "UniPC", "LMS Karras", "Heun",
+];
 export default function ProjectPage() {
   const { projectId } = useParams<{ projectId: string }>();
   const numericProjectId = Number(projectId);
@@ -98,6 +113,16 @@ export default function ProjectPage() {
   // Scene regeneration model override
   const [regenModelKey, setRegenModelKey] = useState<string | null>(null);
 
+  // SD image tuning parameters
+  const [imageParams, setImageParams] = useState({
+    steps: 25,
+    sampler_name: "DPM++ 2M Karras",
+    negative_prompt:
+      "low quality, worst quality, blurry, out of focus, ugly, deformed, disfigured, watermark, text, signature, poorly drawn, bad anatomy, extra limbs",
+    cfg_scale: 7,
+  });
+  const [activePreset, setActivePreset] = useState<string>("balanced");
+  const [tuningOpen, setTuningOpen] = useState(true);
   // Asset grid refresh key — increment to force re-fetch
   const [assetRefreshKey, setAssetRefreshKey] = useState(0);
 
@@ -325,7 +350,7 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/generate-visual-assets`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model_key: "sd15" }),
+        body: JSON.stringify({ model_key: "sd15", image_params: imageParams }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -339,14 +364,14 @@ export default function ProjectPage() {
     } finally {
       setGenerating(false);
     }
-  }, [run]);
+  }, [run, imageParams]);
 
   const handleRegenerateScene = useCallback(
     async (sceneId: string) => {
       if (!run) return;
       setStatusMessage(null);
       try {
-        const payload: Record<string, string> = {};
+        const payload: Record<string, unknown> = { image_params: imageParams };
         if (regenModelKey) payload.model_key = regenModelKey;
         const res = await fetch(
           `${API_BASE}/runs/${run.id}/visual-plan/scenes/${sceneId}/regenerate-image`,
@@ -370,7 +395,7 @@ export default function ProjectPage() {
         setStatusMessage(err instanceof Error ? err.message : "Regenerate failed");
       }
     },
-    [run, regenModelKey, refreshRun],
+    [run, regenModelKey, imageParams, refreshRun],
   );
 
   const handleGenerateScene = useCallback(
@@ -383,7 +408,7 @@ export default function ProjectPage() {
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ model_key: "sd15" }),
+            body: JSON.stringify({ model_key: "sd15", image_params: imageParams }),
           },
         );
         if (!res.ok) {
@@ -399,7 +424,7 @@ export default function ProjectPage() {
         setStatusMessage(err instanceof Error ? err.message : "Generate scene failed");
       }
     },
-    [run, refreshRun],
+    [run, imageParams, refreshRun],
   );
 
   const handleApproveAssets = useCallback(async () => {
@@ -1006,6 +1031,200 @@ export default function ProjectPage() {
                   apiBase={API_BASE}
                   onSelectionChange={(_cat, modelKey) => setRegenModelKey(modelKey)}
                 />
+              </div>
+
+              {/* Image quality tuning controls */}
+              <div
+                data-testid="image-tuning-panel"
+                style={{
+                  marginBottom: 16,
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 8,
+                  background: "#fff",
+                  overflow: "hidden",
+                }}
+              >
+                {/* Panel header — toggle */}
+                <button
+                  type="button"
+                  data-testid="tuning-toggle"
+                  onClick={() => setTuningOpen((v) => !v)}
+                  style={{
+                    width: "100%",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    padding: "10px 14px",
+                    background: "#faf5ff",
+                    border: "none",
+                    borderBottom: tuningOpen ? "1px solid #e5e7eb" : "none",
+                    cursor: "pointer",
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: "#6b21a8",
+                  }}
+                >
+                  <span>🎨 Image Quality Settings</span>
+                  <span style={{ fontSize: 11 }}>{tuningOpen ? "▲" : "▼"}</span>
+                </button>
+
+                {tuningOpen && (
+                  <div style={{ padding: 14, display: "flex", flexDirection: "column", gap: 14 }}>
+                    {/* Quality presets */}
+                    <div>
+                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "#374151", marginBottom: 6 }}>
+                        Quality Preset
+                      </label>
+                      <div style={{ display: "flex", gap: 6 }}>
+                        {Object.entries(SD_QUALITY_PRESETS).map(([key, preset]) => (
+                          <button
+                            type="button"
+                            key={key}
+                            data-testid={`preset-${key}`}
+                            title={preset.description}
+                            onClick={() => {
+                              setActivePreset(key);
+                              setImageParams((p) => ({
+                                ...p,
+                                steps: preset.steps,
+                                cfg_scale: preset.cfg_scale,
+                                sampler_name: preset.sampler_name,
+                              }));
+                            }}
+                            style={{
+                              flex: 1,
+                              padding: "6px 8px",
+                              fontSize: 12,
+                              fontWeight: activePreset === key ? 600 : 400,
+                              border: activePreset === key ? "2px solid #7c3aed" : "1px solid #d1d5db",
+                              borderRadius: 6,
+                              background: activePreset === key ? "#ede9fe" : "#fff",
+                              color: activePreset === key ? "#6b21a8" : "#374151",
+                              cursor: "pointer",
+                              transition: "all 0.15s",
+                            }}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                      </div>
+                      <p style={{ margin: "4px 0 0", fontSize: 11, color: "#9ca3af" }}>
+                        {SD_QUALITY_PRESETS[activePreset]?.description}
+                      </p>
+                    </div>
+
+                    {/* Steps slider */}
+                    <div>
+                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+                        <label style={{ fontSize: 12, fontWeight: 600, color: "#374151" }}>
+                          Steps
+                        </label>
+                        <span style={{ fontSize: 12, color: "#6b21a8", fontWeight: 600 }}>{imageParams.steps}</span>
+                      </div>
+                      <input
+                        data-testid="steps-slider"
+                        type="range"
+                        min={15}
+                        max={50}
+                        value={imageParams.steps}
+                        onChange={(e) => {
+                          setActivePreset("");
+                          setImageParams((p) => ({ ...p, steps: Number(e.target.value) }));
+                        }}
+                        style={{ width: "100%", accentColor: "#7c3aed" }}
+                      />
+                      <p style={{ margin: "2px 0 0", fontSize: 11, color: "#9ca3af" }}>
+                        More steps = higher quality but slower. 20-30 is usually optimal.
+                      </p>
+                    </div>
+
+                    {/* CFG Scale slider */}
+                    <div>
+                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+                        <label style={{ fontSize: 12, fontWeight: 600, color: "#374151" }}>
+                          CFG Scale (Prompt Adherence)
+                        </label>
+                        <span style={{ fontSize: 12, color: "#6b21a8", fontWeight: 600 }}>{imageParams.cfg_scale}</span>
+                      </div>
+                      <input
+                        data-testid="cfg-slider"
+                        type="range"
+                        min={1}
+                        max={20}
+                        value={imageParams.cfg_scale}
+                        onChange={(e) => {
+                          setActivePreset("");
+                          setImageParams((p) => ({ ...p, cfg_scale: Number(e.target.value) }));
+                        }}
+                        style={{ width: "100%", accentColor: "#7c3aed" }}
+                      />
+                      <p style={{ margin: "2px 0 0", fontSize: 11, color: "#9ca3af" }}>
+                        How closely to follow the prompt. 5-9 works well; too high can look harsh.
+                      </p>
+                    </div>
+
+                    {/* Sampler dropdown */}
+                    <div>
+                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "#374151", marginBottom: 4 }}>
+                        Sampler
+                      </label>
+                      <select
+                        data-testid="sampler-select"
+                        value={imageParams.sampler_name}
+                        onChange={(e) => {
+                          setActivePreset("");
+                          setImageParams((p) => ({ ...p, sampler_name: e.target.value }));
+                        }}
+                        style={{
+                          width: "100%",
+                          padding: "6px 10px",
+                          border: "1px solid #d1d5db",
+                          borderRadius: 4,
+                          fontSize: 13,
+                          background: "#fff",
+                          color: "#374151",
+                        }}
+                      >
+                        {SD_SAMPLERS.map((s) => (
+                          <option key={s} value={s}>{s}</option>
+                        ))}
+                      </select>
+                      <p style={{ margin: "2px 0 0", fontSize: 11, color: "#9ca3af" }}>
+                        DPM++ 2M Karras gives best quality for SD 1.5. Euler a is fastest.
+                      </p>
+                    </div>
+
+                    {/* Negative prompt */}
+                    <div>
+                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "#374151", marginBottom: 4 }}>
+                        Negative Prompt
+                      </label>
+                      <textarea
+                        data-testid="negative-prompt"
+                        rows={3}
+                        value={imageParams.negative_prompt}
+                        onChange={(e) => {
+                          setActivePreset("");
+                          setImageParams((p) => ({ ...p, negative_prompt: e.target.value }));
+                        }}
+                        style={{
+                          width: "100%",
+                          padding: "6px 10px",
+                          border: "1px solid #d1d5db",
+                          borderRadius: 4,
+                          fontSize: 12,
+                          fontFamily: "inherit",
+                          resize: "vertical",
+                          color: "#374151",
+                          boxSizing: "border-box",
+                        }}
+                      />
+                      <p style={{ margin: "2px 0 0", fontSize: 11, color: "#9ca3af" }}>
+                        Describe what you do NOT want in the image. Helps avoid common SD artifacts.
+                      </p>
+                    </div>
+                  </div>
+                )}
               </div>
 
               {/* Scene action buttons — rendered per-scene from the asset grid data is impractical

--- a/apps/worker-orchestrator/tasks/generate_scene_image.py
+++ b/apps/worker-orchestrator/tasks/generate_scene_image.py
@@ -77,6 +77,7 @@ def generate_scene_image(
     model_key: str = "sd15",
     prompt_override: str | None = None,
     is_active: bool = True,
+    image_params: dict[str, Any] | None = None,
 ) -> dict[str, object]:
     """Generate image(s) for visual plan scenes.
 
@@ -88,6 +89,9 @@ def generate_scene_image(
         prompt_override: If provided, overrides the scene prompt for a
                          single-scene generation. Ignored for all-scene mode.
         is_active: Whether new assets are marked active (default: True).
+        image_params: Optional dict of per-request image generation params
+                      (steps, sampler_name, negative_prompt, cfg_scale, etc.).
+                      Merged on top of registry default_params.
     """
     start_time = datetime.now(timezone.utc)
     start_iso = start_time.isoformat()
@@ -182,6 +186,9 @@ def generate_scene_image(
                 try:
                     # Generate image via provider.
                     params = dict(entry.default_params or {})
+                    # Merge per-request tuning overrides on top of registry defaults.
+                    if image_params:
+                        params.update(image_params)
                     # Direct provider to write to the artifact directory
                     # instead of a temp file.
                     target_path = str(asset_dir / f"{target_scene.scene_id}.png")

--- a/packages/creator-provider/creator_provider/image/sd_local_provider.py
+++ b/packages/creator-provider/creator_provider/image/sd_local_provider.py
@@ -11,6 +11,16 @@ from creator_provider.base import ImageProvider, ImageResult
 
 
 class SDLocalProvider(ImageProvider):
+    # Quality keywords prepended to all prompts to improve SD 1.5 output.
+    _QUALITY_PREFIX = (
+        "masterpiece, best quality, highly detailed, "
+        "sharp focus, professional, 8k uhd"
+    )
+
+    # Keys that are internal to the pipeline and should NOT be sent to
+    # the AUTOMATIC1111 /sdapi/v1/txt2img endpoint.
+    _INTERNAL_KEYS = frozenset({"output_path", "width", "height"})
+
     def __init__(self, endpoint: str, model_key: str):
         self.endpoint = endpoint.rstrip("/")
         self.model_key = model_key
@@ -20,14 +30,28 @@ class SDLocalProvider(ImageProvider):
         width = int(merged_params.get("width", 512))
         height = int(merged_params.get("height", 768))
 
+        # Auto-prepend quality keywords unless the caller explicitly
+        # passed skip_quality_prefix=True.
+        skip_prefix = merged_params.pop("skip_quality_prefix", False)
+        effective_prompt = (
+            prompt if skip_prefix else f"{self._QUALITY_PREFIX}, {prompt}"
+        )
+
         payload: dict[str, Any] = {
-            "prompt": prompt,
+            "prompt": effective_prompt,
             "width": width,
             "height": height,
-            "steps": 15,
+            "steps": 25,
             "cfg_scale": 7,
+            "sampler_name": "DPM++ 2M Karras",
         }
-        payload.update(merged_params)
+
+        # Merge caller-provided params (from registry defaults + per-request
+        # overrides).  Strip internal keys that the SD API doesn't understand.
+        api_params = {
+            k: v for k, v in merged_params.items() if k not in self._INTERNAL_KEYS
+        }
+        payload.update(api_params)
 
         url = f"{self.endpoint}/sdapi/v1/txt2img"
         try:

--- a/packages/creator-provider/creator_provider/registry.py
+++ b/packages/creator-provider/creator_provider/registry.py
@@ -96,6 +96,16 @@ class ProviderRegistry:
                 category=ProviderCategory.IMAGE,
                 requires_gpu=True,
                 is_local=True,
+                default_params={
+                    "steps": 25,
+                    "cfg_scale": 7,
+                    "sampler_name": "DPM++ 2M Karras",
+                    "negative_prompt": (
+                        "low quality, worst quality, blurry, out of focus, "
+                        "ugly, deformed, disfigured, watermark, text, "
+                        "signature, poorly drawn, bad anatomy, extra limbs"
+                    ),
+                },
             )
         )
         registry.register_model(

--- a/packages/creator-service/creator_service/model_catalog_service.py
+++ b/packages/creator-service/creator_service/model_catalog_service.py
@@ -125,6 +125,7 @@ class ModelCatalogService:
             "is_local": entry.is_local,
             "requires_gpu": entry.requires_gpu,
             "status": self._HEALTH_TO_CATALOG_STATUS[health_result.status],
+            "default_params": entry.default_params or {},
         }
 
     def _format_label(self, model_key: str, is_local: bool) -> str:


### PR DESCRIPTION
## Summary

- Add comprehensive Stable Diffusion image tuning controls to the pipeline UI, enabling users to fine-tune generation parameters (steps, CFG scale, sampler, negative prompt) with quality presets
- Backend: improved SD defaults (steps 25, DPM++ 2M Karras sampler, quality prefix, negative prompt), full image_params passthrough from API to AUTOMATIC1111
- Frontend: collapsible "Image Quality Settings" panel with 3 presets (Fast/Balanced/High Quality), sliders, sampler dropdown, and negative prompt textarea

## Changes

### Backend (5 files)
| File | Change |
|------|--------|
| `packages/creator-provider/creator_provider/registry.py` | Added `default_params` to sd15 model entry |
| `packages/creator-provider/creator_provider/image/sd_local_provider.py` | Rewritten with quality prefix, better defaults, internal key stripping |
| `apps/api/src/shorts_api/routes/creator_runs.py` | Added `image_params` field to request models and dispatch functions |
| `apps/worker-orchestrator/tasks/generate_scene_image.py` | Added `image_params` merge in Celery task |
| `packages/creator-service/creator_service/model_catalog_service.py` | Exposed `default_params` in model catalog API |

### Frontend (1 file)
| File | Change |
|------|--------|
| `apps/studio-web/src/pages/ProjectPage.tsx` | Added tuning panel UI + wired `image_params` into all 3 image generation fetch calls |

## Testing
- ✅ All 39 ProjectPage tests pass
- ✅ 0 LSP diagnostics errors across all 6 changed files
- ✅ TypeScript clean (no `as any` or `@ts-ignore`)