### PR TITLE
feat: unified storyboard view with per-paragraph audio/subtitle pipeline (Phase 9)

### DIFF
--- a/apps/api/migrations/versions/008_add_paragraph_artifact_index.py
+++ b/apps/api/migrations/versions/008_add_paragraph_artifact_index.py
@@ -1,0 +1,28 @@
+"""Add per-paragraph artifact index.
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-03-31 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+
+revision: str = "008"
+down_revision: Union[str, None] = "007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Composite index for efficient per-paragraph artifact lookups.
+    # Queries like: SELECT * FROM creator_artifacts
+    #   WHERE run_id = $1 AND scene_id = $2 AND artifact_type = $3
+    op.create_index(
+        "ix_creator_artifacts_run_scene_type",
+        "creator_artifacts",
+        ["run_id", "scene_id", "artifact_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_creator_artifacts_run_scene_type", "creator_artifacts")

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -10,6 +10,8 @@ from creator_service.run_service import run_service
 from creator_service.stage_review_service import stage_review_service
 from creator_service.subtitle_service import subtitle_service
 from creator_service.visual_asset_service import visual_asset_service
+from creator_service.script_service import script_service
+from creator_service.visual_plan_service import visual_plan_service
 
 
 def dispatch_generate_script(
@@ -856,4 +858,342 @@ async def get_preview(run_id: int) -> dict[str, object]:
             "format": subtitle.format,
             "created_at": str(subtitle.created_at),
         } if subtitle else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Storyboard endpoints (Phase 9 — Unified Paragraph Pipeline)
+# ---------------------------------------------------------------------------
+
+
+def dispatch_paragraph_audio(
+    run_id: int, section_id: str, section_text: str, tts_model: str, voice: str
+) -> str:
+    """Dispatch generate_paragraph_audio Celery task. Returns task id."""
+    from importlib import import_module
+
+    tasks = import_module("tasks.generate_paragraph_audio")
+    result = tasks.generate_paragraph_audio.delay(
+        run_id, section_id=section_id, section_text=section_text,
+        tts_model=tts_model, voice=voice,
+    )
+    return str(result.id)
+
+
+def dispatch_paragraph_subtitles(
+    run_id: int, section_id: str, audio_path: str,
+    subtitle_model: str, subtitle_format: str,
+) -> str:
+    """Dispatch generate_paragraph_subtitles Celery task. Returns task id."""
+    from importlib import import_module
+
+    tasks = import_module("tasks.generate_paragraph_subtitles")
+    result = tasks.generate_paragraph_subtitles.delay(
+        run_id, section_id=section_id, audio_path=audio_path,
+        subtitle_model=subtitle_model, subtitle_format=subtitle_format,
+    )
+    return str(result.id)
+
+
+class ParagraphAudioRequest(BaseModel):
+    tts_model: str = "qwen3-tts"
+    voice: str = "default"
+
+
+class ParagraphSubtitlesRequest(BaseModel):
+    subtitle_model: str = "whisper-small"
+    subtitle_format: str = "srt"
+
+
+class BulkParagraphAudioRequest(BaseModel):
+    tts_model: str = "qwen3-tts"
+    voice: str = "default"
+
+
+class BulkParagraphSubtitlesRequest(BaseModel):
+    subtitle_model: str = "whisper-small"
+    subtitle_format: str = "srt"
+
+
+@router.get("/runs/{run_id}/storyboard")
+async def get_storyboard(run_id: int) -> dict[str, object]:
+    """Assemble the full storyboard for a run.
+
+    Joins script sections + visual plan scenes + images + audio + subtitles
+    into a unified per-paragraph view.
+    """
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 1. Get active script draft → sections
+    draft = await script_service.get_active_draft(run_id)
+    if draft is None or not draft.structured_script:
+        return {
+            "run_id": run_id,
+            "paragraphs": [],
+            "render_ready": False,
+            "total_paragraphs": 0,
+            "ready_paragraphs": 0,
+        }
+
+    sections = draft.structured_script
+
+    # 2. Get active visual plan → scenes keyed by section_id
+    plan = await visual_plan_service.get_active_plan(run_id)
+    scene_by_section: dict[str, Any] = {}
+    if plan:
+        for scene in plan.scenes:
+            scene_by_section[scene.section_id] = scene
+
+    # 3. Get visual assets grouped by scene_id
+    grouped_assets = await visual_asset_service.list_by_run(run_id)
+
+    # 4. Get per-paragraph audio artifacts keyed by section_id
+    audio_artifacts = await audio_service.list_paragraph_audio(run_id)
+    audio_by_section: dict[str, Any] = {}
+    for a in audio_artifacts:
+        if a.section_id and a.section_id not in audio_by_section:
+            audio_by_section[a.section_id] = a
+
+    # 5. Get per-paragraph subtitle artifacts keyed by section_id
+    subtitle_artifacts = await subtitle_service.list_paragraph_subtitles(run_id)
+    subtitle_by_section: dict[str, Any] = {}
+    for s in subtitle_artifacts:
+        if s.section_id and s.section_id not in subtitle_by_section:
+            subtitle_by_section[s.section_id] = s
+
+    # 6. Assemble paragraphs
+    paragraphs: list[dict[str, object]] = []
+    ready_count = 0
+
+    for idx, section in enumerate(sections):
+        scene = scene_by_section.get(section.section_id)
+        scene_id = scene.scene_id if scene else None
+
+        # Image: find active asset for this scene
+        image_url: str | None = None
+        image_asset_id: int | None = None
+        if scene_id and scene_id in grouped_assets:
+            for asset in grouped_assets[scene_id]:
+                if asset.is_active:
+                    image_url = asset.asset_path
+                    image_asset_id = asset.id
+                    break
+
+        # Audio
+        audio = audio_by_section.get(section.section_id)
+        audio_url = audio.path if audio else None
+        audio_duration = None  # Duration computed at render time
+        audio_artifact_id = audio.id if audio else None
+
+        # Subtitles
+        subtitle = subtitle_by_section.get(section.section_id)
+        subtitles_url = subtitle.path if subtitle else None
+        subtitle_artifact_id = subtitle.id if subtitle else None
+
+        # Status
+        has_image = image_url is not None
+        has_audio = audio_url is not None
+        has_subtitles = subtitles_url is not None
+
+        if has_image and has_audio and has_subtitles:
+            status = "ready"
+            ready_count += 1
+        elif not has_image and not has_audio and not has_subtitles:
+            status = "idle"
+        else:
+            status = "idle"  # partially done = still idle
+
+        paragraphs.append({
+            "section_id": section.section_id,
+            "order": idx,
+            "text": section.text,
+            "display_text": section.display_text,
+            "image_prompt": scene.prompt if scene else None,
+            "image_url": image_url,
+            "audio_url": audio_url,
+            "audio_duration": audio_duration,
+            "subtitles_url": subtitles_url,
+            "subtitle_entries": None,
+            "status": status,
+            "stale_flags": None,
+            "scene_id": scene_id,
+            "image_asset_id": image_asset_id,
+            "audio_artifact_id": audio_artifact_id,
+            "subtitle_artifact_id": subtitle_artifact_id,
+        })
+
+    total = len(paragraphs)
+    render_ready = total > 0 and ready_count == total
+
+    return {
+        "run_id": run_id,
+        "paragraphs": paragraphs,
+        "render_ready": render_ready,
+        "total_paragraphs": total,
+        "ready_paragraphs": ready_count,
+    }
+
+
+@router.post(
+    "/runs/{run_id}/storyboard/paragraphs/{section_id}/generate-audio",
+    status_code=202,
+)
+async def generate_paragraph_audio_endpoint(
+    run_id: int, section_id: str, request: ParagraphAudioRequest | None = None
+) -> dict[str, object]:
+    """Dispatch per-paragraph TTS audio generation."""
+    effective = request or ParagraphAudioRequest()
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # Find section text
+    draft = await script_service.get_active_draft(run_id)
+    if draft is None or not draft.structured_script:
+        raise HTTPException(status_code=400, detail="No script available")
+
+    section_text: str | None = None
+    for section in draft.structured_script:
+        if section.section_id == section_id:
+            section_text = section.text
+            break
+
+    if section_text is None:
+        raise HTTPException(status_code=404, detail=f"Section '{section_id}' not found")
+
+    try:
+        task_id = dispatch_paragraph_audio(
+            run_id=run_id,
+            section_id=section_id,
+            section_text=section_text,
+            tts_model=effective.tts_model,
+            voice=effective.voice,
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue paragraph audio task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "section_id": section_id,
+    }
+
+
+@router.post(
+    "/runs/{run_id}/storyboard/paragraphs/{section_id}/generate-subtitles",
+    status_code=202,
+)
+async def generate_paragraph_subtitles_endpoint(
+    run_id: int, section_id: str, request: ParagraphSubtitlesRequest | None = None
+) -> dict[str, object]:
+    """Dispatch per-paragraph subtitle generation."""
+    effective = request or ParagraphSubtitlesRequest()
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # Need audio to exist first
+    audio = await audio_service.get_paragraph_audio(run_id, section_id)
+    if audio is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"No audio found for section '{section_id}'. Generate audio first.",
+        )
+
+    try:
+        task_id = dispatch_paragraph_subtitles(
+            run_id=run_id,
+            section_id=section_id,
+            audio_path=audio.path,
+            subtitle_model=effective.subtitle_model,
+            subtitle_format=effective.subtitle_format,
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue paragraph subtitle task",
+        ) from None
+
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "section_id": section_id,
+    }
+
+
+@router.post("/runs/{run_id}/storyboard/generate-all-audio", status_code=202)
+async def generate_all_paragraph_audio(
+    run_id: int, request: BulkParagraphAudioRequest | None = None
+) -> dict[str, object]:
+    """Dispatch TTS audio generation for ALL paragraphs in the script."""
+    effective = request or BulkParagraphAudioRequest()
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    draft = await script_service.get_active_draft(run_id)
+    if draft is None or not draft.structured_script:
+        raise HTTPException(status_code=400, detail="No script available")
+
+    task_ids: list[dict[str, str]] = []
+    for section in draft.structured_script:
+        try:
+            tid = dispatch_paragraph_audio(
+                run_id=run_id,
+                section_id=section.section_id,
+                section_text=section.text,
+                tts_model=effective.tts_model,
+                voice=effective.voice,
+            )
+            task_ids.append({"section_id": section.section_id, "task_id": tid})
+        except Exception:
+            task_ids.append({"section_id": section.section_id, "task_id": "", "error": "dispatch_failed"})
+
+    return {
+        "run_id": run_id,
+        "tasks": task_ids,
+        "total": len(task_ids),
+    }
+
+
+@router.post("/runs/{run_id}/storyboard/generate-all-subtitles", status_code=202)
+async def generate_all_paragraph_subtitles(
+    run_id: int, request: BulkParagraphSubtitlesRequest | None = None
+) -> dict[str, object]:
+    """Dispatch subtitle generation for ALL paragraphs that have audio."""
+    effective = request or BulkParagraphSubtitlesRequest()
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # Get all per-paragraph audio artifacts
+    audio_artifacts = await audio_service.list_paragraph_audio(run_id)
+    if not audio_artifacts:
+        raise HTTPException(status_code=400, detail="No paragraph audio found. Generate audio first.")
+
+    task_ids: list[dict[str, str]] = []
+    for audio in audio_artifacts:
+        if not audio.section_id:
+            continue
+        try:
+            tid = dispatch_paragraph_subtitles(
+                run_id=run_id,
+                section_id=audio.section_id,
+                audio_path=audio.path,
+                subtitle_model=effective.subtitle_model,
+                subtitle_format=effective.subtitle_format,
+            )
+            task_ids.append({"section_id": audio.section_id, "task_id": tid})
+        except Exception:
+            task_ids.append({"section_id": audio.section_id, "task_id": "", "error": "dispatch_failed"})
+
+    return {
+        "run_id": run_id,
+        "tasks": task_ids,
+        "total": len(task_ids),
     }

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -139,6 +139,39 @@ function mockFetchProjectAndRuns(
           Promise.resolve({ script_models: [], image_models: [], tts_models: [], stt_models: [] }),
       } as Response);
     }
+    // GET /runs/:id/storyboard
+    if (url.includes("/storyboard")) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            run_id: 1,
+            paragraphs: [
+              {
+                section_id: "sec-0",
+                order: 0,
+                text: "Test paragraph",
+                display_text: null,
+                image_prompt: "test prompt",
+                image_url: null,
+                audio_url: null,
+                audio_duration: null,
+                subtitles_url: null,
+                subtitle_entries: null,
+                status: "idle",
+                stale_flags: null,
+                scene_id: "scene-0",
+                image_asset_id: null,
+                audio_artifact_id: null,
+                subtitle_artifact_id: null,
+              },
+            ],
+            render_ready: false,
+            total_paragraphs: 1,
+            ready_paragraphs: 0,
+          }),
+      } as Response);
+    }
     // GET /runs/:id (for refreshRun)
     if (url.includes("/runs/")) {
       const latestRun = runs[0];
@@ -699,40 +732,43 @@ describe("ProjectPage", () => {
 
   // ---- Audio / Subtitle / Render / Final Review Stages ----
 
-  it("shows audio generating indicator for AUDIO_GENERATING", async () => {
+  it("shows storyboard view for AUDIO_GENERATING", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_AUDIO_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("audio-generating-indicator")).toBeInTheDocument();
+      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
     });
-    expect(screen.getByText("Generating Audio…")).toBeInTheDocument();
+    // Render Video and Restart from Script buttons should be in action bar
+    expect(screen.getByRole("button", { name: "Render Video" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Restart from Script" })).toBeInTheDocument();
   });
 
-  it("shows subtitle generating indicator for SUBTITLE_GENERATING", async () => {
+  it("shows storyboard view for SUBTITLE_GENERATING", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_SUBTITLE_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("subtitle-generating-indicator")).toBeInTheDocument();
+      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
     });
-    expect(screen.getByText("Generating Subtitles…")).toBeInTheDocument();
   });
 
-  it("shows render generating indicator for RENDER_GENERATING", async () => {
+  it("shows storyboard view for RENDER_GENERATING", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_RENDER_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("render-generating-indicator")).toBeInTheDocument();
+      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
     });
-    expect(screen.getByText("Rendering Video…")).toBeInTheDocument();
+    // During render, storyboard should be read-only (no generate buttons in storyboard)
+    expect(screen.getByRole("button", { name: "Restart from Script" })).toBeInTheDocument();
   });
 
-  it("shows final review section with review link for FINAL_REVIEW", async () => {
+  it("shows final review section with storyboard and review link for FINAL_REVIEW", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_FINAL_REVIEW]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("final-review-section")).toBeInTheDocument();
+      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
     });
-    expect(screen.getByText("🎬 Pipeline Complete")).toBeInTheDocument();
+    expect(screen.getByTestId("final-review-section")).toBeInTheDocument();
+    expect(screen.getByText("Pipeline Complete")).toBeInTheDocument();
     expect(screen.getByTestId("review-link")).toBeInTheDocument();
     expect(screen.getByTestId("review-link").getAttribute("href")).toBe("/review/1");
   });
@@ -745,13 +781,12 @@ describe("ProjectPage", () => {
     });
   });
 
-  it("hides approve and generate buttons during AUDIO_GENERATING", async () => {
+  it("hides approve button during AUDIO_GENERATING", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_AUDIO_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("audio-generating-indicator")).toBeInTheDocument();
+      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
     });
     expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Generate" })).not.toBeInTheDocument();
   });
 });

--- a/apps/studio-web/src/__tests__/ReviewPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ReviewPage.test.tsx
@@ -94,6 +94,39 @@ function mockFetchAll(
       if (!opts.preview) return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) } as Response);
       return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.preview) } as Response);
     }
+    // GET /runs/:id/storyboard
+    if (url.includes("/storyboard")) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            run_id: run?.id ?? 0,
+            paragraphs: [
+              {
+                section_id: "sec-0",
+                order: 0,
+                text: "A calm morning in Tokyo.",
+                display_text: null,
+                image_prompt: "panoramic tokyo",
+                image_url: null,
+                audio_url: "data/artifacts/10/audio/sec-0.wav",
+                audio_duration: 5.2,
+                subtitles_url: "data/artifacts/10/subtitles/sec-0.srt",
+                subtitle_entries: [{ index: 1, start: "00:00:00,000", end: "00:00:05,200", text: "A calm morning in Tokyo." }],
+                status: "ready",
+                stale_flags: null,
+                scene_id: "scene-0",
+                image_asset_id: null,
+                audio_artifact_id: 2,
+                subtitle_artifact_id: 3,
+              },
+            ],
+            render_ready: true,
+            total_paragraphs: 1,
+            ready_paragraphs: 1,
+          }),
+      } as Response);
+    }
     // GET /runs/:id/visual-assets
     if (url.includes("/visual-assets")) {
       if (!opts.assets) return Promise.resolve({ ok: true, json: () => Promise.resolve({ run_id: run?.id ?? 0, scenes: {}, total_scenes: 0, total_assets: 0 }) } as Response);
@@ -173,14 +206,8 @@ describe("ReviewPage", () => {
     expect(screen.getByTestId("review-assets-section")).toBeTruthy();
     expect(screen.getByText(/scene-0\.png/)).toBeTruthy();
 
-    // Audio section
-    expect(screen.getByTestId("review-audio-section")).toBeTruthy();
-    expect(screen.getByText("qwen3-tts")).toBeTruthy();
-
-    // Subtitle section
-    expect(screen.getByTestId("review-subtitle-section")).toBeTruthy();
-    expect(screen.getByText("srt")).toBeTruthy();
-
+    // Storyboard section (replaces audio + subtitle sections)
+    expect(screen.getByTestId("review-storyboard-section")).toBeTruthy();
     // Video section — video is now rendered as <video> element, no path text
     expect(screen.getByTestId("review-video-section")).toBeTruthy();
     const videoEl = screen.getByTestId("review-video-section").querySelector("video");
@@ -244,14 +271,13 @@ describe("ReviewPage", () => {
     });
   });
 
-  it("shows model metadata in audio section", async () => {
+  it("shows storyboard section when preview has audio data", async () => {
     mockFetchAll(MOCK_RUN_FINAL_REVIEW, { preview: MOCK_PREVIEW });
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByTestId("review-audio-section")).toBeTruthy();
+      expect(screen.getByTestId("review-storyboard-section")).toBeTruthy();
     });
-    expect(screen.getByText("qwen3-tts")).toBeTruthy();
   });
 
   it("handles wrapped visual-assets response with scenes field (regression)", async () => {

--- a/apps/studio-web/src/api/storyboard.ts
+++ b/apps/studio-web/src/api/storyboard.ts
@@ -1,0 +1,188 @@
+/**
+ * Storyboard API client — TypeScript types and fetch functions
+ * for the unified paragraph-based pipeline.
+ *
+ * Mirrors backend models in creator_domain.models.storyboard.
+ */
+
+const API_BASE = "/api/creator";
+
+// --------------- types ---------------
+
+export type ParagraphStatus =
+  | "idle"
+  | "generating_image"
+  | "generating_audio"
+  | "generating_subtitles"
+  | "ready"
+  | "stale"
+  | "failed";
+
+export interface StaleFlags {
+  prompt_stale: boolean;
+  image_stale: boolean;
+  audio_stale: boolean;
+  subtitles_stale: boolean;
+}
+
+export interface SubtitleEntry {
+  index: number;
+  start: string;
+  end: string;
+  text: string;
+}
+
+export interface StoryboardParagraph {
+  section_id: string;
+  order: number;
+  text: string;
+  display_text: string | null;
+  image_prompt: string | null;
+  image_url: string | null;
+  audio_url: string | null;
+  audio_duration: number | null;
+  subtitles_url: string | null;
+  subtitle_entries: SubtitleEntry[] | null;
+  status: ParagraphStatus;
+  stale_flags: StaleFlags | null;
+  scene_id: string | null;
+  image_asset_id: number | null;
+  audio_artifact_id: number | null;
+  subtitle_artifact_id: number | null;
+}
+
+export interface StoryboardResponse {
+  run_id: number;
+  paragraphs: StoryboardParagraph[];
+  render_ready: boolean;
+  total_paragraphs: number;
+  ready_paragraphs: number;
+}
+
+export interface ParagraphAudioParams {
+  tts_model?: string;
+  voice?: string;
+}
+
+export interface ParagraphSubtitlesParams {
+  subtitle_model?: string;
+  subtitle_format?: string;
+}
+
+// --------------- API functions ---------------
+
+/**
+ * Fetch full storyboard for a run — assembles paragraphs from
+ * script sections + visual plan + images + audio + subtitles.
+ */
+export async function fetchStoryboard(runId: number): Promise<StoryboardResponse> {
+  const res = await fetch(`${API_BASE}/runs/${runId}/storyboard`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.detail ?? `Failed to fetch storyboard (${res.status})`);
+  }
+  return res.json();
+}
+
+/**
+ * Generate audio for a single paragraph (section).
+ */
+export async function generateParagraphAudio(
+  runId: number,
+  sectionId: string,
+  params: ParagraphAudioParams = {},
+): Promise<{ task_id: string }> {
+  const res = await fetch(
+    `${API_BASE}/runs/${runId}/storyboard/paragraphs/${sectionId}/generate-audio`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tts_model: params.tts_model ?? "qwen3-tts",
+        voice: params.voice ?? "default",
+      }),
+    },
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.detail ?? `Generate audio failed (${res.status})`);
+  }
+  return res.json();
+}
+
+/**
+ * Generate subtitles for a single paragraph (section).
+ * Requires audio to already exist for this paragraph.
+ */
+export async function generateParagraphSubtitles(
+  runId: number,
+  sectionId: string,
+  params: ParagraphSubtitlesParams = {},
+): Promise<{ task_id: string }> {
+  const res = await fetch(
+    `${API_BASE}/runs/${runId}/storyboard/paragraphs/${sectionId}/generate-subtitles`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        subtitle_model: params.subtitle_model ?? "whisper-small",
+        subtitle_format: params.subtitle_format ?? "srt",
+      }),
+    },
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.detail ?? `Generate subtitles failed (${res.status})`);
+  }
+  return res.json();
+}
+
+/**
+ * Generate audio for ALL paragraphs in bulk.
+ */
+export async function generateAllParagraphAudio(
+  runId: number,
+  params: ParagraphAudioParams = {},
+): Promise<{ dispatched: number }> {
+  const res = await fetch(
+    `${API_BASE}/runs/${runId}/storyboard/generate-all-audio`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tts_model: params.tts_model ?? "qwen3-tts",
+        voice: params.voice ?? "default",
+      }),
+    },
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.detail ?? `Bulk audio generation failed (${res.status})`);
+  }
+  return res.json();
+}
+
+/**
+ * Generate subtitles for ALL paragraphs that have audio.
+ */
+export async function generateAllParagraphSubtitles(
+  runId: number,
+  params: ParagraphSubtitlesParams = {},
+): Promise<{ dispatched: number }> {
+  const res = await fetch(
+    `${API_BASE}/runs/${runId}/storyboard/generate-all-subtitles`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        subtitle_model: params.subtitle_model ?? "whisper-small",
+        subtitle_format: params.subtitle_format ?? "srt",
+      }),
+    },
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.detail ?? `Bulk subtitle generation failed (${res.status})`);
+  }
+  return res.json();
+}

--- a/apps/studio-web/src/components/creator/StoryboardCard.tsx
+++ b/apps/studio-web/src/components/creator/StoryboardCard.tsx
@@ -1,0 +1,309 @@
+/**
+ * StoryboardCard — single-paragraph card in the unified storyboard view.
+ *
+ * Displays: script text, image prompt, generated image preview, audio player,
+ * subtitle preview, per-paragraph regenerate buttons, and status indicator.
+ */
+
+import type {
+  StoryboardParagraph,
+  ParagraphAudioParams,
+  ParagraphSubtitlesParams,
+} from "../../api/storyboard";
+
+// --------------- helpers ---------------
+
+/** Convert API artifact path → browser URL via Vite proxy. */
+function artifactUrl(path: string): string {
+  const match = path.match(/data\/artifacts\/(.*)/);
+  return match ? `/artifacts/${match[1]}` : `/artifacts/${path}`;
+}
+
+const STATUS_COLORS: Record<string, { bg: string; border: string; text: string; label: string }> = {
+  idle: { bg: "#f9fafb", border: "#e5e7eb", text: "#6b7280", label: "Idle" },
+  generating_image: { bg: "#fdf4ff", border: "#e9d5ff", text: "#6b21a8", label: "Generating Image…" },
+  generating_audio: { bg: "#fefce8", border: "#fde68a", text: "#92400e", label: "Generating Audio…" },
+  generating_subtitles: { bg: "#f0f9ff", border: "#bae6fd", text: "#075985", label: "Generating Subtitles…" },
+  ready: { bg: "#f0fdf4", border: "#bbf7d0", text: "#166534", label: "Ready" },
+  stale: { bg: "#fffbeb", border: "#fde68a", text: "#b45309", label: "Stale" },
+  failed: { bg: "#fef2f2", border: "#fca5a5", text: "#b91c1c", label: "Failed" },
+};
+
+// --------------- props ---------------
+
+export interface StoryboardCardProps {
+  paragraph: StoryboardParagraph;
+  readOnly?: boolean;
+  onGenerateAudio?: (sectionId: string, params: ParagraphAudioParams) => void;
+  onGenerateSubtitles?: (sectionId: string, params: ParagraphSubtitlesParams) => void;
+}
+
+// --------------- styles ---------------
+
+const cardStyle: React.CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 10,
+  background: "#fff",
+  overflow: "hidden",
+  display: "flex",
+  flexDirection: "column",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "10px 14px",
+  borderBottom: "1px solid #f3f4f6",
+  background: "#fafafa",
+};
+
+const bodyStyle: React.CSSProperties = {
+  padding: 14,
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+  flex: 1,
+};
+
+const sectionLabelStyle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  color: "#6b7280",
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  marginBottom: 4,
+};
+
+const textBlockStyle: React.CSSProperties = {
+  fontSize: 13,
+  lineHeight: 1.5,
+  color: "#374151",
+  fontFamily: '"Inter", "Noto Sans KR", system-ui, sans-serif',
+};
+
+const promptStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "#6b7280",
+  fontStyle: "italic",
+  lineHeight: 1.4,
+  padding: "6px 10px",
+  background: "#f9fafb",
+  borderRadius: 4,
+  border: "1px solid #f3f4f6",
+};
+
+const btnStyle: React.CSSProperties = {
+  padding: "4px 10px",
+  fontSize: 11,
+  fontWeight: 500,
+  border: "1px solid #d1d5db",
+  borderRadius: 5,
+  background: "#fff",
+  cursor: "pointer",
+  color: "#374151",
+  transition: "all 0.15s",
+};
+
+const subtitlePreviewStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "#6b7280",
+  fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+  maxHeight: 100,
+  overflowY: "auto",
+  padding: "6px 10px",
+  background: "#f9fafb",
+  borderRadius: 4,
+  border: "1px solid #f3f4f6",
+  whiteSpace: "pre-wrap",
+};
+
+// --------------- component ---------------
+
+export default function StoryboardCard({
+  paragraph,
+  readOnly = false,
+  onGenerateAudio,
+  onGenerateSubtitles,
+}: StoryboardCardProps) {
+  const p = paragraph;
+  const statusInfo = STATUS_COLORS[p.status] ?? STATUS_COLORS.idle;
+  const isGenerating = p.status.startsWith("generating_");
+
+  return (
+    <div style={cardStyle} data-testid={`storyboard-card-${p.section_id}`}>
+      {/* Header — order + status */}
+      <div style={headerStyle}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 13, fontWeight: 700, color: "#111827" }}>
+            §{p.order + 1}
+          </span>
+          <span style={{ fontSize: 11, color: "#9ca3af" }}>{p.section_id}</span>
+        </div>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            padding: "2px 8px",
+            borderRadius: 10,
+            background: statusInfo.bg,
+            border: `1px solid ${statusInfo.border}`,
+            color: statusInfo.text,
+          }}
+        >
+          {statusInfo.label}
+        </span>
+      </div>
+
+      {/* Body */}
+      <div style={bodyStyle}>
+        {/* Script text */}
+        <div>
+          <div style={sectionLabelStyle}>Script</div>
+          <div style={textBlockStyle}>
+            {p.display_text ?? p.text}
+          </div>
+        </div>
+
+        {/* Image prompt */}
+        {p.image_prompt && (
+          <div>
+            <div style={sectionLabelStyle}>Image Prompt</div>
+            <div style={promptStyle}>{p.image_prompt}</div>
+          </div>
+        )}
+
+        {/* Image preview */}
+        {p.image_url && (
+          <div>
+            <div style={sectionLabelStyle}>Image</div>
+            <img
+              src={artifactUrl(p.image_url)}
+              alt={`Scene for §${p.order + 1}`}
+              style={{
+                width: "100%",
+                maxHeight: 220,
+                objectFit: "contain",
+                borderRadius: 6,
+                background: "#f3f4f6",
+                display: "block",
+              }}
+            />
+          </div>
+        )}
+
+        {/* Audio player */}
+        {p.audio_url && (
+          <div>
+            <div style={sectionLabelStyle}>
+              Audio
+              {p.audio_duration != null && (
+                <span style={{ fontWeight: 400, fontSize: 11, color: "#9ca3af", marginLeft: 6 }}>
+                  {p.audio_duration.toFixed(1)}s
+                </span>
+              )}
+            </div>
+            <audio
+              controls
+              style={{ width: "100%", height: 32, borderRadius: 4 }}
+              src={artifactUrl(p.audio_url)}
+            />
+          </div>
+        )}
+
+        {/* Subtitle preview */}
+        {p.subtitle_entries && p.subtitle_entries.length > 0 && (
+          <div>
+            <div style={sectionLabelStyle}>
+              Subtitles ({p.subtitle_entries.length})
+            </div>
+            <div style={subtitlePreviewStyle}>
+              {p.subtitle_entries.map((e, i) => (
+                <div key={i}>
+                  <span style={{ color: "#9ca3af" }}>{e.start} → {e.end}</span>{" "}
+                  {e.text}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Stale flags */}
+        {p.stale_flags && (
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            {p.stale_flags.prompt_stale && (
+              <span style={{ fontSize: 10, padding: "1px 6px", borderRadius: 3, background: "#fef3c7", color: "#b45309" }}>
+                Prompt stale
+              </span>
+            )}
+            {p.stale_flags.image_stale && (
+              <span style={{ fontSize: 10, padding: "1px 6px", borderRadius: 3, background: "#fef3c7", color: "#b45309" }}>
+                Image stale
+              </span>
+            )}
+            {p.stale_flags.audio_stale && (
+              <span style={{ fontSize: 10, padding: "1px 6px", borderRadius: 3, background: "#fef3c7", color: "#b45309" }}>
+                Audio stale
+              </span>
+            )}
+            {p.stale_flags.subtitles_stale && (
+              <span style={{ fontSize: 10, padding: "1px 6px", borderRadius: 3, background: "#fef3c7", color: "#b45309" }}>
+                Subtitles stale
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Action buttons */}
+        {!readOnly && !isGenerating && (
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 4 }}>
+            {/* Generate Audio button */}
+            {!p.audio_url && p.image_url && (
+              <button
+                type="button"
+                style={{ ...btnStyle, borderColor: "#fde68a", background: "#fffbeb", color: "#92400e" }}
+                onClick={() => onGenerateAudio?.(p.section_id, {})}
+                data-testid={`gen-audio-${p.section_id}`}
+              >
+                Generate Audio
+              </button>
+            )}
+            {/* Regenerate Audio button */}
+            {p.audio_url && (
+              <button
+                type="button"
+                style={btnStyle}
+                onClick={() => onGenerateAudio?.(p.section_id, {})}
+                data-testid={`regen-audio-${p.section_id}`}
+              >
+                Regen Audio
+              </button>
+            )}
+            {/* Generate Subtitles button — only when audio exists */}
+            {p.audio_url && !p.subtitles_url && (
+              <button
+                type="button"
+                style={{ ...btnStyle, borderColor: "#bae6fd", background: "#f0f9ff", color: "#075985" }}
+                onClick={() => onGenerateSubtitles?.(p.section_id, {})}
+                data-testid={`gen-subs-${p.section_id}`}
+              >
+                Generate Subtitles
+              </button>
+            )}
+            {/* Regenerate Subtitles button */}
+            {p.subtitles_url && (
+              <button
+                type="button"
+                style={btnStyle}
+                onClick={() => onGenerateSubtitles?.(p.section_id, {})}
+                data-testid={`regen-subs-${p.section_id}`}
+              >
+                Regen Subtitles
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/studio-web/src/components/creator/StoryboardView.tsx
+++ b/apps/studio-web/src/components/creator/StoryboardView.tsx
@@ -1,0 +1,434 @@
+/**
+ * StoryboardView — unified grid of all paragraphs for a run.
+ *
+ * Renders StoryboardCard for each paragraph in a scrollable grid,
+ * with bulk action buttons (generate all audio, generate all subtitles)
+ * and a render-ready indicator.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+import StoryboardCard from "./StoryboardCard";
+import type {
+  StoryboardResponse,
+  StoryboardParagraph,
+  ParagraphAudioParams,
+  ParagraphSubtitlesParams,
+} from "../../api/storyboard";
+import {
+  fetchStoryboard,
+  generateParagraphAudio,
+  generateParagraphSubtitles,
+  generateAllParagraphAudio,
+  generateAllParagraphSubtitles,
+} from "../../api/storyboard";
+
+// --------------- props ---------------
+
+export interface StoryboardViewProps {
+  runId: number;
+  readOnly?: boolean;
+  onStatusMessage?: (msg: string) => void;
+  /** Called when render should be triggered (all paragraphs ready). */
+  onRenderReady?: () => void;
+  /** Polling interval in ms. Default 5000. */
+  pollInterval?: number;
+}
+
+// --------------- styles ---------------
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 16,
+};
+
+const headerBarStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "12px 16px",
+  background: "#fafafa",
+  borderRadius: 8,
+  border: "1px solid #e5e7eb",
+};
+
+const bulkBtnStyle: React.CSSProperties = {
+  padding: "6px 14px",
+  fontSize: 12,
+  fontWeight: 600,
+  border: "1px solid #d1d5db",
+  borderRadius: 6,
+  background: "#fff",
+  cursor: "pointer",
+  color: "#374151",
+  transition: "all 0.15s",
+};
+
+const gridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
+  gap: 16,
+};
+
+const progressBarOuter: React.CSSProperties = {
+  height: 6,
+  background: "#e5e7eb",
+  borderRadius: 3,
+  overflow: "hidden",
+  flex: 1,
+  marginRight: 10,
+};
+
+// --------------- component ---------------
+
+export default function StoryboardView({
+  runId,
+  readOnly = false,
+  onStatusMessage,
+  onRenderReady,
+  pollInterval = 5000,
+}: StoryboardViewProps) {
+  const [storyboard, setStoryboard] = useState<StoryboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [bulkGenerating, setBulkGenerating] = useState(false);
+
+  // Track whether any paragraph is actively generating
+  const hasGenerating = storyboard?.paragraphs.some(
+    (p) => p.status.startsWith("generating_"),
+  ) ?? false;
+
+  const loadStoryboard = useCallback(async () => {
+    try {
+      const data = await fetchStoryboard(runId);
+      setStoryboard(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load storyboard");
+    } finally {
+      setLoading(false);
+    }
+  }, [runId]);
+
+  // Initial fetch
+  useEffect(() => {
+    loadStoryboard();
+  }, [loadStoryboard]);
+
+  // Polling while generating
+  useEffect(() => {
+    if (!hasGenerating && !bulkGenerating) return;
+    const timer = setInterval(() => {
+      loadStoryboard();
+    }, pollInterval);
+    return () => clearInterval(timer);
+  }, [hasGenerating, bulkGenerating, pollInterval, loadStoryboard]);
+
+  // Notify when render-ready
+  useEffect(() => {
+    if (storyboard?.render_ready) {
+      onRenderReady?.();
+    }
+  }, [storyboard?.render_ready, onRenderReady]);
+
+  // ---- handlers ----
+
+  const handleGenerateAudio = useCallback(
+    async (sectionId: string, params: ParagraphAudioParams) => {
+      try {
+        await generateParagraphAudio(runId, sectionId, params);
+        onStatusMessage?.(`Audio generation started for §${sectionId}`);
+        // Update local state to show generating
+        setStoryboard((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            paragraphs: prev.paragraphs.map((p) =>
+              p.section_id === sectionId
+                ? { ...p, status: "generating_audio" as const }
+                : p,
+            ),
+          };
+        });
+      } catch (err) {
+        onStatusMessage?.(err instanceof Error ? err.message : "Audio generation failed");
+      }
+    },
+    [runId, onStatusMessage],
+  );
+
+  const handleGenerateSubtitles = useCallback(
+    async (sectionId: string, params: ParagraphSubtitlesParams) => {
+      try {
+        await generateParagraphSubtitles(runId, sectionId, params);
+        onStatusMessage?.(`Subtitle generation started for §${sectionId}`);
+        setStoryboard((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            paragraphs: prev.paragraphs.map((p) =>
+              p.section_id === sectionId
+                ? { ...p, status: "generating_subtitles" as const }
+                : p,
+            ),
+          };
+        });
+      } catch (err) {
+        onStatusMessage?.(err instanceof Error ? err.message : "Subtitle generation failed");
+      }
+    },
+    [runId, onStatusMessage],
+  );
+
+  const handleBulkAudio = useCallback(async () => {
+    setBulkGenerating(true);
+    try {
+      const result = await generateAllParagraphAudio(runId);
+      onStatusMessage?.(`Audio generation started for ${result.dispatched} paragraphs`);
+      // Mark all paragraphs as generating
+      setStoryboard((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          paragraphs: prev.paragraphs.map((p) =>
+            !p.audio_url
+              ? { ...p, status: "generating_audio" as const }
+              : p,
+          ),
+        };
+      });
+    } catch (err) {
+      onStatusMessage?.(err instanceof Error ? err.message : "Bulk audio generation failed");
+    } finally {
+      setBulkGenerating(false);
+    }
+  }, [runId, onStatusMessage]);
+
+  const handleBulkSubtitles = useCallback(async () => {
+    setBulkGenerating(true);
+    try {
+      const result = await generateAllParagraphSubtitles(runId);
+      onStatusMessage?.(`Subtitle generation started for ${result.dispatched} paragraphs`);
+      setStoryboard((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          paragraphs: prev.paragraphs.map((p) =>
+            p.audio_url && !p.subtitles_url
+              ? { ...p, status: "generating_subtitles" as const }
+              : p,
+          ),
+        };
+      });
+    } catch (err) {
+      onStatusMessage?.(err instanceof Error ? err.message : "Bulk subtitle generation failed");
+    } finally {
+      setBulkGenerating(false);
+    }
+  }, [runId, onStatusMessage]);
+
+  // ---- render ----
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          textAlign: "center",
+          padding: 32,
+          color: "#6b7280",
+          fontSize: 13,
+        }}
+      >
+        Loading storyboard…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        role="alert"
+        style={{
+          padding: "12px 16px",
+          background: "#fef2f2",
+          border: "1px solid #fca5a5",
+          borderRadius: 6,
+          color: "#b91c1c",
+          fontSize: 13,
+        }}
+      >
+        {error}
+        <button
+          type="button"
+          onClick={loadStoryboard}
+          style={{
+            marginLeft: 12,
+            padding: "2px 10px",
+            fontSize: 12,
+            border: "1px solid #fca5a5",
+            borderRadius: 4,
+            background: "#fff",
+            cursor: "pointer",
+            color: "#b91c1c",
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!storyboard || storyboard.paragraphs.length === 0) {
+    return (
+      <div
+        style={{
+          textAlign: "center",
+          padding: 32,
+          color: "#6b7280",
+          fontSize: 13,
+          background: "#f9fafb",
+          borderRadius: 8,
+          border: "1px dashed #d1d5db",
+        }}
+      >
+        No paragraphs in storyboard. Generate a script and visual plan first.
+      </div>
+    );
+  }
+
+  const paragraphs: StoryboardParagraph[] = storyboard.paragraphs;
+  const readyCount = storyboard.ready_paragraphs;
+  const totalCount = storyboard.total_paragraphs;
+  const progress = totalCount > 0 ? (readyCount / totalCount) * 100 : 0;
+
+  // Count paragraphs with audio / subtitles
+  const audioCount = paragraphs.filter((p) => p.audio_url).length;
+  const subtitleCount = paragraphs.filter((p) => p.subtitles_url).length;
+
+  return (
+    <div style={containerStyle} data-testid="storyboard-view">
+      {/* Header bar with progress + bulk actions */}
+      <div style={headerBarStyle}>
+        <div style={{ display: "flex", alignItems: "center", flex: 1, gap: 12 }}>
+          <div style={{ fontSize: 14, fontWeight: 600, color: "#111827", whiteSpace: "nowrap" }}>
+            Storyboard
+          </div>
+          <div style={progressBarOuter}>
+            <div
+              style={{
+                height: "100%",
+                width: `${progress}%`,
+                background: storyboard.render_ready ? "#22c55e" : "#4285f4",
+                borderRadius: 3,
+                transition: "width 0.3s ease",
+              }}
+            />
+          </div>
+          <span style={{ fontSize: 12, color: "#6b7280", whiteSpace: "nowrap" }}>
+            {readyCount}/{totalCount} ready
+          </span>
+        </div>
+
+        {!readOnly && (
+          <div style={{ display: "flex", gap: 8, marginLeft: 16 }}>
+            <button
+              type="button"
+              style={{
+                ...bulkBtnStyle,
+                borderColor: "#fde68a",
+                background: "#fffbeb",
+                color: "#92400e",
+                opacity: bulkGenerating || hasGenerating ? 0.6 : 1,
+              }}
+              disabled={bulkGenerating || hasGenerating}
+              onClick={handleBulkAudio}
+              data-testid="bulk-generate-audio"
+            >
+              {audioCount > 0 ? `Regen All Audio (${audioCount}/${totalCount})` : "Generate All Audio"}
+            </button>
+            <button
+              type="button"
+              style={{
+                ...bulkBtnStyle,
+                borderColor: "#bae6fd",
+                background: "#f0f9ff",
+                color: "#075985",
+                opacity: bulkGenerating || hasGenerating || audioCount === 0 ? 0.6 : 1,
+              }}
+              disabled={bulkGenerating || hasGenerating || audioCount === 0}
+              onClick={handleBulkSubtitles}
+              data-testid="bulk-generate-subtitles"
+            >
+              {subtitleCount > 0 ? `Regen All Subs (${subtitleCount}/${totalCount})` : "Generate All Subtitles"}
+            </button>
+            <button
+              type="button"
+              style={{ ...bulkBtnStyle, color: "#6b7280" }}
+              onClick={loadStoryboard}
+              title="Refresh storyboard data"
+            >
+              Refresh
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Render-ready banner */}
+      {storyboard.render_ready && (
+        <div
+          data-testid="render-ready-banner"
+          style={{
+            padding: "10px 16px",
+            background: "#f0fdf4",
+            border: "1px solid #bbf7d0",
+            borderRadius: 8,
+            color: "#166534",
+            fontSize: 13,
+            fontWeight: 600,
+            textAlign: "center",
+          }}
+        >
+          All paragraphs are ready — you can now render the video.
+        </div>
+      )}
+
+      {/* Paragraph cards grid */}
+      <div style={gridStyle}>
+        {paragraphs.map((p) => (
+          <StoryboardCard
+            key={p.section_id}
+            paragraph={p}
+            readOnly={readOnly}
+            onGenerateAudio={handleGenerateAudio}
+            onGenerateSubtitles={handleGenerateSubtitles}
+          />
+        ))}
+      </div>
+
+      {/* Summary footer */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          gap: 16,
+          padding: "8px 0",
+          fontSize: 12,
+          color: "#9ca3af",
+        }}
+      >
+        <span>{totalCount} paragraphs</span>
+        <span>·</span>
+        <span>{audioCount} audio</span>
+        <span>·</span>
+        <span>{subtitleCount} subtitles</span>
+        {storyboard.render_ready && (
+          <>
+            <span>·</span>
+            <span style={{ color: "#22c55e", fontWeight: 600 }}>Render Ready</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -24,6 +24,7 @@ import VisualPlanEditor from "../components/creator/VisualPlanEditor";
 import VisualAssetGrid from "../components/creator/VisualAssetGrid";
 import ProgressDialog from "../components/creator/ProgressDialog";
 import ModelSelector from "../components/creator/ModelSelector";
+import StoryboardView from "../components/creator/StoryboardView";
 
 const API_BASE = "/api/creator";
 
@@ -66,6 +67,9 @@ const RENDER_STAGES = new Set(["RENDER_GENERATING"]);
 
 // Final review
 const FINAL_REVIEW_STAGES = new Set(["FINAL_REVIEW"]);
+
+// Storyboard stages — show unified storyboard view instead of separate indicators
+const STORYBOARD_STAGES = new Set(["AUDIO_GENERATING", "SUBTITLE_GENERATING", "RENDER_GENERATING", "FINAL_REVIEW"]);
 
 // Stages where editing is allowed (not generating)
 const EDITABLE_STAGES = new Set(["SCRIPT_REVIEW", "VISUAL_PLAN_REVIEW"]);
@@ -589,6 +593,7 @@ export default function ProjectPage() {
   const isSubtitleStage = SUBTITLE_STAGES.has(currentStage);
   const isRenderStage = RENDER_STAGES.has(currentStage);
   const isFinalReview = FINAL_REVIEW_STAGES.has(currentStage);
+  const isStoryboardStage = STORYBOARD_STAGES.has(currentStage);
   const previewVideo = (preview as Record<string, unknown> | null)?.video;
   const previewVideoPath =
     previewVideo && typeof previewVideo === "object"
@@ -623,33 +628,42 @@ export default function ProjectPage() {
       };
     }
 
-    // Render stage
+    // Storyboard stages — audio/subtitle generation is handled by StoryboardView
+    // Only show render button and restart in the action bar
+    if (isAudioStage || isSubtitleStage) {
+      return {
+        save: { visible: false },
+        approve: { visible: false },
+        generate: {
+          visible: true,
+          disabled: generating,
+          loading: generating,
+          onClick: handleRender,
+          label: "Render Video",
+        },
+        restart: {
+          visible: true,
+          disabled: restarting,
+          loading: restarting,
+          onClick: handleRestart,
+          label: "Restart from Script",
+        },
+      };
+    }
+
+    // Render stage — rendering in progress, show restart only
     if (isRenderStage) {
       return {
         save: { visible: false },
         approve: { visible: false },
-        generate: { visible: false, onClick: handleRender },
-        restart: { visible: false },
-      };
-    }
-
-    // Subtitle stage
-    if (isSubtitleStage) {
-      return {
-        save: { visible: false },
-        approve: { visible: false },
-        generate: { visible: false, onClick: handleGenerateSubtitles },
-        restart: { visible: false },
-      };
-    }
-
-    // Audio stage
-    if (isAudioStage) {
-      return {
-        save: { visible: false },
-        approve: { visible: false },
-        generate: { visible: false, onClick: handleGenerateAudio },
-        restart: { visible: false },
+        generate: { visible: false },
+        restart: {
+          visible: true,
+          disabled: restarting,
+          loading: restarting,
+          onClick: handleRestart,
+          label: "Restart from Script",
+        },
       };
     }
 
@@ -1287,108 +1301,61 @@ export default function ProjectPage() {
         </div>
       )}
 
-      {/* Audio generating indicator */}
-      {run && isAudioStage && (
-        <div
-          data-testid="audio-generating-indicator"
-          style={{
-            textAlign: "center",
-            padding: 32,
-            background: "#fefce8",
-            borderRadius: 8,
-            border: "1px solid #fde68a",
-            color: "#92400e",
-            marginBottom: 24,
-          }}
-        >
-          <p style={{ margin: "0 0 4px", fontWeight: 600 }}>Generating Audio…</p>
-          <p style={{ margin: 0, fontSize: 13 }}>
-            The TTS model is generating audio narration. This may take a moment.
-          </p>
-        </div>
-      )}
-
-      {/* Subtitle generating indicator */}
-      {run && isSubtitleStage && (
-        <div
-          data-testid="subtitle-generating-indicator"
-          style={{
-            textAlign: "center",
-            padding: 32,
-            background: "#f0f9ff",
-            borderRadius: 8,
-            border: "1px solid #bae6fd",
-            color: "#075985",
-            marginBottom: 24,
-          }}
-        >
-          <p style={{ margin: "0 0 4px", fontWeight: 600 }}>Generating Subtitles…</p>
-          <p style={{ margin: 0, fontSize: 13 }}>
-            The STT model is generating subtitles from audio. This may take a moment.
-          </p>
-        </div>
-      )}
-
-      {/* Render generating indicator */}
-      {run && isRenderStage && (
-        <div
-          data-testid="render-generating-indicator"
-          style={{
-            textAlign: "center",
-            padding: 32,
-            background: "#faf5ff",
-            borderRadius: 8,
-            border: "1px solid #d8b4fe",
-            color: "#6b21a8",
-            marginBottom: 24,
-          }}
-        >
-          <p style={{ margin: "0 0 4px", fontWeight: 600 }}>Rendering Video…</p>
-          <p style={{ margin: 0, fontSize: 13 }}>
-            FFmpeg is rendering the final video. This may take several minutes.
-          </p>
-        </div>
-      )}
-
-      {/* Final review section */}
-      {run && isFinalReview && (
-        <div
-          data-testid="final-review-section"
-          style={{
-            textAlign: "center",
-            padding: 32,
-            background: "#f0fdf4",
-            borderRadius: 8,
-            border: "1px solid #bbf7d0",
-            color: "#166534",
-            marginBottom: 24,
-          }}
-        >
-          <p style={{ margin: "0 0 8px", fontWeight: 600, fontSize: 16 }}>🎬 Pipeline Complete</p>
-          <p style={{ margin: "0 0 16px", fontSize: 13 }}>
-            All stages are done. Review the final output or restart from any stage.
-          </p>
-          {typeof previewVideoPath === "string" && (
-            <p style={{ margin: "0 0 8px", fontSize: 13, color: "#374151" }}>
-              Video: {previewVideoPath}
-            </p>
-          )}
-          <Link
-            to={`/review/${run.id}`}
-            data-testid="review-link"
-            style={{
-              display: "inline-block",
-              padding: "8px 24px",
-              background: "#166534",
-              color: "#fff",
-              borderRadius: 6,
-              textDecoration: "none",
-              fontWeight: 600,
-              fontSize: 14,
+      {/* Unified Storyboard view — replaces separate audio/subtitle/render indicators */}
+      {run && isStoryboardStage && (
+        <div style={{ marginBottom: 24 }}>
+          <StoryboardView
+            runId={run.id}
+            readOnly={isRenderStage}
+            onStatusMessage={setStatusMessage}
+            onRenderReady={() => {
+              if (run) refreshRun(run.id);
             }}
-          >
-            Open Review Page →
-          </Link>
+          />
+
+          {/* Final review extras — review link + video path */}
+          {isFinalReview && (
+            <div
+              data-testid="final-review-section"
+              style={{
+                textAlign: "center",
+                padding: 24,
+                marginTop: 16,
+                background: "#f0fdf4",
+                borderRadius: 8,
+                border: "1px solid #bbf7d0",
+                color: "#166534",
+              }}
+            >
+              <p style={{ margin: "0 0 8px", fontWeight: 600, fontSize: 16 }}>
+                Pipeline Complete
+              </p>
+              <p style={{ margin: "0 0 16px", fontSize: 13 }}>
+                All stages are done. Review the final output or restart from any stage.
+              </p>
+              {typeof previewVideoPath === "string" && (
+                <p style={{ margin: "0 0 8px", fontSize: 13, color: "#374151" }}>
+                  Video: {previewVideoPath}
+                </p>
+              )}
+              <Link
+                to={`/review/${run.id}`}
+                data-testid="review-link"
+                style={{
+                  display: "inline-block",
+                  padding: "8px 24px",
+                  background: "#166534",
+                  color: "#fff",
+                  borderRadius: 6,
+                  textDecoration: "none",
+                  fontWeight: 600,
+                  fontSize: 14,
+                }}
+              >
+                Open Review Page →
+              </Link>
+            </div>
+          )}
         </div>
       )}
 

--- a/apps/studio-web/src/pages/ReviewPage.tsx
+++ b/apps/studio-web/src/pages/ReviewPage.tsx
@@ -14,6 +14,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 
 import PipelineStepper from "../components/creator/PipelineStepper";
+import StoryboardView from "../components/creator/StoryboardView";
 
 const API_BASE = "/api/creator";
 
@@ -167,7 +168,6 @@ export default function ReviewPage() {
   const [assets, setAssets] = useState<Record<string, { asset_path: string; model_used: string; is_active: boolean }[]>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [subtitleContent, setSubtitleContent] = useState<string | null>(null);
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
@@ -230,21 +230,6 @@ export default function ReviewPage() {
     }
   }, [numericRunId, fetchAll]);
 
-  // Fetch subtitle content when preview is available
-  useEffect(() => {
-    if (!preview?.subtitle?.path) {
-      setSubtitleContent(null);
-      return;
-    }
-    setSubtitleContent(null); // reset before fetching
-    const url = artifactUrl(preview.subtitle.path);
-    let cancelled = false;
-    fetch(url)
-      .then((res) => (res.ok ? res.text() : Promise.reject(res.status)))
-      .then((text) => { if (!cancelled) setSubtitleContent(text); })
-      .catch(() => { if (!cancelled) setSubtitleContent("(Failed to load subtitle content)"); });
-    return () => { cancelled = true; };
-  }, [preview?.subtitle?.path]);
 
   // ---- render ----
 
@@ -424,43 +409,17 @@ export default function ReviewPage() {
         </div>
       )}
 
-      {/* Audio section */}
-      {preview?.audio && (
-        <div style={cardStyle} data-testid="review-audio-section">
+      {/* Unified Storyboard — per-paragraph audio + subtitles (read-only) */}
+      {POST_AUDIO_STAGES.has(stage) && (
+        <div style={cardStyle} data-testid="review-storyboard-section">
           <div style={headerStyle}>
-            <h3 style={sectionTitle}>Audio</h3>
+            <h3 style={sectionTitle}>Storyboard (Audio &amp; Subtitles)</h3>
             <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
           </div>
-          <audio
-            controls
-            style={{ width: "100%", marginBottom: 8, borderRadius: 6 }}
-            src={artifactUrl(preview.audio.path)}
+          <StoryboardView
+            runId={run.id}
+            readOnly={true}
           />
-          <div style={{ fontSize: 13 }}>
-            <div><strong>Model:</strong> {preview.audio.model_used}</div>
-            <div style={metaStyle}>Created: {new Date(preview.audio.created_at).toLocaleString()}</div>
-          </div>
-        </div>
-      )}
-
-      {/* Subtitle section */}
-      {preview?.subtitle && (
-        <div style={cardStyle} data-testid="review-subtitle-section">
-          <div style={headerStyle}>
-            <h3 style={sectionTitle}>Subtitles</h3>
-            <Link to={editUrl} style={editLinkStyle}>Edit in Project &rarr;</Link>
-          </div>
-          {subtitleContent !== null ? (
-            <div style={previewBoxStyle}>{subtitleContent}</div>
-          ) : (
-            <div style={{ fontSize: 13, color: "#6b7280", fontStyle: "italic" }}>
-              Loading subtitle content…
-            </div>
-          )}
-          <div style={{ fontSize: 13, marginTop: 8 }}>
-            <div><strong>Format:</strong> {preview.subtitle.format}</div>
-            <div style={metaStyle}>Created: {new Date(preview.subtitle.created_at).toLocaleString()}</div>
-          </div>
         </div>
       )}
 

--- a/apps/worker-orchestrator/tasks/generate_paragraph_audio.py
+++ b/apps/worker-orchestrator/tasks/generate_paragraph_audio.py
@@ -1,0 +1,155 @@
+"""Celery task for per-paragraph TTS audio generation.
+
+Generates audio for a single script section (paragraph).  Unlike the
+run-level ``generate_audio`` task this does NOT transition stages — the
+caller (storyboard API) manages aggregate state.
+
+Audio is saved to: data/artifacts/{run_id}/audio/{section_id}.wav
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    import redis
+except ImportError:
+    redis = None  # type: ignore[assignment]
+
+from celery_app import celery_app
+from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+from creator_provider.registry import ProviderRegistry
+from creator_service.audio_service import audio_service as _audio_service
+
+logger = logging.getLogger(__name__)
+
+_ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _get_redis_client() -> Any | None:
+    if redis is None:
+        return None
+    return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+@celery_app.task(bind=True, name="generate_paragraph_audio")
+def generate_paragraph_audio(
+    self,
+    run_id: int,
+    section_id: str,
+    section_text: str,
+    tts_model: str = "qwen3-tts",
+    voice: str = "default",
+) -> dict[str, object]:
+    """Generate TTS audio for a single paragraph.
+
+    Parameters
+    ----------
+    run_id : int
+        Parent run ID (used for artifact storage path).
+    section_id : str
+        The ``section_id`` from the structured script.
+    section_text : str
+        Plain text of the paragraph to synthesise.
+    tts_model : str
+        Model key from the provider registry.
+    voice : str
+        Voice identifier for the TTS provider.
+    """
+    start_time = datetime.now(timezone.utc)
+    start_iso = start_time.isoformat()
+    task_id = str(getattr(getattr(self, "request", None), "id", None) or f"para-{run_id}-{section_id}")
+
+    provider_type: str | None = None
+    endpoint: str | None = None
+    gpu_lock_acquired_at: str | None = None
+    gpu_lock_released_at: str | None = None
+    redis_client: Any | None = None
+    lock_acquired = False
+
+    async def _run_task() -> dict[str, object]:
+        nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
+        nonlocal redis_client, lock_acquired
+
+        # 1. Provider resolution
+        registry = ProviderRegistry.create_default()
+        entry = registry.resolve(tts_model)
+        provider = registry.get_provider(tts_model)
+
+        provider_type = entry.provider_type
+        endpoint = entry.endpoint
+
+        # 2. GPU lock
+        if entry.requires_gpu:
+            redis_client = _get_redis_client()
+            if redis_client is None:
+                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+            acquire_gpu_lock(redis_client, task_id)
+            lock_acquired = True
+            gpu_lock_acquired_at = _utc_now_iso()
+
+        audio_path = f"{_ARTIFACT_ROOT}/{run_id}/audio/{section_id}.wav"
+
+        try:
+            os.makedirs(os.path.dirname(audio_path), exist_ok=True)
+
+            # 3. Generate audio via provider
+            params = dict(entry.default_params or {})
+            params["output_path"] = audio_path
+            await provider.generate(section_text, voice=voice, params=params)
+
+            # 4. Save per-paragraph artifact
+            artifact = await _audio_service.create_paragraph_artifact(
+                run_id=run_id,
+                section_id=section_id,
+                path=audio_path,
+                model_used=tts_model,
+                provider_type=entry.provider_type,
+                voice=voice,
+            )
+        finally:
+            if lock_acquired:
+                try:
+                    release_gpu_lock(redis_client, task_id)
+                    gpu_lock_released_at = _utc_now_iso()
+                except Exception:
+                    logger.exception("Failed to release GPU lock for task %s", task_id)
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "section_id": section_id,
+            "tts_model": tts_model,
+            "voice": voice,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+            "gpu_lock_released_at": gpu_lock_released_at,
+            "audio_artifact_id": artifact.id,
+            "audio_path": artifact.path,
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "success",
+        }
+
+    try:
+        return asyncio.run(_run_task())
+    except Exception:
+        logger.exception(
+            "Failed to generate paragraph audio for run %d section %s",
+            run_id,
+            section_id,
+        )
+        raise

