### PR TITLE
feat: back-navigation between stages and per-stage model selection (Phase 11)

### DIFF
--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -1326,7 +1326,10 @@ async def go_back(run_id: int) -> dict[str, object]:
         run = await run_service.go_back(run_id)
         return run.model_dump(mode="json")
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -125,6 +125,14 @@ class GenerateSubtitlesRequest(BaseModel):
 class RenderRequest(BaseModel):
     render_profile: str = "shorts_default"
 
+
+class UpdateModelDefaultsRequest(BaseModel):
+    script_model: str | None = None
+    image_model: str | None = None
+    tts_model: str | None = None
+    subtitle_model: str | None = None
+    render_profile: str | None = None
+
 @router.post("/projects/{project_id}/runs", status_code=201)
 async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
     run = await run_service.create_run(
@@ -1263,7 +1271,15 @@ async def _append_task_id(run_id: int, task_id: str) -> None:
 
     await execute(
         "UPDATE creator_runs "
-        "SET active_task_id = (COALESCE(active_task_id::jsonb, '[]'::jsonb) || to_jsonb($2::text))::text "
+        "SET active_task_id = ("
+        "  COALESCE("
+        "    CASE WHEN active_task_id IS NOT NULL "
+        "         AND left(active_task_id, 1) = '[' "
+        "    THEN active_task_id::jsonb "
+        "    ELSE '[]'::jsonb "
+        "    END, '[]'::jsonb"
+        "  ) || to_jsonb($2::text)"
+        ")::text "
         "WHERE id = $1",
         run_id,
         task_id,
@@ -1302,6 +1318,29 @@ async def resume_run(run_id: int) -> dict[str, object]:
         raise HTTPException(status_code=400, detail=detail) from exc
 
     return updated.model_dump(mode="json")
+
+
+@router.post("/runs/{run_id}/go-back")
+async def go_back(run_id: int) -> dict[str, object]:
+    try:
+        run = await run_service.go_back(run_id)
+        return run.model_dump(mode="json")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.patch("/runs/{run_id}/model-defaults")
+async def update_model_defaults(run_id: int, request: UpdateModelDefaultsRequest) -> dict[str, object]:
+    updates = {k: v for k, v in request.model_dump().items() if v is not None}
+    if not updates:
+        raise HTTPException(status_code=400, detail="No model defaults to update")
+    try:
+        run = await run_service.update_model_defaults(run_id, updates)
+        return run.model_dump(mode="json")
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.delete("/runs/{run_id}")

--- a/apps/studio-web/src/components/creator/StoryboardView.tsx
+++ b/apps/studio-web/src/components/creator/StoryboardView.tsx
@@ -33,6 +33,10 @@ export interface StoryboardViewProps {
   onRenderReady?: () => void;
   /** Polling interval in ms. Default 5000. */
   pollInterval?: number;
+  /** TTS model key passed from parent model selection */
+  ttsModel?: string;
+  /** Subtitle (STT) model key passed from parent model selection */
+  subtitleModel?: string;
 }
 
 // --------------- styles ---------------
@@ -88,6 +92,8 @@ export default function StoryboardView({
   onStatusMessage,
   onRenderReady,
   pollInterval = 5000,
+  ttsModel,
+  subtitleModel,
 }: StoryboardViewProps) {
   const [storyboard, setStoryboard] = useState<StoryboardResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -137,7 +143,7 @@ export default function StoryboardView({
   const handleGenerateAudio = useCallback(
     async (sectionId: string, params: ParagraphAudioParams) => {
       try {
-        await generateParagraphAudio(runId, sectionId, params);
+        await generateParagraphAudio(runId, sectionId, { ...params, tts_model: params.tts_model || ttsModel });
         onStatusMessage?.(`Audio generation started for §${sectionId}`);
         // Update local state to show generating
         setStoryboard((prev) => {
@@ -155,13 +161,13 @@ export default function StoryboardView({
         onStatusMessage?.(err instanceof Error ? err.message : "Audio generation failed");
       }
     },
-    [runId, onStatusMessage],
+    [runId, onStatusMessage, ttsModel],
   );
 
   const handleGenerateSubtitles = useCallback(
     async (sectionId: string, params: ParagraphSubtitlesParams) => {
       try {
-        await generateParagraphSubtitles(runId, sectionId, params);
+        await generateParagraphSubtitles(runId, sectionId, { ...params, subtitle_model: params.subtitle_model || subtitleModel });
         onStatusMessage?.(`Subtitle generation started for §${sectionId}`);
         setStoryboard((prev) => {
           if (!prev) return prev;
@@ -178,13 +184,13 @@ export default function StoryboardView({
         onStatusMessage?.(err instanceof Error ? err.message : "Subtitle generation failed");
       }
     },
-    [runId, onStatusMessage],
+    [runId, onStatusMessage, subtitleModel],
   );
 
   const handleBulkAudio = useCallback(async () => {
     setBulkGenerating(true);
     try {
-      const result = await generateAllParagraphAudio(runId);
+      const result = await generateAllParagraphAudio(runId, { tts_model: ttsModel });
       onStatusMessage?.(`Audio generation started for ${result.dispatched} paragraphs`);
       // Mark all paragraphs as generating
       setStoryboard((prev) => {
@@ -203,12 +209,12 @@ export default function StoryboardView({
     } finally {
       setBulkGenerating(false);
     }
-  }, [runId, onStatusMessage]);
+  }, [runId, onStatusMessage, ttsModel]);
 
   const handleBulkSubtitles = useCallback(async () => {
     setBulkGenerating(true);
     try {
-      const result = await generateAllParagraphSubtitles(runId);
+      const result = await generateAllParagraphSubtitles(runId, { subtitle_model: subtitleModel });
       onStatusMessage?.(`Subtitle generation started for ${result.dispatched} paragraphs`);
       setStoryboard((prev) => {
         if (!prev) return prev;
@@ -226,7 +232,7 @@ export default function StoryboardView({
     } finally {
       setBulkGenerating(false);
     }
-  }, [runId, onStatusMessage]);
+  }, [runId, onStatusMessage, subtitleModel]);
 
   // ---- render ----
 

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -11,7 +11,7 @@
  * - StageActionBar (save / approve / generate / restart)
  */
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 
 import PipelineStepper from "../components/creator/PipelineStepper";
@@ -243,6 +243,16 @@ export default function ProjectPage() {
     }
   }, [run?.model_defaults]);
 
+  // Build selectedModels map for controlled ModelSelector (category → model key)
+  const selectedModelsMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    if (modelSelection.script_model) map.script = modelSelection.script_model;
+    if (modelSelection.image_model) map.image = modelSelection.image_model;
+    if (modelSelection.tts_model) map.tts = modelSelection.tts_model;
+    if (modelSelection.subtitle_model) map.stt = modelSelection.subtitle_model;
+    return Object.keys(map).length > 0 ? map : undefined;
+  }, [modelSelection]);
+
   // Persist model selection to backend
   const handleModelChange = useCallback(
     (category: string, modelKey: string) => {
@@ -252,6 +262,7 @@ export default function ProjectPage() {
         image: "image_model",
         tts: "tts_model",
         stt: "subtitle_model",
+        render: "render_profile",
       };
       const field = fieldMap[category];
       if (!field) return;
@@ -628,7 +639,7 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/render`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ render_profile: "shorts_default" }),
+        body: JSON.stringify({ render_profile: modelSelection.render_profile || "shorts_default" }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -642,7 +653,7 @@ export default function ProjectPage() {
     } finally {
       setGenerating(false);
     }
-  }, [run]);
+  }, [run, modelSelection.render_profile]);
 
   // ---- progress dialog callbacks ----
 
@@ -1510,6 +1521,7 @@ export default function ProjectPage() {
             <div style={{ marginBottom: 12 }}>
               <ModelSelector
                 categories={["tts", "stt"]}
+                selectedModels={selectedModelsMap}
                 apiBase=""
                 onSelectionChange={handleModelChange}
               />
@@ -1615,6 +1627,7 @@ export default function ProjectPage() {
         <div style={{ padding: "8px 16px" }}>
           <ModelSelector
             categories={["script"]}
+            selectedModels={selectedModelsMap}
             apiBase=""
             onSelectionChange={handleModelChange}
           />
@@ -1624,6 +1637,7 @@ export default function ProjectPage() {
         <div style={{ padding: "8px 16px" }}>
           <ModelSelector
             categories={["script"]}
+            selectedModels={selectedModelsMap}
             apiBase=""
             onSelectionChange={handleModelChange}
           />
@@ -1633,6 +1647,7 @@ export default function ProjectPage() {
         <div style={{ padding: "8px 16px" }}>
           <ModelSelector
             categories={["image"]}
+            selectedModels={selectedModelsMap}
             apiBase=""
             onSelectionChange={handleModelChange}
           />

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -11,7 +11,7 @@
  * - StageActionBar (save / approve / generate / restart)
  */
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 
 import PipelineStepper from "../components/creator/PipelineStepper";
@@ -243,15 +243,28 @@ export default function ProjectPage() {
     }
   }, [run?.model_defaults]);
 
-  // Build selectedModels map for controlled ModelSelector (category → model key)
-  const selectedModelsMap = useMemo(() => {
-    const map: Record<string, string> = {};
-    if (modelSelection.script_model) map.script = modelSelection.script_model;
-    if (modelSelection.image_model) map.image = modelSelection.image_model;
-    if (modelSelection.tts_model) map.tts = modelSelection.tts_model;
-    if (modelSelection.subtitle_model) map.stt = modelSelection.subtitle_model;
-    return Object.keys(map).length > 0 ? map : undefined;
-  }, [modelSelection]);
+  // Build a selectedModels map scoped to specific categories.
+  // Returns undefined when none of the requested categories have persisted values,
+  // so ModelSelector stays uncontrolled and can compute its own defaults.
+  const buildSelectedModels = useCallback(
+    (categories: string[]): Record<string, string> | undefined => {
+      const FIELD_TO_CAT: Record<string, string> = {
+        script_model: "script",
+        image_model: "image",
+        tts_model: "tts",
+        subtitle_model: "stt",
+      };
+      const catSet = new Set(categories);
+      const map: Record<string, string> = {};
+      for (const [field, cat] of Object.entries(FIELD_TO_CAT)) {
+        if (catSet.has(cat) && modelSelection[field as keyof ModelDefaults]) {
+          map[cat] = modelSelection[field as keyof ModelDefaults]!;
+        }
+      }
+      return Object.keys(map).length > 0 ? map : undefined;
+    },
+    [modelSelection],
+  );
 
   // Persist model selection to backend
   const handleModelChange = useCallback(
@@ -1521,7 +1534,7 @@ export default function ProjectPage() {
             <div style={{ marginBottom: 12 }}>
               <ModelSelector
                 categories={["tts", "stt"]}
-                selectedModels={selectedModelsMap}
+                selectedModels={buildSelectedModels(["tts", "stt"])}
                 apiBase=""
                 onSelectionChange={handleModelChange}
               />
@@ -1627,7 +1640,7 @@ export default function ProjectPage() {
         <div style={{ padding: "8px 16px" }}>
           <ModelSelector
             categories={["script"]}
-            selectedModels={selectedModelsMap}
+            selectedModels={buildSelectedModels(["script"])}
             apiBase=""
             onSelectionChange={handleModelChange}
           />
@@ -1637,7 +1650,7 @@ export default function ProjectPage() {
         <div style={{ padding: "8px 16px" }}>
           <ModelSelector
             categories={["script"]}
-            selectedModels={selectedModelsMap}
+            selectedModels={buildSelectedModels(["script"])}
             apiBase=""
             onSelectionChange={handleModelChange}
           />
@@ -1647,7 +1660,7 @@ export default function ProjectPage() {
         <div style={{ padding: "8px 16px" }}>
           <ModelSelector
             categories={["image"]}
-            selectedModels={selectedModelsMap}
+            selectedModels={buildSelectedModels(["image"])}
             apiBase=""
             onSelectionChange={handleModelChange}
           />

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -38,12 +38,21 @@ interface ProjectDetail {
   status: string;
 }
 
+interface ModelDefaults {
+  script_model?: string;
+  image_model?: string;
+  tts_model?: string;
+  subtitle_model?: string;
+  render_profile?: string;
+}
+
 interface RunDetail {
   id: number;
   project_id: number;
   current_stage: string;
   status: string;
   restart_from: string | null;
+  model_defaults: ModelDefaults | null;
 }
 
 type EditorMode = "markdown" | "structured";
@@ -74,6 +83,14 @@ const STORYBOARD_STAGES = new Set(["AUDIO_GENERATING", "SUBTITLE_GENERATING", "R
 
 // Stages where editing is allowed (not generating)
 const EDITABLE_STAGES = new Set(["SCRIPT_REVIEW", "VISUAL_PLAN_REVIEW"]);
+
+// Back navigation labels per review stage
+const STAGE_BACK_LABELS: Record<string, string> = {
+  SCRIPT_REVIEW: "\u2190 Back to Idea",
+  VISUAL_PLAN_REVIEW: "\u2190 Back to Script Review",
+  VISUAL_ASSET_REVIEW: "\u2190 Back to Visual Plan",
+  FINAL_REVIEW: "\u2190 Back to Visual Assets",
+};
 
 // SD quality presets for image generation tuning
 const SD_QUALITY_PRESETS: Record<
@@ -140,6 +157,10 @@ export default function ProjectPage() {
 
   // Preview data for FINAL_REVIEW
   const [preview, setPreview] = useState<Record<string, unknown> | null>(null);
+
+  // Per-stage model selection (persisted to backend via model_defaults)
+  const [modelSelection, setModelSelection] = useState<ModelDefaults>({});
+  const [goingBack, setGoingBack] = useState(false);
 
   // ---- data fetching ----
 
@@ -210,6 +231,66 @@ export default function ProjectPage() {
     }
   }, []);
 
+  // Initialize model selection from run.model_defaults on load
+  useEffect(() => {
+    if (run?.model_defaults) {
+      setModelSelection((prev) => {
+        // Only set if we don't have local selections yet
+        const hasLocal = Object.keys(prev).length > 0;
+        if (hasLocal) return prev;
+        return { ...run.model_defaults } as ModelDefaults;
+      });
+    }
+  }, [run?.model_defaults]);
+
+  // Persist model selection to backend
+  const handleModelChange = useCallback(
+    (category: string, modelKey: string) => {
+      // Map ModelSelector category → ModelDefaults field
+      const fieldMap: Record<string, keyof ModelDefaults> = {
+        script: "script_model",
+        image: "image_model",
+        tts: "tts_model",
+        stt: "subtitle_model",
+      };
+      const field = fieldMap[category];
+      if (!field) return;
+      setModelSelection((prev) => ({ ...prev, [field]: modelKey }));
+      // Fire-and-forget persist to backend
+      if (run) {
+        fetch(`${API_BASE}/runs/${run.id}/model-defaults`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ [field]: modelKey }),
+        }).catch(() => { /* non-critical */ });
+      }
+    },
+    [run],
+  );
+
+  // ---- go-back navigation ----
+
+  const handleGoBack = useCallback(async () => {
+    if (!run) return;
+    setGoingBack(true);
+    setStatusMessage(null);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${run.id}/go-back`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Go back failed (${res.status})`);
+      }
+      setStatusMessage("Navigated back");
+      await refreshRun(run.id);
+    } catch (err) {
+      setStatusMessage(err instanceof Error ? err.message : "Go back failed");
+    } finally {
+      setGoingBack(false);
+    }
+  }, [run, refreshRun]);
+
   // ---- script actions ----
 
   const handleApprove = useCallback(async () => {
@@ -243,7 +324,7 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/generate-script`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model_key: "qwen3-4b" }),
+        body: JSON.stringify({ model_key: modelSelection.script_model || "qwen3-4b" }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -256,7 +337,7 @@ export default function ProjectPage() {
     } finally {
       setGenerating(false);
     }
-  }, [run, refreshRun]);
+  }, [run, refreshRun, modelSelection.script_model]);
 
   const handleRestart = useCallback(async () => {
     if (!run) return;
@@ -314,7 +395,7 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/generate-visual-plan`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model_key: "qwen3-4b" }),
+        body: JSON.stringify({ model_key: modelSelection.script_model || "qwen3-4b" }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -327,7 +408,7 @@ export default function ProjectPage() {
     } finally {
       setGenerating(false);
     }
-  }, [run, refreshRun]);
+  }, [run, refreshRun, modelSelection.script_model]);
 
   const handleRestartVisualPlan = useCallback(async () => {
     if (!run) return;
@@ -362,7 +443,7 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/generate-visual-assets`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model_key: "sd15", image_params: imageParams }),
+        body: JSON.stringify({ model_key: modelSelection.image_model || "sd15", image_params: imageParams }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -376,7 +457,7 @@ export default function ProjectPage() {
     } finally {
       setGenerating(false);
     }
-  }, [run, imageParams]);
+  }, [run, imageParams, modelSelection.image_model]);
 
   const handleRegenerateScene = useCallback(
     async (sceneId: string) => {
@@ -420,7 +501,7 @@ export default function ProjectPage() {
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ model_key: "sd15", image_params: imageParams }),
+            body: JSON.stringify({ model_key: modelSelection.image_model || "sd15", image_params: imageParams }),
           },
         );
         if (!res.ok) {
@@ -436,7 +517,7 @@ export default function ProjectPage() {
         setStatusMessage(err instanceof Error ? err.message : "Generate scene failed");
       }
     },
-    [run, imageParams, refreshRun],
+    [run, imageParams, refreshRun, modelSelection.image_model],
   );
 
   const handleApproveAssets = useCallback(async () => {
@@ -495,7 +576,7 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/generate-audio`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tts_model: "qwen3-tts", voice: "default" }),
+        body: JSON.stringify({ tts_model: modelSelection.tts_model || "qwen3-tts", voice: "default" }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -509,7 +590,7 @@ export default function ProjectPage() {
     } finally {
       setGenerating(false);
     }
-  }, [run]);
+  }, [run, modelSelection.tts_model]);
 
   // ---- subtitle actions ----
 
@@ -521,7 +602,7 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/generate-subtitles`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ subtitle_model: "whisper-small", subtitle_format: "srt" }),
+        body: JSON.stringify({ subtitle_model: modelSelection.subtitle_model || "whisper-small", subtitle_format: "srt" }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -535,7 +616,7 @@ export default function ProjectPage() {
     } finally {
       setGenerating(false);
     }
-  }, [run]);
+  }, [run, modelSelection.subtitle_model]);
 
   // ---- render actions ----
 
@@ -665,9 +746,6 @@ export default function ProjectPage() {
       ? (previewVideo as Record<string, unknown>).path
       : null;
 
-  void handleGenerateAudio;
-  void handleGenerateSubtitles;
-  void handleRender;
 
   // ---- action bar config ----
 
@@ -1428,6 +1506,15 @@ export default function ProjectPage() {
       {/* Unified Storyboard view — replaces separate audio/subtitle/render indicators */}
       {run && isStoryboardStage && (
         <div style={{ marginBottom: 24 }}>
+          {!isRenderStage && (
+            <div style={{ marginBottom: 12 }}>
+              <ModelSelector
+                categories={["tts", "stt"]}
+                apiBase=""
+                onSelectionChange={handleModelChange}
+              />
+            </div>
+          )}
           <StoryboardView
             runId={run.id}
             readOnly={isRenderStage}
@@ -1435,6 +1522,8 @@ export default function ProjectPage() {
             onRenderReady={() => {
               if (run) refreshRun(run.id);
             }}
+            ttsModel={modelSelection.tts_model}
+            subtitleModel={modelSelection.subtitle_model}
           />
 
           {/* Final review extras — review link + video path */}
@@ -1494,6 +1583,60 @@ export default function ProjectPage() {
           onFailed={handleProgressFailed}
           onClose={() => setProgressOpen(false)}
         />
+      )}
+
+      {/* Back navigation button */}
+      {run && STAGE_BACK_LABELS[currentStage] && (
+        <div style={{ display: "flex", justifyContent: "flex-start", padding: "8px 16px" }}>
+          <button
+            type="button"
+            data-testid="go-back-btn"
+            disabled={goingBack}
+            onClick={handleGoBack}
+            style={{
+              padding: "6px 16px",
+              fontSize: 13,
+              fontWeight: 500,
+              border: "1px solid #d1d5db",
+              borderRadius: 6,
+              background: "#fff",
+              color: "#374151",
+              cursor: goingBack ? "not-allowed" : "pointer",
+              opacity: goingBack ? 0.6 : 1,
+            }}
+          >
+            {goingBack ? "Going back\u2026" : STAGE_BACK_LABELS[currentStage]}
+          </button>
+        </div>
+      )}
+
+      {/* Per-stage model selector */}
+      {run && currentStage === "IDEA_READY" && (
+        <div style={{ padding: "8px 16px" }}>
+          <ModelSelector
+            categories={["script"]}
+            apiBase=""
+            onSelectionChange={handleModelChange}
+          />
+        </div>
+      )}
+      {run && currentStage === "SCRIPT_REVIEW" && (
+        <div style={{ padding: "8px 16px" }}>
+          <ModelSelector
+            categories={["script"]}
+            apiBase=""
+            onSelectionChange={handleModelChange}
+          />
+        </div>
+      )}
+      {run && currentStage === "VISUAL_PLAN_REVIEW" && (
+        <div style={{ padding: "8px 16px" }}>
+          <ModelSelector
+            categories={["image"]}
+            apiBase=""
+            onSelectionChange={handleModelChange}
+          />
+        </div>
       )}
 
       {/* Stage action bar */}

--- a/packages/creator-domain/creator_domain/models/__init__.py
+++ b/packages/creator-domain/creator_domain/models/__init__.py
@@ -5,6 +5,7 @@ from .project import Project
 from .script_draft import ScriptDraft, ScriptSection, VisualOverride
 from .stage import (
     GENERATING_STAGES,
+    STAGE_BACK,
     STAGE_BEFORE_GENERATING,
     REVIEW_STAGES,
     TRANSITIONS,
@@ -30,6 +31,7 @@ __all__ = [
     "TRANSITIONS",
     "REVIEW_STAGES",
     "GENERATING_STAGES",
+    "STAGE_BACK",
     "STAGE_BEFORE_GENERATING",
     "can_transition",
     "next_stages",

--- a/packages/creator-domain/creator_domain/models/stage.py
+++ b/packages/creator-domain/creator_domain/models/stage.py
@@ -84,6 +84,12 @@ STAGE_BEFORE_GENERATING: dict[RunStage, RunStage] = {
     RunStage.RENDER_GENERATING: RunStage.VISUAL_ASSET_REVIEW,
 
 }
+STAGE_BACK: dict[RunStage, RunStage] = {
+    RunStage.SCRIPT_REVIEW: RunStage.IDEA_READY,
+    RunStage.VISUAL_PLAN_REVIEW: RunStage.SCRIPT_REVIEW,
+    RunStage.VISUAL_ASSET_REVIEW: RunStage.VISUAL_PLAN_REVIEW,
+    RunStage.FINAL_REVIEW: RunStage.VISUAL_ASSET_REVIEW,
+}
 
 
 

--- a/packages/creator-service/creator_service/postgres_run_storage.py
+++ b/packages/creator-service/creator_service/postgres_run_storage.py
@@ -111,6 +111,18 @@ class PostgresRunStorage:
             return False, None
         return False, current
 
+    async def merge_model_defaults(self, run_id: int, updates_json: str) -> dict[str, Any]:
+        """Atomically merge JSON updates into model_defaults_json using PostgreSQL jsonb."""
+        row = await fetch_one(
+            "UPDATE creator_runs "
+            "SET model_defaults_json = (COALESCE(model_defaults_json, '{}')::jsonb || $2::jsonb)::text "
+            "WHERE id = $1 RETURNING *",
+            run_id,
+            updates_json,
+        )
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+        return row
     async def list_runs_by_project(self, project_id: int) -> list[dict[str, Any]]:
         return await fetch_all(
             "SELECT * FROM creator_runs WHERE project_id = $1 ORDER BY id DESC",

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
-from creator_domain.models import ModelSelection, PipelineRun, RunStage, REVIEW_STAGES, GENERATING_STAGES, STAGE_BEFORE_GENERATING, can_transition
+from creator_domain.models import ModelSelection, PipelineRun, RunStage, REVIEW_STAGES, GENERATING_STAGES, STAGE_BEFORE_GENERATING, STAGE_BACK, can_transition
 
 class RunStorageBackend(Protocol):
     async def create_run(self, row: dict[str, Any]) -> dict[str, Any]:
@@ -276,6 +276,58 @@ class RunService:
         row = await self.storage.update_run(
             run_id,
             {"status": "running"},
+        )
+        return PipelineRun.from_row(row)
+
+    async def go_back(self, run_id: int) -> PipelineRun:
+        run = await self.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        if run.current_stage is None:
+            raise ValueError(f"Run {run_id} has no current stage")
+
+        try:
+            current = RunStage(run.current_stage)
+        except ValueError as exc:
+            raise ValueError(f"Invalid current stage '{run.current_stage}'") from exc
+
+        if current not in STAGE_BACK:
+            raise ValueError(
+                f"Cannot go back from stage '{current.value}'. "
+                f"Go-back is only allowed from review stages: "
+                f"{', '.join(s.value for s in STAGE_BACK)}"
+            )
+
+        target = STAGE_BACK[current]
+
+        ok, row = await self.storage.conditional_update_run(
+            run_id,
+            {"current_stage": target.value},
+            frozenset({current.value}),
+        )
+        if not ok:
+            if row is None:
+                raise ValueError(f"Run {run_id} not found")
+            raise RuntimeError(
+                f"Stage conflict: expected '{current.value}' but run is at '{row.get('current_stage')}'"
+            )
+        return PipelineRun.from_row(row)
+
+    async def update_model_defaults(self, run_id: int, updates: dict[str, str]) -> PipelineRun:
+        run = await self.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+
+        current_defaults = {}
+        if run.model_defaults is not None:
+            current_defaults = run.model_defaults.model_dump(exclude_none=True)
+
+        merged = {**current_defaults, **updates}
+
+        row = await self.storage.update_run(
+            run_id,
+            {"model_defaults_json": json.dumps(merged)},
         )
         return PipelineRun.from_row(row)
 

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -43,6 +43,9 @@ class RunStorageBackend(Protocol):
     async def delete_runs_by_project(self, project_id: int) -> int:
         """Delete all runs for a project. Returns count of deleted rows."""
         ...
+    async def merge_model_defaults(self, run_id: int, updates_json: str) -> dict[str, Any]:
+        """Atomically merge JSON updates into model_defaults_json."""
+        ...
 
 class InMemoryRunStorage:
     def __init__(self) -> None:
@@ -105,6 +108,17 @@ class InMemoryRunStorage:
             return True
         return False
 
+    async def merge_model_defaults(self, run_id: int, updates_json: str) -> dict[str, Any]:
+        row = self._rows.get(run_id)
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+        current = json.loads(row.get("model_defaults_json") or "{}")
+        updates = json.loads(updates_json)
+        merged = {**current, **updates}
+        row["model_defaults_json"] = json.dumps(merged)
+        row["updated_at"] = datetime.now(timezone.utc)
+        self._rows[run_id] = row
+        return dict(row)
     async def delete_runs_by_project(self, project_id: int) -> int:
         to_delete = [rid for rid, r in self._rows.items() if r.get("project_id") == project_id]
         for rid in to_delete:
@@ -315,20 +329,8 @@ class RunService:
         return PipelineRun.from_row(row)
 
     async def update_model_defaults(self, run_id: int, updates: dict[str, str]) -> PipelineRun:
-        run = await self.get_run(run_id)
-        if run is None:
-            raise ValueError(f"Run {run_id} not found")
-
-        current_defaults = {}
-        if run.model_defaults is not None:
-            current_defaults = run.model_defaults.model_dump(exclude_none=True)
-
-        merged = {**current_defaults, **updates}
-
-        row = await self.storage.update_run(
-            run_id,
-            {"model_defaults_json": json.dumps(merged)},
-        )
+        """Atomically merge model default updates (no read-merge-write race)."""
+        row = await self.storage.merge_model_defaults(run_id, json.dumps(updates))
         return PipelineRun.from_row(row)
 
     async def delete_run(self, run_id: int) -> bool:


### PR DESCRIPTION
## Summary
- Add back-navigation between pipeline review stages (SCRIPT_REVIEW → IDEA_READY, VISUAL_PLAN_REVIEW → SCRIPT_REVIEW, etc.) via new `POST /runs/{id}/go-back` endpoint using CAS for safe stage transitions
- Add `PATCH /runs/{id}/model-defaults` endpoint to persist per-run model selections
- Replace all 6 hardcoded model keys in frontend with dynamic `modelSelection` state persisted to backend
- Add Back button UI in all review stages
- Add per-stage ModelSelector components (script model at Idea/Script stages, image model at Visual Plan stage, TTS/STT at storyboard stages)
- Thread model selection from ProjectPage → StoryboardView → storyboard.ts API functions

## Changes

### Backend (4 files)
- `packages/creator-domain/creator_domain/models/stage.py` — `STAGE_BACK` map
- `packages/creator-domain/creator_domain/models/__init__.py` — Export `STAGE_BACK`
- `packages/creator-service/creator_service/run_service.py` — `go_back()` + `update_model_defaults()` methods
- `apps/api/src/shorts_api/routes/creator_runs.py` — Two new endpoints + `UpdateModelDefaultsRequest`

### Frontend (2 files)
- `apps/studio-web/src/pages/ProjectPage.tsx` — Model selection state, back button, per-stage ModelSelector, dynamic model keys in all handlers
- `apps/studio-web/src/components/creator/StoryboardView.tsx` — Accept `ttsModel`/`subtitleModel` props, pass to API functions

## Testing
- TypeScript compiles cleanly (zero source file errors)
- Pre-existing test file type errors remain (unrelated to this PR)

Closes #245, #246, #247, #248, #249, #250