### PR TITLE
feat: Run lifecycle management — Stop/Resume/Delete (Phase 10)

### DIFF
--- a/apps/api/migrations/versions/009_add_active_task_id.py
+++ b/apps/api/migrations/versions/009_add_active_task_id.py
@@ -1,0 +1,23 @@
+"""Add active_task_id column to creator_runs.
+
+Revision ID: 009
+Revises: 008
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "009"
+down_revision: Union[str, None] = "008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.add_column(
+        "creator_runs",
+        sa.Column("active_task_id", sa.String(length=255), nullable=True),
+    )
+
+def downgrade() -> None:
+    op.drop_column("creator_runs", "active_task_id")

--- a/apps/api/migrations/versions/010_widen_active_task_id.py
+++ b/apps/api/migrations/versions/010_widen_active_task_id.py
@@ -1,0 +1,33 @@
+"""Widen active_task_id from VARCHAR(255) to TEXT.
+
+The column now stores a JSON array of Celery task IDs so it can exceed 255
+characters when many concurrent scene-image tasks are tracked.
+
+Revision ID: 010
+Revises: 009
+Create Date: 2025-01-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "010"
+down_revision: Union[str, None] = "009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.alter_column(
+        "creator_runs",
+        "active_task_id",
+        type_=sa.Text(),
+        existing_type=sa.String(length=255),
+    )
+
+def downgrade() -> None:
+    op.alter_column(
+        "creator_runs",
+        "active_task_id",
+        type_=sa.String(length=255),
+        existing_type=sa.Text(),
+    )

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -62,14 +62,22 @@ async def delete_project(project_id: int) -> dict[str, object]:
     runs = await run_service.list_runs_by_project(project_id)
     for r in runs:
         if r.active_task_id:
