### PR TITLE
feat: pre-fill markdown textarea with example template

### DIFF
--- a/apps/studio-web/src/__tests__/CreatePage.test.tsx
+++ b/apps/studio-web/src/__tests__/CreatePage.test.tsx
@@ -412,6 +412,8 @@ describe("CreatePage", () => {
 
     // Leave markdown content empty, just set title
     fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "My Project" } });
+    // Clear pre-filled template to test empty submission
+    fireEvent.change(screen.getByLabelText(/Markdown Content/), { target: { value: "" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
 
     // Should NOT navigate since markdown is empty

--- a/apps/studio-web/src/pages/CreatePage.tsx
+++ b/apps/studio-web/src/pages/CreatePage.tsx
@@ -11,6 +11,29 @@ interface MarkdownFormState {
 }
 
 const API_BASE = "/api/creator";
+const MARKDOWN_TEMPLATE = `## Hook
+
+여러분, AI가 60초 만에 영상을 만들어준다면 믿으시겠어요?
+
+## Body 1
+
+최신 AI 기술을 활용하면 스크립트 작성부터 영상 렌더링까지
+모든 과정이 자동화됩니다.
+
+## Body 2
+
+텍스트를 입력하면 AI가 장면별 이미지를 생성하고,
+음성과 자막까지 자동으로 추가해줍니다.
+
+## Body 3
+
+이제 영상 제작에 전문 지식이 필요하지 않습니다.
+누구나 몇 분 만에 숏폼 콘텐츠를 만들 수 있어요.
+
+## CTA
+
+지금 바로 시작해보세요! 링크는 설명란에 있습니다.`.trimStart();
+
 
 export default function CreatePage() {
   const navigate = useNavigate();
@@ -19,7 +42,7 @@ export default function CreatePage() {
   // Markdown form state
   const [markdownForm, setMarkdownForm] = useState<MarkdownFormState>({
     title: "",
-    markdown: "",
+    markdown: MARKDOWN_TEMPLATE,
   });
 
   // Shared state
@@ -252,111 +275,12 @@ export default function CreatePage() {
             <label htmlFor="md-content" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
               Markdown Content <span style={{ color: "#c00" }}>*</span>
             </label>
-
-            {/* Collapsible markdown format guide */}
-            <details
-              style={{
-                marginBottom: 12,
-                background: "#f0f7ff",
-                border: "1px solid #d0e3f7",
-                borderRadius: 8,
-                padding: 0,
-                fontSize: 13,
-              }}
-            >
-              <summary
-                style={{
-                  padding: "10px 14px",
-                  cursor: "pointer",
-                  fontWeight: 600,
-                  color: "#1a56db",
-                  fontSize: 13,
-                  listStyle: "none",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 6,
-                }}
-              >
-                <span style={{ fontSize: 16 }}>📝</span> 마크다운 형식 가이드
-              </summary>
-              <div style={{ padding: "0 14px 14px" }}>
-                <p style={{ margin: "0 0 8px", color: "#374151", lineHeight: 1.6 }}>
-                  <code style={{ fontFamily: "'JetBrains Mono', monospace", background: "#e8f0fe", padding: "2px 6px", borderRadius: 3 }}>## 헤딩</code> 으로 섹션을 구분합니다. 각 섹션이 하나의 장면(scene)이 되어 이미지가 생성됩니다.
-                </p>
-                <p style={{ margin: "0 0 8px", color: "#374151", lineHeight: 1.6, fontSize: 12 }}>
-                  섹션 이름 예시: <strong>Hook</strong>, <strong>Body 1</strong>, <strong>Body 2</strong>, <strong>CTA</strong>, <strong>Outro</strong> 등 자유롭게 지정 가능
-                </p>
-                <div style={{ position: "relative", marginTop: 10 }}>
-                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
-                    <span style={{ fontSize: 12, fontWeight: 600, color: "#6b7280" }}>예시 스크립트</span>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const example = `## Hook\n\n여러분, AI가 60초 만에 영상을 만들어준다면 믿으시겠어요?\n\n## Body 1\n\n최신 AI 기술을 활용하면 스크립트 작성부터 영상 렌더링까지\n모든 과정이 자동화됩니다.\n\n## Body 2\n\n텍스트를 입력하면 AI가 장면별 이미지를 생성하고,\n음성과 자막까지 자동으로 추가해줍니다.\n\n## Body 3\n\n이제 영상 제작에 전문 지식이 필요하지 않습니다.\n누구나 몇 분 만에 숏폼 콘텐츠를 만들 수 있어요.\n\n## CTA\n\n지금 바로 시작해보세요! 링크는 설명란에 있습니다.`;
-                        navigator.clipboard.writeText(example);
-                        setMarkdownForm((prev) => ({ ...prev, markdown: example }));
-                      }}
-                      style={{
-                        padding: "4px 12px",
-                        fontSize: 12,
-                        border: "1px solid #d0e3f7",
-                        borderRadius: 4,
-                        background: "#fff",
-                        color: "#1a56db",
-                        cursor: "pointer",
-                        fontWeight: 500,
-                      }}
-                    >
-                      📋 예시 복사 & 붙여넣기
-                    </button>
-                  </div>
-                  <pre style={{
-                    fontFamily: "'JetBrains Mono', monospace",
-                    fontSize: 12,
-                    lineHeight: 1.6,
-                    background: "#fff",
-                    border: "1px solid #d0e3f7",
-                    borderRadius: 6,
-                    padding: 12,
-                    margin: 0,
-                    overflowX: "auto",
-                    whiteSpace: "pre-wrap",
-                    color: "#1f2937",
-                  }}>{`## Hook\n\n여러분, AI가 60초 만에 영상을 만들어준다면 믿으시겠어요?\n\n## Body 1\n\n최신 AI 기술을 활용하면 스크립트 작성부터\n영상 렌더링까지 모든 과정이 자동화됩니다.\n\n## Body 2\n\n텍스트를 입력하면 AI가 장면별 이미지를 생성하고,\n음성과 자막까지 자동으로 추가해줍니다.\n\n## Body 3\n\n이제 영상 제작에 전문 지식이 필요하지 않습니다.\n누구나 몇 분 만에 숏폼 콘텐츠를 만들 수 있어요.\n\n## CTA\n\n지금 바로 시작해보세요! 링크는 설명란에 있습니다.`}</pre>
-                </div>
-                <table style={{ marginTop: 10, width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
-                  <thead>
-                    <tr style={{ borderBottom: "1px solid #d0e3f7" }}>
-                      <th style={{ textAlign: "left", padding: "4px 8px", color: "#6b7280" }}>섹션</th>
-                      <th style={{ textAlign: "left", padding: "4px 8px", color: "#6b7280" }}>Section ID</th>
-                      <th style={{ textAlign: "left", padding: "4px 8px", color: "#6b7280" }}>생성 결과</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {[
-                      ["## Hook", "hook-1", "장면 1 이미지"],
-                      ["## Body 1", "body-1-2", "장면 2 이미지"],
-                      ["## Body 2", "body-2-3", "장면 3 이미지"],
-                      ["## Body 3", "body-3-4", "장면 4 이미지"],
-                      ["## CTA", "cta-5", "장면 5 이미지"],
-                    ].map(([section, id, result], i) => (
-                      <tr key={i} style={{ borderBottom: "1px solid #e5edf5" }}>
-                        <td style={{ padding: "4px 8px", fontFamily: "'JetBrains Mono', monospace" }}>{section}</td>
-                        <td style={{ padding: "4px 8px", fontFamily: "'JetBrains Mono', monospace", color: "#6b7280" }}>{id}</td>
-                        <td style={{ padding: "4px 8px" }}>{result}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </details>
             <textarea
               id="md-content"
               required
               value={markdownForm.markdown}
               onChange={(e) => setMarkdownForm((prev) => ({ ...prev, markdown: e.target.value }))}
               disabled={submitting}
-              placeholder="Paste your script markdown here..."
               rows={10}
               style={{ width: "100%", padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14, fontFamily: "monospace", resize: "vertical", boxSizing: "border-box" }}
             />


### PR DESCRIPTION
## Summary
- Replace collapsible markdown format guide with pre-filled example template in textarea
- Users immediately see the expected `## heading` structure without expanding a guide
- Removed ~100 lines of `<details>` guide markup, replaced with ~26 lines of clean template constant

## Changes
- `apps/studio-web/src/pages/CreatePage.tsx`: Extract `MARKDOWN_TEMPLATE` constant, pre-fill initial state, remove `<details>` block
- `apps/studio-web/src/__tests__/CreatePage.test.tsx`: Update empty-submission test to explicitly clear pre-filled content

## Verification
- Vite build: ✅ SUCCESS
- TypeScript: 0 errors in changed files
- CreatePage tests: 25/25 PASSED

Closes #253