--- a/apps/worker-orchestrator/tasks/generate_paragraph_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_paragraph_subtitles.py
@@ -1,0 +1,160 @@
+"""Celery task for per-paragraph subtitle generation.
+
+Transcribes a single paragraph's audio file to produce a per-section SRT.
+Unlike the run-level ``generate_subtitles`` task this does NOT transition
+stages — the caller (storyboard API) manages aggregate state.
+
+Subtitles are saved to: data/artifacts/{run_id}/subtitles/{section_id}.srt
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    import redis
+except ImportError:
+    redis = None  # type: ignore[assignment]
+
+from celery_app import celery_app
+from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
+from creator_provider.registry import ProviderRegistry
+from creator_service.subtitle_service import subtitle_service as _subtitle_service
+
+logger = logging.getLogger(__name__)
+
+_ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _get_redis_client() -> Any | None:
+    if redis is None:
+        return None
+    return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+@celery_app.task(bind=True, name="generate_paragraph_subtitles")
+def generate_paragraph_subtitles(
+    self,
+    run_id: int,
+    section_id: str,
+    audio_path: str,
+    subtitle_model: str = "whisper-small",
+    subtitle_format: str = "srt",
+) -> dict[str, object]:
+    """Generate subtitles for a single paragraph's audio.
+
+    Parameters
+    ----------
+    run_id : int
+        Parent run ID.
+    section_id : str
+        Script section identifier.
+    audio_path : str
+        Path to the per-paragraph audio WAV file.
+    subtitle_model : str
+        Model key from the provider registry.
+    subtitle_format : str
+        Output format (``srt`` or ``vtt``).
+    """
+    start_time = datetime.now(timezone.utc)
+    start_iso = start_time.isoformat()
+    task_id = str(getattr(getattr(self, "request", None), "id", None) or f"sub-{run_id}-{section_id}")
+
+    provider_type: str | None = None
+    endpoint: str | None = None
+    gpu_lock_acquired_at: str | None = None
+    gpu_lock_released_at: str | None = None
+    redis_client: Any | None = None
+    lock_acquired = False
+
+    async def _run_task() -> dict[str, object]:
+        nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
+        nonlocal redis_client, lock_acquired
+
+        if not os.path.exists(audio_path):
+            raise RuntimeError(f"Audio file not found: {audio_path}")
+
+        # 1. Provider resolution
+        registry = ProviderRegistry.create_default()
+        entry = registry.resolve(subtitle_model)
+        provider = registry.get_provider(subtitle_model)
+
+        provider_type = entry.provider_type
+        endpoint = entry.endpoint
+
+        # 2. GPU lock
+        if entry.requires_gpu:
+            redis_client = _get_redis_client()
+            if redis_client is None:
+                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+            acquire_gpu_lock(redis_client, task_id)
+            lock_acquired = True
+            gpu_lock_acquired_at = _utc_now_iso()
+
+        subtitle_path = f"{_ARTIFACT_ROOT}/{run_id}/subtitles/{section_id}.{subtitle_format}"
+
+        try:
+            os.makedirs(os.path.dirname(subtitle_path), exist_ok=True)
+
+            # 3. Transcribe via provider
+            params = dict(entry.default_params or {})
+            params["format"] = subtitle_format
+            params["output_path"] = subtitle_path
+            await provider.transcribe(audio_path, params=params)
+
+            # 4. Save per-paragraph subtitle artifact
+            artifact = await _subtitle_service.create_paragraph_artifact(
+                run_id=run_id,
+                section_id=section_id,
+                path=subtitle_path,
+                fmt=subtitle_format,
+                model_used=subtitle_model,
+                provider_type=entry.provider_type,
+            )
+        finally:
+            if lock_acquired:
+                try:
+                    release_gpu_lock(redis_client, task_id)
+                    gpu_lock_released_at = _utc_now_iso()
+                except Exception:
+                    logger.exception("Failed to release GPU lock for task %s", task_id)
+
+        end_time = datetime.now(timezone.utc)
+        duration_seconds = (end_time - start_time).total_seconds()
+
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "section_id": section_id,
+            "subtitle_model": subtitle_model,
+            "subtitle_format": subtitle_format,
+            "provider_type": provider_type,
+            "endpoint": endpoint,
+            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+            "gpu_lock_released_at": gpu_lock_released_at,
+            "subtitle_artifact_id": artifact.id,
+            "subtitle_path": artifact.path,
+            "audio_path": audio_path,
+            "start_time": start_iso,
+            "end_time": end_time.isoformat(),
+            "duration_seconds": duration_seconds,
+            "status": "success",
+        }
+
+    try:
+        return asyncio.run(_run_task())
+    except Exception:
+        logger.exception(
+            "Failed to generate paragraph subtitles for run %d section %s",
+            run_id,
+            section_id,
+        )
+        raise

--- a/apps/worker-orchestrator/tasks/render_video.py
+++ b/apps/worker-orchestrator/tasks/render_video.py
@@ -2,6 +2,9 @@
 
 Consumes active visual assets and optional audio/subtitle artifacts,
 renders a single MP4 output for the run, and stores it as a video artifact.
+
+Phase 9: Supports per-paragraph audio/subtitle concatenation when available.
+Falls back to run-level audio/subtitles if per-paragraph artifacts don't exist.
 """
 
 from __future__ import annotations