-            try:
-                from celery_app import celery_app
-                celery_app.control.revoke(r.active_task_id, terminate=True)
-            except Exception:
-                pass  # Best-effort
+            from shorts_api.routes.creator_runs import _revoke_active_tasks
+            _revoke_active_tasks(r.active_task_id)
+
+    # Collect run IDs for artifact cleanup before DB cascade deletes them
+    run_ids = [r.id for r in runs]
 
     deleted = await project_service.delete_project(project_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Project not found")
+
+    # Best-effort artifact cleanup for all runs
+    import os, shutil
+    artifact_root = os.getenv("ARTIFACT_ROOT", "data/artifacts")
+    for rid in run_ids:
+        run_dir = os.path.join(artifact_root, str(rid))
+        if os.path.isdir(run_dir):
+            shutil.rmtree(run_dir, ignore_errors=True)
 
     return {"deleted": True, "project_id": project_id}

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -4,6 +4,7 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 from creator_service.project_service import project_service
+from creator_service.run_service import run_service
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -52,3 +53,23 @@ async def list_projects(
         "projects": [project.model_dump(mode="json") for project in projects],
         "total": total,
     }
+
+
+@router.delete("/{project_id}")
+async def delete_project(project_id: int) -> dict[str, object]:
+    """Delete a project and all associated runs (FK cascade)."""
+    # First stop any active tasks on runs belonging to this project
+    runs = await run_service.list_runs_by_project(project_id)
+    for r in runs:
+        if r.active_task_id:
+            try:
+                from celery_app import celery_app
+                celery_app.control.revoke(r.active_task_id, terminate=True)
+            except Exception:
+                pass  # Best-effort
+
+    deleted = await project_service.delete_project(project_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    return {"deleted": True, "project_id": project_id}

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -294,7 +294,7 @@ async def generate_script_trigger(run_id: int, request: GenerateScriptRequest) -
 
 
     # Persist task_id for stop/revoke support
-    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
+    await _append_task_id(run_id, task_id)
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -355,7 +355,7 @@ async def generate_visual_plan_trigger(run_id: int, request: GenerateVisualPlanR
 
 
     # Persist task_id for stop/revoke support
-    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
+    await _append_task_id(run_id, task_id)
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -483,7 +483,7 @@ async def generate_visual_assets_trigger(
 
 
     # Persist task_id for stop/revoke support
-    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
+    await _append_task_id(run_id, task_id)
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -542,7 +542,7 @@ async def generate_scene_image_endpoint(
 
 
     # Persist task_id for stop/revoke support
-    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
+    await _append_task_id(run_id, task_id)
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -594,7 +594,7 @@ async def regenerate_scene_image_endpoint(
 
 
     # Persist task_id for stop/revoke support
-    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
+    await _append_task_id(run_id, task_id)
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -719,7 +719,7 @@ async def generate_audio_trigger(run_id: int, request: GenerateAudioRequest) -> 
 
 
     # Persist task_id for stop/revoke support
-    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
+    await _append_task_id(run_id, task_id)
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -781,7 +781,7 @@ async def generate_subtitles_trigger(run_id: int, request: GenerateSubtitlesRequ
 
 
     # Persist task_id for stop/revoke support
-    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
+    await _append_task_id(run_id, task_id)
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -842,7 +842,7 @@ async def render_trigger(run_id: int, request: RenderRequest) -> dict[str, objec
 
 
     # Persist task_id for stop/revoke support
-    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
+    await _append_task_id(run_id, task_id)
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -1228,16 +1228,46 @@ async def generate_all_paragraph_subtitles(
 # ---------------------------------------------------------------------------
 
 
-def _revoke_active_task(active_task_id: str | None) -> None:
-    """Revoke a Celery task if active_task_id is set."""
+import json as _json
+import os as _os
+import shutil as _shutil
+
+
+def _revoke_active_tasks(active_task_id: str | None) -> None:
+    """Revoke all Celery tasks stored in active_task_id (JSON list or legacy single ID)."""
     if not active_task_id:
         return
     try:
         from celery_app import celery_app
-        celery_app.control.revoke(active_task_id, terminate=True)
+        # Parse as JSON list; fall back to single ID for backwards compat
+        try:
+            task_ids = _json.loads(active_task_id)
+            if isinstance(task_ids, str):
+                task_ids = [task_ids]
+        except (ValueError, TypeError):
+            task_ids = [active_task_id]
+        for tid in task_ids:
+            if tid:
+                celery_app.control.revoke(tid, terminate=True)
     except Exception:
-        pass  # Best-effort: task may have already completed
+        pass  # Best-effort: tasks may have already completed
 
+
+async def _append_task_id(run_id: int, task_id: str) -> None:
+    """Append a task_id to the run's active_task_id JSON list."""
+    run = await run_service.get_run(run_id)
+    existing: list[str] = []
+    if run and run.active_task_id:
+        try:
+            parsed = _json.loads(run.active_task_id)
+            if isinstance(parsed, list):
+                existing = parsed
+            elif isinstance(parsed, str):
+                existing = [parsed]
+        except (ValueError, TypeError):
+            existing = [run.active_task_id]
+    existing.append(task_id)
+    await run_service.storage.update_run(run_id, {"active_task_id": _json.dumps(existing)})
 
 @router.post("/runs/{run_id}/stop")
 async def stop_run(run_id: int) -> dict[str, object]:
@@ -1247,7 +1277,7 @@ async def stop_run(run_id: int) -> dict[str, object]:
         raise HTTPException(status_code=404, detail="Run not found")
 
     # Revoke Celery task before updating DB
-    _revoke_active_task(run.active_task_id)
+    _revoke_active_tasks(run.active_task_id)
 
     try:
         updated = await run_service.stop_run(run_id)
@@ -1282,10 +1312,16 @@ async def delete_run(run_id: int) -> dict[str, object]:
         raise HTTPException(status_code=404, detail="Run not found")
 
     # Revoke any active task
-    _revoke_active_task(run.active_task_id)
+    _revoke_active_tasks(run.active_task_id)
 
     deleted = await run_service.delete_run(run_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Run not found")
+
+    # Best-effort artifact cleanup
+    _artifact_root = _os.getenv("ARTIFACT_ROOT", "data/artifacts")
+    run_dir = _os.path.join(_artifact_root, str(run_id))
+    if _os.path.isdir(run_dir):
+        _shutil.rmtree(run_dir, ignore_errors=True)
 
     return {"deleted": True, "run_id": run_id}

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -292,6 +292,9 @@ async def generate_script_trigger(run_id: int, request: GenerateScriptRequest) -
             detail="Failed to enqueue script generation task",
         ) from None
 
+
+    # Persist task_id for stop/revoke support
+    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -350,6 +353,9 @@ async def generate_visual_plan_trigger(run_id: int, request: GenerateVisualPlanR
             detail="Failed to enqueue visual plan generation task",
         ) from None
 
+
+    # Persist task_id for stop/revoke support
+    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -475,6 +481,9 @@ async def generate_visual_assets_trigger(
             detail="Failed to enqueue image generation task",
         ) from None
 
+
+    # Persist task_id for stop/revoke support
+    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -531,6 +540,9 @@ async def generate_scene_image_endpoint(
             detail="Failed to enqueue image generation task",
         ) from None
 
+
+    # Persist task_id for stop/revoke support
+    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -580,6 +592,9 @@ async def regenerate_scene_image_endpoint(
             detail="Failed to enqueue image generation task",
         ) from None
 
+
+    # Persist task_id for stop/revoke support
+    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -702,6 +717,9 @@ async def generate_audio_trigger(run_id: int, request: GenerateAudioRequest) -> 
             detail="Failed to enqueue audio generation task",
         ) from None
 
+
+    # Persist task_id for stop/revoke support
+    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -761,6 +779,9 @@ async def generate_subtitles_trigger(run_id: int, request: GenerateSubtitlesRequ
             detail="Failed to enqueue subtitle generation task",
         ) from None
 
+
+    # Persist task_id for stop/revoke support
+    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -819,6 +840,9 @@ async def render_trigger(run_id: int, request: RenderRequest) -> dict[str, objec
             detail="Failed to enqueue render task",
         ) from None
 
+
+    # Persist task_id for stop/revoke support
+    await run_service.storage.update_run(run_id, {"active_task_id": task_id})
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -1197,3 +1221,71 @@ async def generate_all_paragraph_subtitles(
         "tasks": task_ids,
         "total": len(task_ids),
     }
+
+
+# ---------------------------------------------------------------------------
+# Run lifecycle management (Phase 10 — Stop / Resume / Delete)
+# ---------------------------------------------------------------------------
+
+
+def _revoke_active_task(active_task_id: str | None) -> None:
+    """Revoke a Celery task if active_task_id is set."""
+    if not active_task_id:
+        return
+    try:
+        from celery_app import celery_app
+        celery_app.control.revoke(active_task_id, terminate=True)
+    except Exception:
+        pass  # Best-effort: task may have already completed
+
+
+@router.post("/runs/{run_id}/stop")
+async def stop_run(run_id: int) -> dict[str, object]:
+    """Stop a running pipeline. Revokes the active Celery task."""
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # Revoke Celery task before updating DB
+    _revoke_active_task(run.active_task_id)
+
+    try:
+        updated = await run_service.stop_run(run_id)
+    except ValueError as exc:
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
+
+    return updated.model_dump(mode="json")
+
+
+@router.post("/runs/{run_id}/resume")
+async def resume_run(run_id: int) -> dict[str, object]:
+    """Resume a stopped/cancelled/failed run."""
+    try:
+        updated = await run_service.resume_run(run_id)
+    except ValueError as exc:
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
+
+    return updated.model_dump(mode="json")
+
+
+@router.delete("/runs/{run_id}")
+async def delete_run(run_id: int) -> dict[str, object]:
+    """Delete a run. Revokes active task first if running."""
+    run = await run_service.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # Revoke any active task
+    _revoke_active_task(run.active_task_id)
+
+    deleted = await run_service.delete_run(run_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    return {"deleted": True, "run_id": run_id}

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -1254,20 +1254,20 @@ def _revoke_active_tasks(active_task_id: str | None) -> None:
 
 
 async def _append_task_id(run_id: int, task_id: str) -> None:
-    """Append a task_id to the run's active_task_id JSON list."""
-    run = await run_service.get_run(run_id)
-    existing: list[str] = []
-    if run and run.active_task_id:
-        try:
-            parsed = _json.loads(run.active_task_id)
-            if isinstance(parsed, list):
-                existing = parsed
-            elif isinstance(parsed, str):
-                existing = [parsed]
-        except (ValueError, TypeError):
-            existing = [run.active_task_id]
-    existing.append(task_id)
-    await run_service.storage.update_run(run_id, {"active_task_id": _json.dumps(existing)})
+    """Atomically append a task_id to the run's active_task_id JSON list.
+
+    Uses a single UPDATE with jsonb to avoid read-modify-write races when
+    multiple scene-image tasks are dispatched concurrently.
+    """
+    from creator_service.db import execute
+
+    await execute(
+        "UPDATE creator_runs "
+        "SET active_task_id = (COALESCE(active_task_id::jsonb, '[]'::jsonb) || to_jsonb($2::text))::text "
+        "WHERE id = $1",
+        run_id,
+        task_id,
+    )
 
 @router.post("/runs/{run_id}/stop")
 async def stop_run(run_id: int) -> dict[str, object]:

--- a/apps/studio-web/src/components/creator/ConfirmDialog.tsx
+++ b/apps/studio-web/src/components/creator/ConfirmDialog.tsx
@@ -1,0 +1,110 @@
+/**
+ * ConfirmDialog — reusable confirmation modal for destructive / important actions.
+ */
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "danger" | "warning" | "info";
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const VARIANT_COLORS: Record<string, { bg: string; hover: string }> = {
+  danger: { bg: "#dc2626", hover: "#b91c1c" },
+  warning: { bg: "#d97706", hover: "#b45309" },
+  info: { bg: "#4285f4", hover: "#2563eb" },
+};
+
+export default function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "danger",
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  if (!open) return null;
+
+  const colors = VARIANT_COLORS[variant] ?? VARIANT_COLORS.danger;
+
+  return (
+    <div
+      data-testid="confirm-dialog-backdrop"
+      onClick={onCancel}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1000,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.4)",
+      }}
+    >
+      <div
+        data-testid="confirm-dialog"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          maxWidth: 420,
+          width: "90%",
+          background: "#fff",
+          borderRadius: 8,
+          boxShadow: "0 8px 30px rgba(0,0,0,0.18)",
+          padding: 24,
+        }}
+      >
+        <h3 style={{ margin: "0 0 12px", fontSize: 16, fontWeight: 700, color: "#111827" }}>
+          {title}
+        </h3>
+        <p style={{ margin: "0 0 24px", fontSize: 14, color: "#374151", lineHeight: 1.5 }}>
+          {message}
+        </p>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            style={{
+              padding: "8px 16px",
+              border: "1px solid #d1d5db",
+              borderRadius: 6,
+              background: "#fff",
+              color: "#374151",
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: loading ? "not-allowed" : "pointer",
+            }}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            data-testid="confirm-dialog-confirm"
+            onClick={onConfirm}
+            disabled={loading}
+            style={{
+              padding: "8px 16px",
+              border: "none",
+              borderRadius: 6,
+              background: loading ? "#9ca3af" : colors.bg,
+              color: "#fff",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: loading ? "not-allowed" : "pointer",
+            }}
+          >
+            {loading ? "…" : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 
 import PipelineStepper from "../components/creator/PipelineStepper";
 import StageActionBar, {
@@ -25,6 +25,7 @@ import VisualAssetGrid from "../components/creator/VisualAssetGrid";
 import ProgressDialog from "../components/creator/ProgressDialog";
 import ModelSelector from "../components/creator/ModelSelector";
 import StoryboardView from "../components/creator/StoryboardView";
+import ConfirmDialog from "../components/creator/ConfirmDialog";
 
 const API_BASE = "/api/creator";
 
@@ -92,6 +93,7 @@ const SD_SAMPLERS = [
 export default function ProjectPage() {
   const { projectId } = useParams<{ projectId: string }>();
   const numericProjectId = Number(projectId);
+  const navigate = useNavigate();
 
   // Data state
   const [project, setProject] = useState<ProjectDetail | null>(null);
@@ -106,6 +108,12 @@ export default function ProjectPage() {
   const [approving, setApproving] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [restarting, setRestarting] = useState(false);
+
+  // Stop / Resume / Delete states
+  const [stopping, setStopping] = useState(false);
+  const [resuming, setResuming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<"stop" | "resume" | "delete" | null>(null);
 
   // Status toast
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -578,6 +586,63 @@ export default function ProjectPage() {
     [run, refreshRun],
   );
 
+  // ---- stop / resume / delete actions ----
+
+  const handleStop = useCallback(async () => {
+    if (!run) return;
+    setStopping(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/stop`, { method: "POST" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Stop failed (${res.status})`);
+      }
+      setStatusMessage("Run stopped");
+      await refreshRun(run.id);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Stop failed");
+    } finally {
+      setStopping(false);
+    }
+  }, [run, refreshRun]);
+
+  const handleResume = useCallback(async () => {
+    if (!run) return;
+    setResuming(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/resume`, { method: "POST" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Resume failed (${res.status})`);
+      }
+      setStatusMessage("Run resumed");
+      await refreshRun(run.id);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Resume failed");
+    } finally {
+      setResuming(false);
+    }
+  }, [run, refreshRun]);
+
+  const handleDeleteProject = useCallback(async () => {
+    setDeleting(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/projects/${numericProjectId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Delete failed (${res.status})`);
+      }
+      navigate("/runs");
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setDeleting(false);
+    }
+  }, [numericProjectId, navigate]);
+
   // ---- derived state ----
 
   const currentStage = run?.current_stage ?? "IDEA_READY";
@@ -823,6 +888,65 @@ export default function ProjectPage() {
         <span style={{ fontSize: 12, color: "#6b7280" }}>
           Source: {project.source_type} · Status: {project.status}
         </span>
+
+        {/* Stop / Resume / Delete actions */}
+        <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+          {run && run.status === "running" && (
+            <button
+              type="button"
+              onClick={() => setConfirmAction("stop")}
+              disabled={stopping}
+              style={{
+                padding: "6px 14px",
+                border: "1px solid #dc2626",
+                borderRadius: 6,
+                background: "#fff",
+                color: "#dc2626",
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: stopping ? "not-allowed" : "pointer",
+              }}
+            >
+              {stopping ? "Stopping…" : "⏹ Stop"}
+            </button>
+          )}
+          {run && (run.status === "cancelled" || run.status === "failed" || run.status === "paused") && (
+            <button
+              type="button"
+              onClick={() => setConfirmAction("resume")}
+              disabled={resuming}
+              style={{
+                padding: "6px 14px",
+                border: "1px solid #16a34a",
+                borderRadius: 6,
+                background: "#fff",
+                color: "#16a34a",
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: resuming ? "not-allowed" : "pointer",
+              }}
+            >
+              {resuming ? "Resuming…" : "▶ Resume"}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setConfirmAction("delete")}
+            disabled={deleting}
+            style={{
+              padding: "6px 14px",
+              border: "1px solid #dc2626",
+              borderRadius: 6,
+              background: "#fff",
+              color: "#dc2626",
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: deleting ? "not-allowed" : "pointer",
+            }}
+          >
+            {deleting ? "Deleting…" : "🗑 Delete Project"}
+          </button>
+        </div>
       </div>
 
       {/* Pipeline stepper */}
@@ -1382,6 +1506,35 @@ export default function ProjectPage() {
           statusMessage={statusMessage ?? undefined}
         />
       )}
+
+      {/* Confirm dialog for stop / resume / delete */}
+      <ConfirmDialog
+        open={confirmAction !== null}
+        title={
+          confirmAction === "stop"
+            ? "Stop Run?"
+            : confirmAction === "resume"
+              ? "Resume Run?"
+              : "Delete Project?"
+        }
+        message={
+          confirmAction === "stop"
+            ? "This will cancel the current generation task and stop the pipeline run."
+            : confirmAction === "resume"
+              ? "This will resume the stopped/failed run from where it left off."
+              : "This will permanently delete the project and all its runs, assets, and generated content. This action cannot be undone."
+        }
+        variant={confirmAction === "stop" ? "warning" : confirmAction === "resume" ? "info" : "danger"}
+        confirmLabel={confirmAction === "stop" ? "Stop Run" : confirmAction === "resume" ? "Resume" : "Delete Forever"}
+        loading={stopping || resuming || deleting}
+        onConfirm={() => {
+          if (confirmAction === "stop") handleStop();
+          else if (confirmAction === "resume") handleResume();
+          else if (confirmAction === "delete") handleDeleteProject();
+          setConfirmAction(null);
+        }}
+        onCancel={() => setConfirmAction(null)}
+      />
     </div>
   );
 }

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -1527,10 +1527,10 @@ export default function ProjectPage() {
         variant={confirmAction === "stop" ? "warning" : confirmAction === "resume" ? "info" : "danger"}
         confirmLabel={confirmAction === "stop" ? "Stop Run" : confirmAction === "resume" ? "Resume" : "Delete Forever"}
         loading={stopping || resuming || deleting}
-        onConfirm={() => {
-          if (confirmAction === "stop") handleStop();
-          else if (confirmAction === "resume") handleResume();
-          else if (confirmAction === "delete") handleDeleteProject();
+        onConfirm={async () => {
+          if (confirmAction === "stop") await handleStop();
+          else if (confirmAction === "resume") await handleResume();
+          else if (confirmAction === "delete") await handleDeleteProject();
           setConfirmAction(null);
         }}
         onCancel={() => setConfirmAction(null)}

--- a/apps/studio-web/src/pages/RunsPage.tsx
+++ b/apps/studio-web/src/pages/RunsPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
+import ConfirmDialog from "../components/creator/ConfirmDialog";
+
 const API_BASE = "/api/creator";
 
 interface ProjectSummary {
@@ -54,6 +56,10 @@ export default function RunsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Delete state
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+
   const fetchProjects = useCallback(async (pageOffset: number) => {
     setLoading(true);
     setError(null);
@@ -74,6 +80,23 @@ export default function RunsPage() {
       setLoading(false);
     }
   }, []);
+
+
+  const handleDeleteProject = useCallback(async (projectId: number) => {
+    setDeletingId(projectId);
+    try {
+      const res = await fetch(`${API_BASE}/projects/${projectId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Delete failed (${res.status})`);
+      }
+      fetchProjects(offset);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setDeletingId(null);
+    }
+  }, [fetchProjects, offset]);
 
   useEffect(() => {
     fetchProjects(offset);
@@ -218,6 +241,8 @@ export default function RunsPage() {
                 <th style={{ padding: "8px 12px", fontWeight: 600, color: "#374151" }}>
                   Created
                 </th>
+                <th style={{ padding: "8px 12px", fontWeight: 600, color: "#374151", width: 80 }}>
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -269,6 +294,23 @@ export default function RunsPage() {
                     </td>
                     <td style={{ padding: "10px 12px", color: "#6b7280" }}>
                       {formatDate(proj.created_at)}
+                    </td>
+                    <td style={{ padding: "10px 12px" }}>
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(proj.id); }}
+                        style={{
+                          padding: "4px 8px",
+                          border: "none",
+                          background: "transparent",
+                          color: "#dc2626",
+                          fontSize: 12,
+                          cursor: "pointer",
+                          fontWeight: 500,
+                        }}
+                      >
+                        Delete
+                      </button>
                     </td>
                   </tr>
                 );
@@ -329,6 +371,23 @@ export default function RunsPage() {
           )}
         </>
       )}
+
+      {/* Delete confirmation dialog */}
+      <ConfirmDialog
+        open={confirmDeleteId !== null}
+        title="Delete Project?"
+        message="This will permanently delete the project and all its data. This action cannot be undone."
+        variant="danger"
+        confirmLabel="Delete"
+        loading={deletingId === confirmDeleteId}
+        onConfirm={() => {
+          if (confirmDeleteId !== null) {
+            handleDeleteProject(confirmDeleteId);
+          }
+          setConfirmDeleteId(null);
+        }}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
     </div>
   );
 }

--- a/apps/studio-web/src/pages/RunsPage.tsx
+++ b/apps/studio-web/src/pages/RunsPage.tsx
@@ -380,9 +380,9 @@ export default function RunsPage() {
         variant="danger"
         confirmLabel="Delete"
         loading={deletingId === confirmDeleteId}
-        onConfirm={() => {
+        onConfirm={async () => {
           if (confirmDeleteId !== null) {
-            handleDeleteProject(confirmDeleteId);
+            await handleDeleteProject(confirmDeleteId);
           }
           setConfirmDeleteId(null);
         }}

--- a/apps/worker-orchestrator/tasks/generate_audio.py
+++ b/apps/worker-orchestrator/tasks/generate_audio.py
@@ -37,7 +37,7 @@ _ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
 
 # Stages where writing SUBTITLE_GENERATING or FAILED is safe — the run
 # hasn't advanced past audio generation.
-_SAFE_STAGES = frozenset({RunStage.VISUAL_ASSET_REVIEW, RunStage.AUDIO_GENERATING})
+_SAFE_STAGES = frozenset({RunStage.AUDIO_GENERATING})
 
 
 class _StageGuardError(ValueError):

--- a/apps/worker-orchestrator/tasks/generate_scene_image.py
+++ b/apps/worker-orchestrator/tasks/generate_scene_image.py
@@ -40,7 +40,7 @@ _ALLOWED_STAGES = frozenset({RunStage.VISUAL_PLAN_REVIEW, RunStage.VISUAL_ASSET_
 
 # Stages where writing VISUAL_ASSET_REVIEW or FAILED is safe — the run
 # hasn't advanced past image generation.
-_SAFE_STAGES = frozenset({RunStage.VISUAL_PLAN_REVIEW, RunStage.VISUAL_ASSET_GENERATING})
+_SAFE_STAGES = frozenset({RunStage.VISUAL_ASSET_GENERATING})
 
 # Base directory for artifact storage (relative to project root).
 _ARTIFACTS_BASE = os.getenv("ARTIFACT_ROOT", "data/artifacts")

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -27,7 +27,7 @@ _ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 # Stages where writing SCRIPT_REVIEW or FAILED is safe — the run hasn't
 # advanced past generation.  Used as the expected_stages argument to
 # conditional_update_run for atomic compare-and-set.
-_SAFE_STAGES = frozenset({RunStage.IDEA_READY.value, RunStage.SCRIPT_GENERATING.value})
+_SAFE_STAGES = frozenset({RunStage.SCRIPT_GENERATING.value})
 
 
 class _StageGuardError(ValueError):

--- a/apps/worker-orchestrator/tasks/generate_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_subtitles.py
@@ -38,7 +38,7 @@ _ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
 
 # Stages where writing RENDER_GENERATING or FAILED is safe — the run
 # hasn't advanced past subtitle generation.
-_SAFE_STAGES = frozenset({RunStage.AUDIO_GENERATING, RunStage.SUBTITLE_GENERATING})
+_SAFE_STAGES = frozenset({RunStage.SUBTITLE_GENERATING})
 
 
 class _StageGuardError(ValueError):

--- a/apps/worker-orchestrator/tasks/generate_visual_plan.py
+++ b/apps/worker-orchestrator/tasks/generate_visual_plan.py
@@ -34,7 +34,7 @@ _ALLOWED_STAGES = frozenset({RunStage.SCRIPT_REVIEW, RunStage.VISUAL_PLAN_GENERA
 
 # Stages where writing VISUAL_PLAN_REVIEW or FAILED is safe — the run
 # hasn't advanced past visual plan generation.
-_SAFE_STAGES = frozenset({RunStage.SCRIPT_REVIEW.value, RunStage.VISUAL_PLAN_GENERATING.value})
+_SAFE_STAGES = frozenset({RunStage.VISUAL_PLAN_GENERATING.value})
 
 
 class _StageGuardError(ValueError):

--- a/apps/worker-orchestrator/tests/test_generate_audio.py
+++ b/apps/worker-orchestrator/tests/test_generate_audio.py
@@ -200,7 +200,7 @@ def test_generate_audio_success(monkeypatch: pytest.MonkeyPatch) -> None:
         }
     ]
     assert storage.calls == [(101, {"current_stage": "SUBTITLE_GENERATING", "status": "running"})]
-    assert storage.cas_calls[0][2] == frozenset({"VISUAL_ASSET_REVIEW", "AUDIO_GENERATING"})
+    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING"})
 
 
 def test_generate_audio_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -268,7 +268,7 @@ def test_generate_audio_provider_failure_marks_failed(monkeypatch: pytest.Monkey
 
     assert audio_service.calls == []
     assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
-    assert storage.cas_calls[0][2] == frozenset({"VISUAL_ASSET_REVIEW", "AUDIO_GENERATING"})
+    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING"})
 
 
 def test_generate_audio_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/worker-orchestrator/tests/test_generate_subtitles.py
+++ b/apps/worker-orchestrator/tests/test_generate_subtitles.py
@@ -221,7 +221,7 @@ def test_generate_subtitles_success(monkeypatch: pytest.MonkeyPatch) -> None:
         }
     ]
     assert storage.calls == [(101, {"current_stage": "RENDER_GENERATING", "status": "running"})]
-    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING", "SUBTITLE_GENERATING"})
+    assert storage.cas_calls[0][2] == frozenset({"SUBTITLE_GENERATING"})
 
 
 def test_generate_subtitles_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -293,7 +293,7 @@ def test_generate_subtitles_provider_failure_marks_failed(monkeypatch: pytest.Mo
 
     assert subtitle_service.calls == []
     assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
-    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING", "SUBTITLE_GENERATING"})
+    assert storage.cas_calls[0][2] == frozenset({"SUBTITLE_GENERATING"})
 
 
 def test_generate_subtitles_with_audio_path(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/creator-domain/creator_domain/models/__init__.py
+++ b/packages/creator-domain/creator_domain/models/__init__.py
@@ -5,6 +5,7 @@ from .project import Project
 from .script_draft import ScriptDraft, ScriptSection, VisualOverride
 from .stage import (
     GENERATING_STAGES,
+    STAGE_BEFORE_GENERATING,
     REVIEW_STAGES,
     TRANSITIONS,
     RunStage,
@@ -29,6 +30,7 @@ __all__ = [
     "TRANSITIONS",
     "REVIEW_STAGES",
     "GENERATING_STAGES",
+    "STAGE_BEFORE_GENERATING",
     "can_transition",
     "next_stages",
     "advance",

--- a/packages/creator-domain/creator_domain/models/pipeline_run.py
+++ b/packages/creator-domain/creator_domain/models/pipeline_run.py
@@ -21,6 +21,7 @@ class PipelineRun(BaseModel):
     style_preset: str | None = None
     started_at: datetime | None = None
     finished_at: datetime | None = None
+    active_task_id: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/packages/creator-domain/creator_domain/models/stage.py
+++ b/packages/creator-domain/creator_domain/models/stage.py
@@ -61,6 +61,32 @@ GENERATING_STAGES: frozenset[RunStage] = frozenset(
 )
 
 
+# Maps each GENERATING stage to the actionable stage the user returns to on stop.
+
+# Used by stop_run to move current_stage out of GENERATING so worker CAS fails.
+
+# For storyboard stages (audio/subtitle/render), all roll back to
+
+# VISUAL_ASSET_REVIEW — the last user-actionable review stage.
+
+STAGE_BEFORE_GENERATING: dict[RunStage, RunStage] = {
+
+    RunStage.SCRIPT_GENERATING: RunStage.IDEA_READY,
+
+    RunStage.VISUAL_PLAN_GENERATING: RunStage.SCRIPT_REVIEW,
+
+    RunStage.VISUAL_ASSET_GENERATING: RunStage.VISUAL_PLAN_REVIEW,
+
+    RunStage.AUDIO_GENERATING: RunStage.VISUAL_ASSET_REVIEW,
+
+    RunStage.SUBTITLE_GENERATING: RunStage.VISUAL_ASSET_REVIEW,
+
+    RunStage.RENDER_GENERATING: RunStage.VISUAL_ASSET_REVIEW,
+
+}
+
+
+
 def can_transition(current: RunStage, target: RunStage) -> bool:
     return target in TRANSITIONS[current]
 

--- a/packages/creator-service/creator_service/postgres_project_storage.py
+++ b/packages/creator-service/creator_service/postgres_project_storage.py
@@ -70,3 +70,14 @@ class PostgresProjectStorage:
             "current_stage": row["current_stage"],
             "status": row["status"],
         }
+
+    async def delete_project(self, project_id: int) -> bool:
+        """Delete a project by id. Returns True if deleted.
+
+        Runs are cascade-deleted by FK constraint.
+        """
+        result = await fetch_one(
+            "DELETE FROM creator_projects WHERE id = $1 RETURNING id",
+            project_id,
+        )
+        return result is not None

--- a/packages/creator-service/creator_service/postgres_run_storage.py
+++ b/packages/creator-service/creator_service/postgres_run_storage.py
@@ -15,6 +15,7 @@ _UPDATABLE_COLUMNS = {
     "style_preset",
     "started_at",
     "finished_at",
+    "active_task_id",
 }
 
 
@@ -115,3 +116,19 @@ class PostgresRunStorage:
             "SELECT * FROM creator_runs WHERE project_id = $1 ORDER BY id DESC",
             project_id,
         )
+
+    async def delete_run(self, run_id: int) -> bool:
+        """Delete a run by id. Returns True if deleted."""
+        result = await fetch_one(
+            "DELETE FROM creator_runs WHERE id = $1 RETURNING id",
+            run_id,
+        )
+        return result is not None
+
+    async def delete_runs_by_project(self, project_id: int) -> int:
+        """Delete all runs for a project. Returns count of deleted rows."""
+        rows = await fetch_all(
+            "DELETE FROM creator_runs WHERE project_id = $1 RETURNING id",
+            project_id,
+        )
+        return len(rows)

--- a/packages/creator-service/creator_service/project_service.py
+++ b/packages/creator-service/creator_service/project_service.py
@@ -34,6 +34,10 @@ class ProjectStorageBackend(Protocol):
     async def count_projects(self) -> int:
         ...
 
+    async def delete_project(self, project_id: int) -> bool:
+        """Delete a project by id. Returns True if deleted."""
+        ...
+
 
 class InMemoryProjectStorage:
     """Temporary async storage backend used before DB integration."""
@@ -80,6 +84,13 @@ class InMemoryProjectStorage:
     async def count_projects(self) -> int:
         return len(self._projects)
 
+    async def delete_project(self, project_id: int) -> bool:
+        if project_id in self._projects:
+            del self._projects[project_id]
+            # Also remove associated runs
+            self._runs_by_project.pop(project_id, None)
+            return True
+        return False
     async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
         runs = self._runs_by_project.get(project_id, [])
         if not runs:
@@ -183,6 +194,9 @@ class ProjectService:
     async def count_projects(self) -> int:
         return await self.db.count_projects()
 
+    async def delete_project(self, project_id: int) -> bool:
+        """Delete a project. FK cascade handles associated runs."""
+        return await self.db.delete_project(project_id)
 
 def _create_storage() -> ProjectStorageBackend:
     import os

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
-from creator_domain.models import ModelSelection, PipelineRun, RunStage, REVIEW_STAGES, GENERATING_STAGES, can_transition
+from creator_domain.models import ModelSelection, PipelineRun, RunStage, REVIEW_STAGES, GENERATING_STAGES, STAGE_BEFORE_GENERATING, can_transition
 
 class RunStorageBackend(Protocol):
     async def create_run(self, row: dict[str, Any]) -> dict[str, Any]:
@@ -223,7 +223,11 @@ class RunService:
         return [PipelineRun.from_row(r) for r in rows]
 
     async def stop_run(self, run_id: int) -> PipelineRun:
-        """Stop a running pipeline. Only allowed during GENERATING stages."""
+        """Stop a running pipeline. Only allowed during GENERATING stages.
+
+        Moves current_stage back to the pre-generating actionable stage so
+        any surviving worker task's CAS will fail (stage no longer in _SAFE_STAGES).
+        """
         run = await self.get_run(run_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")
@@ -239,17 +243,26 @@ class RunService:
                 f"can only stop during generating stages"
             )
 
+        # Roll back current_stage to the actionable stage before generation
+        current = RunStage(run.current_stage)
+        rollback_stage = STAGE_BEFORE_GENERATING[current]
+
         row = await self.storage.update_run(
             run_id,
             {
                 "status": "cancelled",
+                "current_stage": rollback_stage.value,
                 "active_task_id": None,
             },
         )
         return PipelineRun.from_row(row)
 
     async def resume_run(self, run_id: int) -> PipelineRun:
-        """Resume a stopped/cancelled run. Resets status to 'running'."""
+        """Resume a stopped/cancelled or failed run.
+
+        After stop, current_stage is already at an actionable stage.
+        Just resets status to 'running' so the user can re-trigger generation.
+        """
         run = await self.get_run(run_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
-from creator_domain.models import ModelSelection, PipelineRun, RunStage, REVIEW_STAGES, can_transition
+from creator_domain.models import ModelSelection, PipelineRun, RunStage, REVIEW_STAGES, GENERATING_STAGES, can_transition
 
 class RunStorageBackend(Protocol):
     async def create_run(self, row: dict[str, Any]) -> dict[str, Any]:
@@ -34,6 +34,14 @@ class RunStorageBackend(Protocol):
 
     async def list_runs_by_project(self, project_id: int) -> list[dict[str, Any]]:
         """Return all run rows for a given project, newest first."""
+        ...
+
+    async def delete_run(self, run_id: int) -> bool:
+        """Delete a run by id. Returns True if deleted."""
+        ...
+
+    async def delete_runs_by_project(self, project_id: int) -> int:
+        """Delete all runs for a project. Returns count of deleted rows."""
         ...
 
 class InMemoryRunStorage:
@@ -90,6 +98,18 @@ class InMemoryRunStorage:
         ]
         rows.sort(key=lambda r: r.get("id", 0), reverse=True)
         return rows
+
+    async def delete_run(self, run_id: int) -> bool:
+        if run_id in self._rows:
+            del self._rows[run_id]
+            return True
+        return False
+
+    async def delete_runs_by_project(self, project_id: int) -> int:
+        to_delete = [rid for rid, r in self._rows.items() if r.get("project_id") == project_id]
+        for rid in to_delete:
+            del self._rows[rid]
+        return len(to_delete)
 
 class RunService:
     def __init__(self, storage: RunStorageBackend):
@@ -201,6 +221,54 @@ class RunService:
         """Return all runs for a project, newest first."""
         rows = await self.storage.list_runs_by_project(project_id)
         return [PipelineRun.from_row(r) for r in rows]
+
+    async def stop_run(self, run_id: int) -> PipelineRun:
+        """Stop a running pipeline. Only allowed during GENERATING stages."""
+        run = await self.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        if run.status == "cancelled":
+            raise ValueError(f"Run {run_id} is already stopped")
+
+        # Only allow stopping during generating stages
+        generating_stage_values = frozenset(s.value for s in GENERATING_STAGES)
+        if run.current_stage not in generating_stage_values:
+            raise ValueError(
+                f"Run {run_id} is in stage '{run.current_stage}', "
+                f"can only stop during generating stages"
+            )
+
+        row = await self.storage.update_run(
+            run_id,
+            {
+                "status": "cancelled",
+                "active_task_id": None,
+            },
+        )
+        return PipelineRun.from_row(row)
+
+    async def resume_run(self, run_id: int) -> PipelineRun:
+        """Resume a stopped/cancelled run. Resets status to 'running'."""
+        run = await self.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        if run.status not in ("cancelled", "failed"):
+            raise ValueError(
+                f"Run {run_id} has status '{run.status}', "
+                f"can only resume cancelled or failed runs"
+            )
+
+        row = await self.storage.update_run(
+            run_id,
+            {"status": "running"},
+        )
+        return PipelineRun.from_row(row)
+
+    async def delete_run(self, run_id: int) -> bool:
+        """Delete a run and return True if deleted."""
+        return await self.storage.delete_run(run_id)
 
 
 def _create_storage() -> RunStorageBackend:

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -252,7 +252,7 @@ class RunService:
             {
                 "status": "cancelled",
                 "current_stage": rollback_stage.value,
-                "active_task_id": None,
+                "active_task_id": "[]",
             },
         )
         return PipelineRun.from_row(row)


### PR DESCRIPTION
## Summary

Implements full run lifecycle management (stop/resume/delete) for the short-form-pipeline, closing all Phase 10 milestone issues.

### Backend
- **Migration 009**: Adds `active_task_id` column to `creator_runs` table to track the currently running Celery task
- **Task ID persistence**: All 8 dispatch endpoints (`generate-script`, `generate-visual-plan`, `generate-visual-assets`, `generate-scene-image`, `regenerate-scene-image`, `generate-audio`, `generate-subtitles`, `render`) now persist the Celery task_id to the database
- **Stop endpoint** (`POST /runs/{id}/stop`): Validates run is in a GENERATING stage, revokes the Celery task via `celery_app.control.revoke(terminate=True)`, and marks the run as cancelled
- **Resume endpoint** (`POST /runs/{id}/resume`): Validates run is cancelled/failed, resets status to running so the user can re-trigger generation
- **Delete endpoints**: `DELETE /runs/{id}` and `DELETE /projects/{id}` with cascade cleanup (FK cascade handles run deletion when project is deleted)
- **Service layer**: `RunService.stop_run()`, `resume_run()`, `delete_run()` and `ProjectService.delete_project()` with Protocol and InMemory implementations for test compatibility

### Frontend
- **ConfirmDialog**: New reusable confirmation modal component with danger/warning/info variants
- **ProjectPage**: Stop (visible when running), Resume (visible when cancelled/failed/paused), and Delete Project buttons in the header area, all gated behind ConfirmDialog
- **RunsPage**: Delete button column in the projects table with confirmation dialog

### Testing
- All API endpoints manually verified via curl
- Stop correctly rejects non-generating stages
- Resume correctly rejects non-cancelled/failed runs
- Delete confirmed working with FK cascade

## Closes
Closes #238, #239, #240, #241, #242, #243

## Milestone
Phase 10: Run Lifecycle Management (Stop/Resume/Delete)