@@ -11,7 +14,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 from celery_app import celery_app
 from creator_domain.models.stage import RunStage
@@ -22,6 +25,7 @@ from creator_service.render_service import render_service as _render_service
 from creator_service.run_service import run_service as _run_service
 from creator_service.subtitle_service import subtitle_service as _subtitle_service
 from creator_service.visual_asset_service import visual_asset_service as _visual_asset_service
+from creator_service.script_service import script_service as _script_service
 
 logger = logging.getLogger(__name__)
 
@@ -89,10 +93,105 @@ def render_video(
         profile_data = manifest["render_profile"]
         scene_count = len(manifest["scenes"])
         image_paths = [Path(scene["asset_path"]) for scene in manifest["scenes"]]
-        audio_path = Path(manifest["audio_path"]) if manifest["audio_path"] else None
-        subtitle_path = Path(manifest["subtitle_path"]) if manifest["subtitle_path"] else None
-        scene_duration = profile_data["max_duration_seconds"] / scene_count
-        scene_durations = [scene_duration] * scene_count
+
+        resolved_profile = _resolve_profile(render_profile)
+        ffmpeg = FFmpegService(profile=resolved_profile)
+
+        # --- Per-paragraph audio/subtitle assembly (Phase 9) -----------------
+        # Try per-paragraph artifacts first; fall back to run-level.
+        paragraph_audio = await _audio_service.list_paragraph_audio(run_id)
+        paragraph_subtitles = await _subtitle_service.list_paragraph_subtitles(run_id)
+
+        audio_path: Path | None = None
+        subtitle_path: Path | None = None
+        scene_durations: list[float]
+
+        if paragraph_audio:
+            # Build section_id -> audio mapping
+            audio_by_section: dict[str, Any] = {}
+            for a in paragraph_audio:
+                if a.section_id and a.section_id not in audio_by_section:
+                    audio_by_section[a.section_id] = a
+
+            # Get section order from script
+            draft = await _script_service.get_active_draft(run_id)
+            if draft and draft.structured_script:
+                ordered_sections = [s.section_id for s in draft.structured_script]
+            else:
+                ordered_sections = sorted(audio_by_section.keys())
+
+            # Collect audio files and durations in section order
+            ordered_audio_paths: list[str] = []
+            ordered_durations: list[float] = []
+            for sid in ordered_sections:
+                art = audio_by_section.get(sid)
+                if art:
+                    ordered_audio_paths.append(art.path)
+                    try:
+                        dur = ffmpeg.get_audio_duration(art.path)
+                    except Exception:
+                        logger.warning(
+                            "Failed to probe duration for %s, using 5.0s fallback",
+                            art.path,
+                        )
+                        dur = 5.0
+                    ordered_durations.append(dur)
+
+            if ordered_audio_paths:
+                # Concatenate per-paragraph audio into a single file
+                concat_path = f"{_ARTIFACT_ROOT}/{run_id}/render/audio_concat.wav"
+                ffmpeg.concatenate_audio(ordered_audio_paths, concat_path)
+                audio_path = Path(concat_path)
+
+                # Use actual per-paragraph durations for scene timing
+                scene_durations = ordered_durations[:scene_count]
+                # If fewer durations than scenes, pad with equal split of remaining time
+                if len(scene_durations) < scene_count:
+                    total_known = sum(scene_durations)
+                    remaining = max(0.0, profile_data["max_duration_seconds"] - total_known)
+                    missing = scene_count - len(scene_durations)
+                    pad_dur = remaining / missing if missing > 0 else 5.0
+                    scene_durations.extend([pad_dur] * missing)
+            else:
+                # No matched audio — fall back to equal split
+                scene_duration = profile_data["max_duration_seconds"] / scene_count
+                scene_durations = [scene_duration] * scene_count
+
+            # Merge per-paragraph subtitles if available
+            if paragraph_subtitles:
+                sub_by_section: dict[str, Any] = {}
+                for s in paragraph_subtitles:
+                    if s.section_id and s.section_id not in sub_by_section:
+                        sub_by_section[s.section_id] = s
+
+                ordered_sub_paths: list[str] = []
+                ordered_sub_durations: list[float] = []
+                for sid in ordered_sections:
+                    sub = sub_by_section.get(sid)
+                    if sub:
+                        ordered_sub_paths.append(sub.path)
+                        # Use same duration as audio
+                        art = audio_by_section.get(sid)
+                        ordered_sub_durations.append(
+                            ordered_durations[ordered_sections.index(sid)]
+                            if sid in audio_by_section and ordered_durations
+                            else 5.0
+                        )
+
+                if ordered_sub_paths:
+                    merged_sub_path = f"{_ARTIFACT_ROOT}/{run_id}/render/subtitles_merged.srt"
+                    ffmpeg.merge_subtitles(
+                        ordered_sub_paths, ordered_sub_durations, merged_sub_path
+                    )
+                    subtitle_path = Path(merged_sub_path)
+        else:
+            # No per-paragraph audio — fall back to run-level artifacts
+            run_audio_path = manifest["audio_path"]
+            audio_path = Path(run_audio_path) if run_audio_path else None
+            run_sub_path = manifest["subtitle_path"]
+            subtitle_path = Path(run_sub_path) if run_sub_path else None
+            scene_duration = profile_data["max_duration_seconds"] / scene_count
+            scene_durations = [scene_duration] * scene_count
 
         render_input = RenderInput(
             image_paths=image_paths,

--- a/packages/creator-domain/creator_domain/models/__init__.py
+++ b/packages/creator-domain/creator_domain/models/__init__.py
@@ -16,6 +16,7 @@ from .subtitle_artifact import SubtitleArtifact
 from .video_artifact import VideoArtifact
 from .visual_asset import VisualAsset
 from .visual_plan import VisualPlan, VisualScene
+from .storyboard import ParagraphStatus, StaleFlags, StoryboardParagraph, StoryboardResponse
 
 __all__ = [
     "Project",
@@ -37,4 +38,8 @@ __all__ = [
     "AudioArtifact",
     "SubtitleArtifact",
     "VideoArtifact",
+    "ParagraphStatus",
+    "StaleFlags",
+    "StoryboardParagraph",
+    "StoryboardResponse",
 ]

--- a/packages/creator-domain/creator_domain/models/audio_artifact.py
+++ b/packages/creator-domain/creator_domain/models/audio_artifact.py
@@ -10,6 +10,7 @@ class AudioArtifact(BaseModel):
     id: int
     run_id: int
     path: str
+    section_id: str | None = None
     model_used: str | None = None
     provider_type: str | None = None
     voice: str | None = None
@@ -38,7 +39,12 @@ class AudioArtifact(BaseModel):
             mapped.setdefault("provider_type", meta.get("provider_type"))
             mapped.setdefault("voice", meta.get("voice"))
         # Discard DB-only columns not in this domain model
-        for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
+        # Map scene_id to section_id for per-paragraph support
+        if "scene_id" in mapped and "section_id" not in mapped:
+            mapped["section_id"] = mapped.pop("scene_id")
+        else:
+            mapped.pop("scene_id", None)
+        for key in ("artifact_type", "file_size_bytes", "mime_type", "updated_at"):
             mapped.pop(key, None)
         return cls.model_validate(mapped)
 

--- a/packages/creator-domain/creator_domain/models/storyboard.py
+++ b/packages/creator-domain/creator_domain/models/storyboard.py
@@ -1,0 +1,68 @@
+"""Storyboard domain models for unified paragraph-based pipeline.
+
+Each storyboard paragraph represents one section of the script, with its
+associated image, audio, and subtitles.  The StoryboardResponse aggregates
+all paragraphs for a run into a single view.
+
+Key invariant: 1 paragraph = 1 image = 1 audio = N subtitles.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class ParagraphStatus(str, Enum):
+    """Per-paragraph generation status."""
+
+    IDLE = "idle"
+    GENERATING_IMAGE = "generating_image"
+    GENERATING_AUDIO = "generating_audio"
+    GENERATING_SUBTITLES = "generating_subtitles"
+    READY = "ready"
+    STALE = "stale"
+    FAILED = "failed"
+
+
+class StaleFlags(BaseModel):
+    """Tracks which downstream artifacts are stale after an upstream edit."""
+
+    prompt_stale: bool = False
+    image_stale: bool = False
+    audio_stale: bool = False
+    subtitles_stale: bool = False
+
+
+class StoryboardParagraph(BaseModel):
+    """One paragraph in the unified storyboard view."""
+
+    section_id: str
+    order: int
+    text: str
+    display_text: str | None = None
+    image_prompt: str | None = None
+    image_url: str | None = None
+    audio_url: str | None = None
+    audio_duration: float | None = None
+    subtitles_url: str | None = None
+    subtitle_entries: list[dict[str, object]] | None = None
+    status: ParagraphStatus = ParagraphStatus.IDLE
+    stale_flags: StaleFlags | None = None
+
+    # Scene/asset metadata for cross-reference
+    scene_id: str | None = None
+    image_asset_id: int | None = None
+    audio_artifact_id: int | None = None
+    subtitle_artifact_id: int | None = None
+
+
+class StoryboardResponse(BaseModel):
+    """Full storyboard data for a run."""
+
+    run_id: int
+    paragraphs: list[StoryboardParagraph]
+    render_ready: bool = False
+    total_paragraphs: int = 0
+    ready_paragraphs: int = 0

--- a/packages/creator-domain/creator_domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/creator_domain/models/subtitle_artifact.py
@@ -11,6 +11,7 @@ class SubtitleArtifact(BaseModel):
     id: int
     run_id: int
     path: str
+    section_id: str | None = None
     format: Literal["srt", "vtt"] = "srt"
     created_at: datetime
 
@@ -35,7 +36,12 @@ class SubtitleArtifact(BaseModel):
             meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
             mapped.setdefault("format", meta.get("format"))
         # Discard DB-only columns not in this domain model
-        for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
+        # Map scene_id to section_id for per-paragraph support
+        if "scene_id" in mapped and "section_id" not in mapped:
+            mapped["section_id"] = mapped.pop("scene_id")
+        else:
+            mapped.pop("scene_id", None)
+        for key in ("artifact_type", "file_size_bytes", "mime_type", "updated_at"):
             mapped.pop(key, None)
         return cls.model_validate(mapped)
 

--- a/packages/creator-service/creator_service/audio_service.py
+++ b/packages/creator-service/creator_service/audio_service.py
@@ -42,6 +42,18 @@ class AudioStorageBackend(Protocol):
     async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
         """Fetch the most recent artifact for a run."""
         ...
+    async def get_by_section(self, run_id: int, section_id: str) -> dict[str, Any] | None:
+        """Fetch the latest artifact for a run+section."""
+        ...
+
+    async def list_by_run_sections(self, run_id: int) -> list[dict[str, Any]]:
+        """List all section-level artifacts for a run."""
+        ...
+
+    async def delete_by_section(self, run_id: int, section_id: str) -> None:
+        """Delete artifacts for a run+section."""
+        ...
+
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +95,27 @@ class InMemoryAudioStorage:
     async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
         artifacts = await self.list_by_run(run_id)
         return artifacts[0] if artifacts else None
+
+    async def get_by_section(self, run_id: int, section_id: str) -> dict[str, Any] | None:
+        run_artifacts = [
+            a for a in self._artifacts
+            if a["run_id"] == run_id and a.get("scene_id") == section_id
+        ]
+        if not run_artifacts:
+            return None
+        return dict(sorted(run_artifacts, key=lambda x: x["created_at"], reverse=True)[0])
+
+    async def list_by_run_sections(self, run_id: int) -> list[dict[str, Any]]:
+        return [
+            dict(a) for a in self._artifacts
+            if a["run_id"] == run_id and a.get("scene_id") is not None
+        ]
+
+    async def delete_by_section(self, run_id: int, section_id: str) -> None:
+        self._artifacts = [
+            a for a in self._artifacts
+            if not (a["run_id"] == run_id and a.get("scene_id") == section_id)
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -148,6 +181,51 @@ class AudioService:
             return None
         return self._row_to_artifact(row)
 
+    # -- Per-paragraph methods ------------------------------------------------
+
+    async def create_paragraph_artifact(
+        self,
+        run_id: int,
+        section_id: str,
+        path: str,
+        *,
+        model_used: str | None = None,
+        provider_type: str | None = None,
+        voice: str | None = None,
+    ) -> AudioArtifact:
+        """Create an audio artifact for a specific paragraph/section."""
+        metadata: dict[str, object] = {}
+        if model_used is not None:
+            metadata["model_used"] = model_used
+        if provider_type is not None:
+            metadata["provider_type"] = provider_type
+        if voice is not None:
+            metadata["voice"] = voice
+
+        row: dict[str, object] = {
+            "run_id": run_id,
+            "scene_id": section_id,
+            "file_path": path,
+            "metadata_json": metadata,
+        }
+        saved = await self.storage.save_artifact(row)
+        return self._row_to_artifact(saved)
+
+    async def get_paragraph_audio(self, run_id: int, section_id: str) -> AudioArtifact | None:
+        """Get the latest audio artifact for a specific paragraph."""
+        row = await self.storage.get_by_section(run_id, section_id)
+        if row is None:
+            return None
+        return self._row_to_artifact(row)
+
+    async def list_paragraph_audio(self, run_id: int) -> list[AudioArtifact]:
+        """List all section-level audio artifacts for a run."""
+        rows = await self.storage.list_by_run_sections(run_id)
+        return [self._row_to_artifact(r) for r in rows]
+
+    async def delete_paragraph_audio(self, run_id: int, section_id: str) -> None:
+        """Delete audio artifacts for a specific paragraph (invalidation)."""
+        await self.storage.delete_by_section(run_id, section_id)
     # -- Internal -----------------------------------------------------------
 
     @staticmethod

--- a/packages/creator-service/creator_service/ffmpeg_service.py
+++ b/packages/creator-service/creator_service/ffmpeg_service.py
@@ -122,3 +122,126 @@ class FFmpegService:
         if result.returncode != 0:
             raise RuntimeError(f"FFmpeg render failed: {result.stderr}")
         return output_path
+
+    # -- Per-paragraph helper methods -----------------------------------------
+
+    def get_audio_duration(self, audio_path: str) -> float:
+        """Probe audio file duration in seconds using ffprobe."""
+        cmd = [
+            "ffprobe",
+            "-v", "error",
+            "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1",
+            audio_path,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            raise RuntimeError(f"ffprobe failed for {audio_path}: {result.stderr}")
+        return float(result.stdout.strip())
+
+    def concatenate_audio(self, audio_paths: list[str], output_path: str) -> Path:
+        """Concatenate multiple audio files using FFmpeg concat demuxer.
+
+        Creates a temporary concat list file, runs FFmpeg, and returns the
+        output path.  The caller is responsible for ensuring input files exist.
+        """
+        import tempfile
+
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+
+        # Build concat list file
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False
+        ) as f:
+            for p in audio_paths:
+                # FFmpeg concat requires single-quoted paths with inner quotes escaped
+                escaped = p.replace("'", "'\\''")
+                f.write(f"file '{escaped}'\n")
+            concat_list = f.name
+
+        try:
+            cmd = [
+                "ffmpeg", "-y",
+                "-f", "concat",
+                "-safe", "0",
+                "-i", concat_list,
+                "-c", "copy",
+                str(out),
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+            if result.returncode != 0:
+                raise RuntimeError(f"FFmpeg concat failed: {result.stderr}")
+        finally:
+            Path(concat_list).unlink(missing_ok=True)
+
+        return out
+
+    def merge_subtitles(
+        self,
+        subtitle_paths: list[str],
+        durations: list[float],
+        output_path: str,
+    ) -> Path:
+        """Merge multiple SRT files into one, adjusting timestamps.
+
+        Each subtitle file's timestamps are offset by the cumulative duration
+        of all preceding paragraphs.  This produces a single SRT file suitable
+        for rendering onto the concatenated audio track.
+        """
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+
+        merged_entries: list[str] = []
+        entry_index = 1
+        cumulative_offset = 0.0
+
+        for srt_path, dur in zip(subtitle_paths, durations):
+            path = Path(srt_path)
+            if not path.exists():
+                cumulative_offset += dur
+                continue
+
+            content = path.read_text(encoding="utf-8")
+            blocks = content.strip().split("\n\n")
+
+            for block in blocks:
+                lines = block.strip().split("\n")
+                if len(lines) < 3:
+                    continue  # skip malformed blocks
+
+                # Parse timestamp line: "00:00:01,000 --> 00:00:03,500"
+                ts_line = lines[1]
+                parts = ts_line.split(" --> ")
+                if len(parts) != 2:
+                    continue
+
+                start = _parse_srt_ts(parts[0].strip()) + cumulative_offset
+                end = _parse_srt_ts(parts[1].strip()) + cumulative_offset
+                text = "\n".join(lines[2:])
+
+                merged_entries.append(
+                    f"{entry_index}\n{_format_srt_ts(start)} --> {_format_srt_ts(end)}\n{text}"
+                )
+                entry_index += 1
+
+            cumulative_offset += dur
+
+        out.write_text("\n\n".join(merged_entries) + "\n", encoding="utf-8")
+        return out
+
+
+def _parse_srt_ts(ts: str) -> float:
+    """Parse SRT timestamp 'HH:MM:SS,mmm' to seconds."""
+    ts = ts.replace(",", ".")
+    parts = ts.split(":")
+    return float(parts[0]) * 3600 + float(parts[1]) * 60 + float(parts[2])
+
+
+def _format_srt_ts(seconds: float) -> str:
+    """Format seconds as SRT timestamp 'HH:MM:SS,mmm'."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = seconds % 60
+    ms = int((s - int(s)) * 1000)
+    return f"{h:02d}:{m:02d}:{int(s):02d},{ms:03d}"

--- a/packages/creator-service/creator_service/postgres_audio_storage.py
+++ b/packages/creator-service/creator_service/postgres_audio_storage.py
@@ -67,3 +67,38 @@ class PostgresAudioStorage:
             """,
             run_id,
         )
+
+    async def get_by_section(self, run_id: int, section_id: str) -> dict[str, Any] | None:
+        return await fetch_one(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND scene_id = $2 AND artifact_type = 'audio'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            run_id,
+            section_id,
+        )
+
+    async def list_by_run_sections(self, run_id: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND scene_id IS NOT NULL AND artifact_type = 'audio'
+            ORDER BY scene_id, created_at DESC
+            """,
+            run_id,
+        )
+
+    async def delete_by_section(self, run_id: int, section_id: str) -> None:
+        await fetch_one(
+            """
+            DELETE FROM creator_artifacts
+            WHERE run_id = $1 AND scene_id = $2 AND artifact_type = 'audio'
+            RETURNING id
+            """,
+            run_id,
+            section_id,
+        )

--- a/packages/creator-service/creator_service/postgres_subtitle_storage.py
+++ b/packages/creator-service/creator_service/postgres_subtitle_storage.py
@@ -67,3 +67,38 @@ class PostgresSubtitleStorage:
             """,
             run_id,
         )
+
+    async def get_by_section(self, run_id: int, section_id: str) -> dict[str, Any] | None:
+        return await fetch_one(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND scene_id = $2 AND artifact_type = 'subtitle'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            run_id,
+            section_id,
+        )
+
+    async def list_by_run_sections(self, run_id: int) -> list[dict[str, Any]]:
+        return await fetch_all(
+            """
+            SELECT *
+            FROM creator_artifacts
+            WHERE run_id = $1 AND scene_id IS NOT NULL AND artifact_type = 'subtitle'
+            ORDER BY scene_id, created_at DESC
+            """,
+            run_id,
+        )
+
+    async def delete_by_section(self, run_id: int, section_id: str) -> None:
+        await fetch_one(
+            """
+            DELETE FROM creator_artifacts
+            WHERE run_id = $1 AND scene_id = $2 AND artifact_type = 'subtitle'
+            RETURNING id
+            """,
+            run_id,
+            section_id,
+        )

--- a/packages/creator-service/creator_service/subtitle_service.py
+++ b/packages/creator-service/creator_service/subtitle_service.py
@@ -42,6 +42,18 @@ class SubtitleStorageBackend(Protocol):
     async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
         """Fetch the most recent artifact for a run."""
         ...
+    async def get_by_section(self, run_id: int, section_id: str) -> dict[str, Any] | None:
+        """Fetch the latest artifact for a run+section."""
+        ...
+
+    async def list_by_run_sections(self, run_id: int) -> list[dict[str, Any]]:
+        """List all section-level artifacts for a run."""
+        ...
+
+    async def delete_by_section(self, run_id: int, section_id: str) -> None:
+        """Delete artifacts for a run+section."""
+        ...
+
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +95,27 @@ class InMemorySubtitleStorage:
     async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
         artifacts = await self.list_by_run(run_id)
         return artifacts[0] if artifacts else None
+
+    async def get_by_section(self, run_id: int, section_id: str) -> dict[str, Any] | None:
+        run_artifacts = [
+            a for a in self._artifacts
+            if a["run_id"] == run_id and a.get("scene_id") == section_id
+        ]
+        if not run_artifacts:
+            return None
+        return dict(sorted(run_artifacts, key=lambda x: x["created_at"], reverse=True)[0])
+
+    async def list_by_run_sections(self, run_id: int) -> list[dict[str, Any]]:
+        return [
+            dict(a) for a in self._artifacts
+            if a["run_id"] == run_id and a.get("scene_id") is not None
+        ]
+
+    async def delete_by_section(self, run_id: int, section_id: str) -> None:
+        self._artifacts = [
+            a for a in self._artifacts
+            if not (a["run_id"] == run_id and a.get("scene_id") == section_id)
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -148,6 +181,51 @@ class SubtitleService:
             return None
         return self._row_to_artifact(row)
 
+    # -- Per-paragraph methods ------------------------------------------------
+
+    async def create_paragraph_artifact(
+        self,
+        run_id: int,
+        section_id: str,
+        path: str,
+        *,
+        fmt: str = "srt",
+        model_used: str | None = None,
+        provider_type: str | None = None,
+    ) -> SubtitleArtifact:
+        """Create a subtitle artifact for a specific paragraph/section."""
+        metadata: dict[str, object] = {}
+        if fmt is not None:
+            metadata["format"] = fmt
+        if model_used is not None:
+            metadata["model_used"] = model_used
+        if provider_type is not None:
+            metadata["provider_type"] = provider_type
+
+        row: dict[str, object] = {
+            "run_id": run_id,
+            "scene_id": section_id,
+            "file_path": path,
+            "metadata_json": metadata,
+        }
+        saved = await self.storage.save_artifact(row)
+        return self._row_to_artifact(saved)
+
+    async def get_paragraph_subtitles(self, run_id: int, section_id: str) -> SubtitleArtifact | None:
+        """Get the latest subtitle artifact for a specific paragraph."""
+        row = await self.storage.get_by_section(run_id, section_id)
+        if row is None:
+            return None
+        return self._row_to_artifact(row)
+
+    async def list_paragraph_subtitles(self, run_id: int) -> list[SubtitleArtifact]:
+        """List all section-level subtitle artifacts for a run."""
+        rows = await self.storage.list_by_run_sections(run_id)
+        return [self._row_to_artifact(r) for r in rows]
+
+    async def delete_paragraph_subtitles(self, run_id: int, section_id: str) -> None:
+        """Delete subtitle artifacts for a specific paragraph (invalidation)."""
+        await self.storage.delete_by_section(run_id, section_id)
     # -- Internal -----------------------------------------------------------
 
     @staticmethod


### PR DESCRIPTION
## Summary

Implements Phase 9 (A+B+C) — a complete redesign of the audio/subtitle/render pipeline to work on a per-paragraph basis, with a unified storyboard UI that shows all paragraphs in a single view.

### Architecture: 1 paragraph = 1 image = 1 audio = N subtitles

**Backend (Phase 9A)**
- Added `section_id` field to `AudioArtifact` and `SubtitleArtifact` domain models, mapping to existing `scene_id` DB column
- New domain models: `StoryboardParagraph`, `ParagraphStatus`, `StaleFlags`, `StoryboardResponse`
- Per-section CRUD operations in audio/subtitle storage and service layers
- FFmpeg helpers: `get_audio_duration()`, `concatenate_audio()`, `merge_subtitles()`
- Worker tasks: `generate_paragraph_audio`, `generate_paragraph_subtitles`
- 5 new storyboard API endpoints:
  - `GET /runs/{id}/storyboard` — assembles full storyboard
  - `POST /runs/{id}/storyboard/paragraphs/{section_id}/generate-audio` — per-paragraph TTS
  - `POST /runs/{id}/storyboard/paragraphs/{section_id}/generate-subtitles` — per-paragraph STT
  - `POST /runs/{id}/storyboard/generate-all-audio` — bulk TTS
  - `POST /runs/{id}/storyboard/generate-all-subtitles` — bulk STT
- Render pipeline rewritten for per-paragraph audio concatenation (uses ffprobe for real durations)
- DB migration: index on `(artifact_type, scene_id)` for efficient per-paragraph queries

**Frontend (Phase 9B + 9C)**
- New `storyboard.ts` API client with TypeScript types and 5 fetch functions
- `StoryboardCard` component — per-paragraph card with script text, image, audio player, subtitles, and per-item regeneration controls
- `StoryboardView` component — scrollable grid of all paragraph cards with bulk action buttons and render-ready indicator
- `ProjectPage` — replaced separate audio/subtitle/render stage indicators with unified `StoryboardView`
- `ReviewPage` — replaced separate audio/subtitle review sections with read-only `StoryboardView`
- Updated tests for both pages

### Test Results
- 265 tests passing (1 pre-existing failure in ModelSelector unrelated to this PR)
- 0 LSP diagnostics errors on all changed files

### Files Changed (21 files, +2334/-200 lines)

Closes #217, #218, #219, #220, #221, #222, #223, #224, #225, #226, #227, #228, #229, #230, #231, #232, #233, #234, #235, #236