### PR TITLE
fix: harden run task persistence and render assembly

### DIFF
--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -11,10 +11,9 @@ router = APIRouter(prefix="/projects", tags=["projects"])
 
 class CreateProjectRequest(BaseModel):
     title: str
-    source_type: Literal["idea", "markdown", "url"]
+    source_type: Literal["idea", "markdown"]
     idea_brief: str | None = None
     markdown_source: str | None = None
-    url_source: str | None = None
 
 
 @router.post("", status_code=201)
@@ -25,7 +24,6 @@ async def create_project(request: CreateProjectRequest) -> dict[str, object]:
             source_type=request.source_type,
             idea_brief=request.idea_brief,
             markdown_source=request.markdown_source,
-            url_source=request.url_source,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -135,6 +135,10 @@ class UpdateModelDefaultsRequest(BaseModel):
 
 @router.post("/projects/{project_id}/runs", status_code=201)
 async def create_run(project_id: int, request: CreateRunRequest) -> dict[str, object]:
+    project = await project_service.get_project(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     run = await run_service.create_run(
         project_id=project_id,
         model_defaults=request.model_defaults,

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -1262,28 +1262,8 @@ def _revoke_active_tasks(active_task_id: str | None) -> None:
 
 
 async def _append_task_id(run_id: int, task_id: str) -> None:
-    """Atomically append a task_id to the run's active_task_id JSON list.
-
-    Uses a single UPDATE with jsonb to avoid read-modify-write races when
-    multiple scene-image tasks are dispatched concurrently.
-    """
-    from creator_service.db import execute
-
-    await execute(
-        "UPDATE creator_runs "
-        "SET active_task_id = ("
-        "  COALESCE("
-        "    CASE WHEN active_task_id IS NOT NULL "
-        "         AND left(active_task_id, 1) = '[' "
-        "    THEN active_task_id::jsonb "
-        "    ELSE '[]'::jsonb "
-        "    END, '[]'::jsonb"
-        "  ) || to_jsonb($2::text)"
-        ")::text "
-        "WHERE id = $1",
-        run_id,
-        task_id,
-    )
+    """Atomically append a task id via the configured run storage backend."""
+    await run_service.storage.append_active_task_id(run_id, task_id)
 
 @router.post("/runs/{run_id}/stop")
 async def stop_run(run_id: int) -> dict[str, object]:

--- a/apps/api/src/shorts_api/routes/creator_runs.py
+++ b/apps/api/src/shorts_api/routes/creator_runs.py
@@ -1036,6 +1036,10 @@ async def get_storyboard(run_id: int) -> dict[str, object]:
         if has_image and has_audio and has_subtitles:
             status = "ready"
             ready_count += 1
+        elif run.current_stage == "AUDIO_GENERATING" and has_image and not has_audio:
+            status = "generating_audio"
+        elif run.current_stage == "SUBTITLE_GENERATING" and has_audio and not has_subtitles:
+            status = "generating_subtitles"
         elif not has_image and not has_audio and not has_subtitles:
             status = "idle"
         else:

--- a/apps/api/src/shorts_api/routes/creator_script.py
+++ b/apps/api/src/shorts_api/routes/creator_script.py
@@ -1,6 +1,7 @@
 """Routes for creator script management."""
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ValidationError
+from creator_domain.models import RunStage
 from creator_domain.models.script_draft import ScriptSection
 from creator_service.markdown_parser import parse_markdown
 from creator_service.project_service import project_service
@@ -31,6 +32,8 @@ async def import_markdown(project_id: int, request: ImportMarkdownRequest) -> di
             project_id=project_id,
             model_defaults=request.model_defaults,
             style_preset=request.style_preset,
+            current_stage=RunStage.SCRIPT_REVIEW.value,
+            status="running",
         )
         draft = await script_service.save_draft(
             run_id=run.id,

--- a/apps/api/tests/__init__.py
+++ b/apps/api/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Test module for shorts_api."""

--- a/apps/api/tests/test_creator_projects.py
+++ b/apps/api/tests/test_creator_projects.py
@@ -161,6 +161,16 @@ async def test_create_project_invalid_source_type(client):
 
 
 @pytest.mark.asyncio
+async def test_create_project_url_source_is_not_publicly_supported(client):
+    response = await client.post(
+        "/api/creator/projects",
+        json={"title": "URL", "source_type": "url", "url_source": "https://example.com"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_create_project_missing_required_field(client, stub_project_service: StubProjectService):
     response = await client.post(
         "/api/creator/projects",

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -1,5 +1,6 @@
 # pyright: reportMissingImports=false
 
+import json
 from datetime import datetime, timezone
 from typing import Literal
 
@@ -20,6 +21,7 @@ class StubPipelineRun(BaseModel):
     style_preset: str | None = None
     started_at: datetime | None = None
     finished_at: datetime | None = None
+    active_task_id: str | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -63,6 +65,7 @@ class StubRunService:
             style_preset=style_preset,
             started_at=None,
             finished_at=None,
+            active_task_id=None,
             created_at=now,
             updated_at=now,
         )
@@ -114,6 +117,8 @@ class StubRunStorage:
     def __init__(self, run_svc: "StubRunService") -> None:
         self._run_svc = run_svc
         self.conditional_update_calls: list[dict[str, object]] = []
+        self.append_task_calls: list[dict[str, object]] = []
+        self.remove_task_calls: list[dict[str, object]] = []
 
     async def conditional_update_run(
         self,
@@ -136,6 +141,42 @@ class StubRunStorage:
         updated = run.model_copy(update=updates)
         self._run_svc.runs[run_id] = updated
         return True, updated.model_dump(mode="json")
+
+    async def append_active_task_id(self, run_id: int, task_id: str) -> dict[str, object]:
+        self.append_task_calls.append({"run_id": run_id, "task_id": task_id})
+        run = self._run_svc.runs.get(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        current_raw = getattr(run, "active_task_id", None)
+        if current_raw:
+            try:
+                current = json.loads(current_raw)
+            except (TypeError, ValueError):
+                current = [current_raw]
+        else:
+            current = []
+        current.append(task_id)
+        updated = run.model_copy(update={"active_task_id": json.dumps(current)})
+        self._run_svc.runs[run_id] = updated
+        return updated.model_dump(mode="json")
+
+    async def remove_active_task_id(self, run_id: int, task_id: str) -> dict[str, object]:
+        self.remove_task_calls.append({"run_id": run_id, "task_id": task_id})
+        run = self._run_svc.runs.get(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        current_raw = getattr(run, "active_task_id", None)
+        if current_raw:
+            try:
+                current = json.loads(current_raw)
+            except (TypeError, ValueError):
+                current = [current_raw]
+        else:
+            current = []
+        current = [tid for tid in current if tid != task_id]
+        updated = run.model_copy(update={"active_task_id": json.dumps(current)})
+        self._run_svc.runs[run_id] = updated
+        return updated.model_dump(mode="json")
 class StubStageReviewService:
     def __init__(self, run_svc: StubRunService) -> None:
         self.approve_calls: list[dict[str, object]] = []
@@ -653,6 +694,7 @@ async def test_generate_script_from_idea_ready(client, stub_generate_services):
         "model_key": "qwen3-4b",
         "instructions": "Focus on pasta",
     }]
+    assert run_svc.storage.append_task_calls == [{"run_id": 10, "task_id": "test-task-id-123"}]
 
 
 @pytest.mark.asyncio
@@ -924,6 +966,7 @@ async def test_generate_visual_plan_from_visual_plan_setup(client, stub_generate
         "model_key": "qwen3-4b",
         "style_preset": "cinematic",
     }]
+    assert run_svc.storage.append_task_calls == [{"run_id": 30, "task_id": "test-vp-task-id-456"}]
 
 
 @pytest.mark.asyncio
@@ -952,7 +995,7 @@ async def test_generate_visual_plan_retry_from_generating(client, stub_generate_
 @pytest.mark.asyncio
 async def test_generate_visual_plan_default_model(client, stub_generate_visual_plan_services):
     run_svc, dispatcher = stub_generate_visual_plan_services
-    run_svc.runs[32] = _make_run(32, "SCRIPT_REVIEW")
+    run_svc.runs[32] = _make_run(32, "VISUAL_PLAN_SETUP")
 
     response = await client.post(
         "/api/creator/runs/32/generate-visual-plan",
@@ -1008,7 +1051,7 @@ async def test_generate_visual_plan_wrong_stage_visual_review(client, stub_gener
 async def test_generate_visual_plan_cas_conflict(client, stub_generate_visual_plan_services):
     """CAS fails because stage changed between initial check and CAS."""
     run_svc, dispatcher = stub_generate_visual_plan_services
-    run_svc.runs[35] = _make_run(35, "SCRIPT_REVIEW")
+    run_svc.runs[35] = _make_run(35, "VISUAL_PLAN_SETUP")
 
     async def cas_conflict(run_id, updates, expected_stages):
         return False, {"current_stage": "VISUAL_PLAN_GENERATING", "id": run_id}
@@ -1029,7 +1072,7 @@ async def test_generate_visual_plan_cas_conflict(client, stub_generate_visual_pl
 async def test_generate_visual_plan_dispatch_failure_rollback(client, stub_generate_visual_plan_services):
     """Celery dispatch failure triggers rollback to original stage."""
     run_svc, _ = stub_generate_visual_plan_services
-    run_svc.runs[36] = _make_run(36, "SCRIPT_REVIEW")
+    run_svc.runs[36] = _make_run(36, "VISUAL_PLAN_SETUP")
 
     def failing_dispatcher(run_id, model_key, style_preset):
         raise RuntimeError("Celery broker down")
@@ -1050,13 +1093,13 @@ async def test_generate_visual_plan_dispatch_failure_rollback(client, stub_gener
     # Rollback: CAS was called twice — first to advance, then to rollback
     cas_calls = run_svc.storage.conditional_update_calls
     assert len(cas_calls) == 2
-    # Second CAS = rollback to SCRIPT_REVIEW
+    # Second CAS = rollback to VISUAL_PLAN_SETUP
     rollback = cas_calls[1]
-    assert rollback["updates"]["current_stage"] == "SCRIPT_REVIEW"
+    assert rollback["updates"]["current_stage"] == "VISUAL_PLAN_SETUP"
     assert rollback["expected_stages"] == frozenset({"VISUAL_PLAN_GENERATING"})
 
-    # Verify run was actually rolled back to SCRIPT_REVIEW
-    assert run_svc.runs[36].current_stage == "SCRIPT_REVIEW"
+    # Verify run was actually rolled back to VISUAL_PLAN_SETUP
+    assert run_svc.runs[36].current_stage == "VISUAL_PLAN_SETUP"
 
 
 
@@ -1074,6 +1117,7 @@ class StubImageDispatcher:
     def __call__(
         self, run_id: int, model_key: str, scene_id: str | None,
         prompt_override: str | None, is_active: bool,
+        image_params: dict[str, object] | None = None,
     ) -> str:
         self.calls.append({
             "run_id": run_id,
@@ -1081,6 +1125,7 @@ class StubImageDispatcher:
             "scene_id": scene_id,
             "prompt_override": prompt_override,
             "is_active": is_active,
+            "image_params": image_params,
         })
         return self.task_id
 
@@ -1125,7 +1170,9 @@ async def test_generate_visual_assets_from_visual_plan_review(client, stub_gener
         "scene_id": None,
         "prompt_override": None,
         "is_active": True,
+        "image_params": None,
     }]
+    assert run_svc.storage.append_task_calls == [{"run_id": 60, "task_id": "test-img-task-id-789"}]
 
 
 @pytest.mark.asyncio
@@ -1232,7 +1279,7 @@ async def test_generate_visual_assets_dispatch_failure_rollback(client, stub_gen
     run_svc, _ = stub_generate_visual_assets_services
     run_svc.runs[66] = _make_run(66, "VISUAL_PLAN_REVIEW")
 
-    def failing_dispatcher(run_id, model_key, scene_id, prompt_override, is_active):
+    def failing_dispatcher(run_id, model_key, scene_id, prompt_override, is_active, image_params=None):
         raise RuntimeError("Celery broker down")
 
     from shorts_api.main import runs_router as _r
@@ -1299,6 +1346,7 @@ async def test_generate_scene_image_from_visual_plan_review(client, stub_single_
         "scene_id": "scene-sec-0",
         "prompt_override": None,
         "is_active": True,
+        "image_params": None,
     }]
 
 
@@ -1344,7 +1392,7 @@ async def test_generate_scene_image_dispatch_failure(client, stub_single_scene_s
     run_svc, _ = stub_single_scene_services
     run_svc.runs[73] = _make_run(73, "VISUAL_PLAN_REVIEW")
 
-    def failing_dispatcher(run_id, model_key, scene_id, prompt_override, is_active):
+    def failing_dispatcher(run_id, model_key, scene_id, prompt_override, is_active, image_params=None):
         raise RuntimeError("Celery broker down")
 
     for route in runs_router.routes:
@@ -1386,6 +1434,7 @@ async def test_regenerate_scene_image_success(client, stub_single_scene_services
         "scene_id": "scene-sec-0",
         "prompt_override": "A dark moody scene",
         "is_active": False,  # regenerated assets are inactive
+        "image_params": None,
     }]
 
 
@@ -1448,7 +1497,7 @@ async def test_regenerate_scene_image_dispatch_failure(client, stub_single_scene
     run_svc, _ = stub_single_scene_services
     run_svc.runs[84] = _make_run(84, "VISUAL_ASSET_REVIEW")
 
-    def failing_dispatcher(run_id, model_key, scene_id, prompt_override, is_active):
+    def failing_dispatcher(run_id, model_key, scene_id, prompt_override, is_active, image_params=None):
         raise RuntimeError("Celery broker down")
 
     for route in runs_router.routes:
@@ -1925,7 +1974,7 @@ async def test_generate_audio_default_model(client, stub_generate_audio_services
 
     assert response.status_code == 202
     assert dispatcher.calls[0]["tts_model"] == "qwen3-tts"
-    assert dispatcher.calls[0]["voice"] == "en_US-lessac-medium"
+    assert dispatcher.calls[0]["voice"] == "default"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -213,13 +213,28 @@ class StubStageReviewService:
         self._run_svc.runs[run_id] = updated
         return updated
 
+
+class StubProjectLookupService:
+    def __init__(self, existing_project_ids: set[int] | None = None) -> None:
+        self.existing_project_ids = existing_project_ids or {7, 8}
+        self.get_project_calls: list[int] = []
+
+    async def get_project(self, project_id: int) -> object | None:
+        self.get_project_calls.append(project_id)
+        if project_id in self.existing_project_ids:
+            return {"id": project_id}
+        return None
+
 @pytest.fixture
 def stub_run_service(monkeypatch: pytest.MonkeyPatch) -> StubRunService:
     service = StubRunService()
+    project_lookup = StubProjectLookupService()
 
     for route in runs_router.routes:
         if route.name in {"create_run", "get_run_detail", "restart_run", "approve_script", "generate_script_trigger", "generate_visual_plan_trigger", "generate_audio_trigger", "generate_subtitles_trigger", "list_runs_for_project"}:
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", service)
+        if route.name == "create_run":
+            monkeypatch.setitem(route.endpoint.__globals__, "project_service", project_lookup)
 
     return service
 
@@ -268,6 +283,18 @@ async def test_create_run_minimal(client, stub_run_service: StubRunService):
     assert body["model_defaults"] is None
     assert body["metadata"] is None
     assert body["style_preset"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_create_run_project_not_found(client, stub_run_service: StubRunService):
+    _ = stub_run_service
+    response = await client.post(
+        "/api/creator/projects/999/runs",
+        json={"style_preset": "default"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Project not found"}
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -17,6 +17,8 @@ class StubProject(BaseModel):
 class StubPipelineRun(BaseModel):
     id: int
     project_id: int
+    current_stage: str = "IDEA_READY"
+    status: str = "pending"
 
 
 class StubScriptDraft(BaseModel):
@@ -56,6 +58,8 @@ class StubRunService:
         model_defaults: dict[str, str] | None,
         style_preset: str,
         metadata: dict[str, object] | None = None,
+        current_stage: str = "IDEA_READY",
+        status: str = "pending",
     ) -> StubPipelineRun:
         if self.raise_error_message is not None:
             raise ValueError(self.raise_error_message)
@@ -66,9 +70,16 @@ class StubRunService:
                 "model_defaults": model_defaults,
                 "style_preset": style_preset,
                 "metadata": metadata,
+                "current_stage": current_stage,
+                "status": status,
             }
         )
-        run = StubPipelineRun(id=self.next_run_id, project_id=project_id)
+        run = StubPipelineRun(
+            id=self.next_run_id,
+            project_id=project_id,
+            current_stage=current_stage,
+            status=status,
+        )
         self.next_run_id += 1
         return run
 
@@ -181,6 +192,8 @@ async def test_import_markdown_success(client, stub_services):
             "model_defaults": None,
             "style_preset": "default",
             "metadata": None,
+            "current_stage": "SCRIPT_REVIEW",
+            "status": "running",
         }
     ]
     assert script_service.save_draft_calls == [
@@ -252,6 +265,8 @@ async def test_import_markdown_with_model_defaults(client, stub_services):
             },
             "style_preset": "cinematic",
             "metadata": None,
+            "current_stage": "SCRIPT_REVIEW",
+            "status": "running",
         }
     ]
 
@@ -288,6 +303,8 @@ async def test_import_markdown_service_error(client, stub_services):
             "model_defaults": None,
             "style_preset": "default",
             "metadata": None,
+            "current_stage": "SCRIPT_REVIEW",
+            "status": "running",
         }
     ]
 

--- a/apps/studio-web/src/App.tsx
+++ b/apps/studio-web/src/App.tsx
@@ -11,7 +11,7 @@ import SettingsPage from "./pages/SettingsPage";
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Routes>
         <Route element={<AppShell />}>
           <Route path="/create" element={<CreatePage />} />

--- a/apps/studio-web/src/__tests__/App.test.tsx
+++ b/apps/studio-web/src/__tests__/App.test.tsx
@@ -16,7 +16,7 @@ describe('App', () => {
 
   it('renders CreatePage without crashing', () => {
     render(
-      <MemoryRouter>
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <CreatePage />
       </MemoryRouter>
     );

--- a/apps/studio-web/src/__tests__/AppShell.test.tsx
+++ b/apps/studio-web/src/__tests__/AppShell.test.tsx
@@ -6,7 +6,7 @@ import AppShell from "../components/layout/AppShell";
 
 function renderWithRoute(path: string) {
   return render(
-    <MemoryRouter initialEntries={[path]}>
+    <MemoryRouter initialEntries={[path]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Routes>
         <Route element={<AppShell />}>
           <Route path="/create" element={<div>CreatePage</div>} />
@@ -85,7 +85,7 @@ describe("AppShell", () => {
 
   it("redirects unknown routes to /create", () => {
     render(
-      <MemoryRouter initialEntries={["/unknown-page"]}>
+      <MemoryRouter initialEntries={["/unknown-page"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Routes>
           <Route element={<AppShell />}>
             <Route path="/create" element={<div>CreatePage</div>} />
@@ -99,7 +99,7 @@ describe("AppShell", () => {
 
   it("redirects root / to /create", () => {
     render(
-      <MemoryRouter initialEntries={["/"]}>
+      <MemoryRouter initialEntries={["/"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Routes>
           <Route element={<AppShell />}>
             <Route path="/create" element={<div>CreatePage</div>} />
@@ -113,7 +113,7 @@ describe("AppShell", () => {
 
   it("deep links to /ops still work after redirect setup", () => {
     render(
-      <MemoryRouter initialEntries={["/ops"]}>
+      <MemoryRouter initialEntries={["/ops"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Routes>
           <Route element={<AppShell />}>
             <Route path="/create" element={<div>CreatePage</div>} />
@@ -128,7 +128,7 @@ describe("AppShell", () => {
 
   it("deep links to /runs still work after redirect setup", () => {
     render(
-      <MemoryRouter initialEntries={["/runs"]}>
+      <MemoryRouter initialEntries={["/runs"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Routes>
           <Route element={<AppShell />}>
             <Route path="/create" element={<div>CreatePage</div>} />
@@ -143,7 +143,7 @@ describe("AppShell", () => {
 
   it("redirects legacy /library to /ops/library", () => {
     render(
-      <MemoryRouter initialEntries={["/library"]}>
+      <MemoryRouter initialEntries={["/library"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Routes>
           <Route element={<AppShell />}>
             <Route path="/create" element={<div>CreatePage</div>} />
@@ -159,7 +159,7 @@ describe("AppShell", () => {
 
   it("renders LibraryPage at /ops/library directly", () => {
     render(
-      <MemoryRouter initialEntries={["/ops/library"]}>
+      <MemoryRouter initialEntries={["/ops/library"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Routes>
           <Route element={<AppShell />}>
             <Route path="/create" element={<div>CreatePage</div>} />

--- a/apps/studio-web/src/__tests__/CreatePage.test.tsx
+++ b/apps/studio-web/src/__tests__/CreatePage.test.tsx
@@ -51,7 +51,7 @@ function mockFetchFullFlow() {
 
 function renderCreatePage() {
   return render(
-    <MemoryRouter>
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <CreatePage />
     </MemoryRouter>,
   );
@@ -169,6 +169,16 @@ describe("CreatePage", () => {
     // Should NOT show TTS or STT
     expect(screen.queryByText("TTS Model")).toBeNull();
     expect(screen.queryByText("STT Model")).toBeNull();
+  });
+
+  it("shows only image model on markdown tab", async () => {
+    renderCreatePage();
+    fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+    expect(screen.getByText("Image Model")).toBeTruthy();
+    expect(screen.queryByText("Script Model")).toBeNull();
   });
 
   it("has proper tablist and tabpanel roles", () => {
@@ -408,6 +418,9 @@ describe("CreatePage", () => {
   it("does not submit markdown when content is empty", async () => {
     mockFetchFullFlow();
     renderCreatePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
     fireEvent.click(screen.getByRole("tab", { name: "Start from Markdown" }));
 
     // Leave markdown content empty, just set title
@@ -416,9 +429,9 @@ describe("CreatePage", () => {
     fireEvent.change(screen.getByLabelText(/Markdown Content/), { target: { value: "" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
 
-    // Should NOT navigate since markdown is empty
-    await new Promise((r) => setTimeout(r, 100));
-    expect(mockNavigate).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 
   it("shows error when import-markdown fails", async () => {

--- a/apps/studio-web/src/__tests__/CreatePage.test.tsx
+++ b/apps/studio-web/src/__tests__/CreatePage.test.tsx
@@ -288,6 +288,35 @@ describe("CreatePage", () => {
     expect(runBody.model_defaults.render_profile).toBe("high_quality");
   });
 
+  it("sends backend model-default field names from CreatePage selectors", async () => {
+    mockFetchFullFlow();
+    renderCreatePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("model-selector")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText(/^Title/), { target: { value: "My Video" } });
+    fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "Brief" } });
+
+    fireEvent.click(screen.getByLabelText(/Qwen3 4B/i));
+    fireEvent.click(screen.getByLabelText(/SD 1.5/i));
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/projects/42");
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const runCall = calls.find((c: unknown[]) => typeof c[0] === "string" && c[0].includes("/runs"));
+    const runBody = JSON.parse((runCall![1] as RequestInit).body as string);
+
+    expect(runBody.model_defaults.script_model).toBe("qwen3-4b");
+    expect(runBody.model_defaults.image_model).toBe("sd15");
+    expect(runBody.model_defaults.script).toBeUndefined();
+    expect(runBody.model_defaults.image).toBeUndefined();
+  });
+
   it("shows error when project creation fails", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
       const url = typeof input === "string" ? input : (input as Request).url;

--- a/apps/studio-web/src/__tests__/CreatePage.test.tsx
+++ b/apps/studio-web/src/__tests__/CreatePage.test.tsx
@@ -141,6 +141,15 @@ describe("CreatePage", () => {
     expect(select.value).toBe("cinematic");
   });
 
+  it("render profile select works", () => {
+    renderCreatePage();
+    const select = screen.getByLabelText(/Render Profile/) as HTMLSelectElement;
+    expect(select.value).toBe("shorts_default");
+
+    fireEvent.change(select, { target: { value: "high_quality" } });
+    expect(select.value).toBe("high_quality");
+  });
+
   it("has submit button", () => {
     renderCreatePage();
     expect(screen.getByRole("button", { name: "Create Project" })).toBeTruthy();
@@ -260,6 +269,7 @@ describe("CreatePage", () => {
     fireEvent.change(screen.getByLabelText(/Idea Brief/), { target: { value: "Brief" } });
     fireEvent.change(screen.getByLabelText(/Content Goal/), { target: { value: "educational" } });
     fireEvent.change(screen.getByLabelText(/Target Duration/), { target: { value: "90" } });
+    fireEvent.change(screen.getByLabelText(/Render Profile/), { target: { value: "high_quality" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
 
@@ -275,6 +285,7 @@ describe("CreatePage", () => {
     expect(runBody.metadata.content_goal).toBe("educational");
     expect(runBody.metadata.target_duration).toBe(90);
     expect(runBody.style_preset).toBe("default");
+    expect(runBody.model_defaults.render_profile).toBe("high_quality");
   });
 
   it("shows error when project creation fails", async () => {

--- a/apps/studio-web/src/__tests__/ModelSelector.test.tsx
+++ b/apps/studio-web/src/__tests__/ModelSelector.test.tsx
@@ -104,9 +104,11 @@ describe("ModelSelector", () => {
     expect(gptRadio).not.toBeChecked();
 
     // Parent should have been notified of default selections
-    expect(onChange).toHaveBeenCalledWith("script", "qwen3-4b");
-    expect(onChange).toHaveBeenCalledWith("image", "sd15");
-    expect(onChange).toHaveBeenCalledWith("tts", "qwen3-tts");
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith("script", "qwen3-4b");
+      expect(onChange).toHaveBeenCalledWith("image", "sd15");
+      expect(onChange).toHaveBeenCalledWith("tts", "qwen3-tts");
+    });
   });
 
   it("respects controlled mode with selectedModels prop", async () => {
@@ -209,8 +211,10 @@ describe("ModelSelector", () => {
     });
 
     // Initial defaults should have fired for script + image
-    expect(onChange).toHaveBeenCalledWith("script", "qwen3-4b");
-    expect(onChange).toHaveBeenCalledWith("image", "sd15");
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith("script", "qwen3-4b");
+      expect(onChange).toHaveBeenCalledWith("image", "sd15");
+    });
     const initialCallCount = onChange.mock.calls.length;
     onChange.mockClear();
 

--- a/apps/studio-web/src/__tests__/OpsPage.test.tsx
+++ b/apps/studio-web/src/__tests__/OpsPage.test.tsx
@@ -5,7 +5,7 @@ import OpsPage from "../pages/OpsPage";
 
 function renderPage() {
   return render(
-    <MemoryRouter>
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <OpsPage />
     </MemoryRouter>,
   );

--- a/apps/studio-web/src/__tests__/PipelineStepper.test.tsx
+++ b/apps/studio-web/src/__tests__/PipelineStepper.test.tsx
@@ -100,6 +100,18 @@ describe("PipelineStepper", () => {
     expect(screen.getByText("Render")).toBeInTheDocument();
   });
 
+  it("uses source-aware first label for markdown projects", () => {
+    render(<PipelineStepper currentStage="SCRIPT_REVIEW" sourceType="markdown" />);
+    expect(screen.getByText("Markdown")).toBeInTheDocument();
+    expect(screen.queryByText("Idea")).not.toBeInTheDocument();
+  });
+
+  it("uses source-aware first label for url projects", () => {
+    render(<PipelineStepper currentStage="SCRIPT_REVIEW" sourceType="url" />);
+    expect(screen.getByText("URL")).toBeInTheDocument();
+    expect(screen.queryByText("Idea")).not.toBeInTheDocument();
+  });
+
   it("shows checkmark for completed steps", () => {
     render(<PipelineStepper currentStage="VISUAL_PLAN_GENERATING" />);
     // Idea and Script are completed — should show ✓

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -488,7 +488,7 @@ describe("ProjectPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("visual-plan-editor")).toBeInTheDocument();
     });
-    expect(screen.getByText("Script Model")).toBeInTheDocument();
+    expect(screen.getAllByText("Script Model").length).toBeGreaterThan(0);
     // Approve and Regenerate Plan visible
     expect(screen.getByRole("button", { name: "Approve Visual Plan" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Regenerate Plan" })).toBeInTheDocument();

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -327,9 +327,9 @@ describe("ProjectPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("generating-indicator")).toBeInTheDocument();
     });
-    expect(screen.getByText("Generating Script…")).toBeInTheDocument();
-    // Editor tabs should NOT be visible during generation
-    expect(screen.queryByRole("tab", { name: "Markdown" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Generating Script/i)).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Markdown" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Structured" })).toBeInTheDocument();
   });
 
   // ---- Approve action ----
@@ -478,9 +478,8 @@ describe("ProjectPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("vp-generating-indicator")).toBeInTheDocument();
     });
-    expect(screen.getByText("Generating Visual Plan\u2026")).toBeInTheDocument();
-    // Script editor tabs should NOT be visible
-    expect(screen.queryByRole("tab", { name: "Markdown" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Generating Visual Plan/i)).toBeInTheDocument();
+    expect(screen.getByText("Visual Plan Setup")).toBeInTheDocument();
   });
 
   it("shows VisualPlanEditor and action buttons for VISUAL_PLAN_REVIEW", async () => {

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -746,8 +746,8 @@ describe("ProjectPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
     });
-    // Render Video and Restart from Script buttons should be in action bar
-    expect(screen.getByRole("button", { name: "Render Video" })).toBeInTheDocument();
+    // Render should not be offered before subtitle stage
+    expect(screen.queryByRole("button", { name: "Render Video" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Restart from Script" })).toBeInTheDocument();
   });
 
@@ -757,6 +757,8 @@ describe("ProjectPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: "Render Video" })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Render Profile/)).toBeInTheDocument();
   });
 
   it("shows storyboard view for RENDER_GENERATING", async () => {
@@ -796,5 +798,35 @@ describe("ProjectPage", () => {
       expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
     });
     expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+  });
+
+  it("hides idea-only go-back action for markdown-source script review", async () => {
+    mockFetchProjectAndRuns({ ...MOCK_PROJECT, source_type: "markdown" }, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Approve Script" })).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("go-back-btn")).not.toBeInTheDocument();
+  });
+
+  it("uses selected render profile when rendering from subtitle stage", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_SUBTITLE_GENERATING]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Render Video" })).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fireEvent.change(screen.getByLabelText(/Render Profile/), { target: { value: "high_quality" } });
+    fireEvent.click(screen.getByRole("button", { name: "Render Video" }));
+
+    await waitFor(() => {
+      const renderCall = fetchSpy.mock.calls.find(([url]) =>
+        (typeof url === "string" ? url : (url as Request).url).includes("/render")
+      );
+      expect(renderCall).toBeTruthy();
+      const body = JSON.parse((renderCall![1] as RequestInit).body as string);
+      expect(body.render_profile).toBe("high_quality");
+    });
   });
 });

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -478,6 +478,7 @@ describe("ProjectPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("visual-plan-editor")).toBeInTheDocument();
     });
+    expect(screen.getByText("Script Model")).toBeInTheDocument();
     // Approve and Regenerate Plan visible
     expect(screen.getByRole("button", { name: "Approve Visual Plan" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Regenerate Plan" })).toBeInTheDocument();
@@ -511,6 +512,8 @@ describe("ProjectPage", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Generate Visual Plan" })).toBeInTheDocument();
     });
+    expect(screen.getByText("Script Model")).toBeInTheDocument();
+    expect(screen.queryByText("Image Model")).not.toBeInTheDocument();
   });
 
   it("calls generate-visual-plan endpoint from VISUAL_PLAN_SETUP", async () => {
@@ -620,6 +623,7 @@ describe("ProjectPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("visual-asset-section")).toBeInTheDocument();
     });
+    expect(screen.getAllByText("Image Model").length).toBeGreaterThan(0);
   });
 
   it("shows scene regen controls in VISUAL_ASSET_REVIEW", async () => {

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -10,6 +10,7 @@ const MOCK_PROJECT: {
   title: string | null;
   source_type: string;
   status: string;
+  latest_run?: { run_id: number; current_stage: string | null; status: string | null } | null;
   created_at: string;
   updated_at: string;
 } = {
@@ -17,6 +18,7 @@ const MOCK_PROJECT: {
   title: "My Short",
   source_type: "idea",
   status: "active",
+  latest_run: { run_id: 1, current_stage: "IDEA_READY", status: "pending" },
   created_at: "2025-03-15T10:00:00Z",
   updated_at: "2025-03-15T12:00:00Z",
 };
@@ -255,6 +257,15 @@ describe("ProjectPage", () => {
       expect(screen.getByText(/Source: idea/)).toBeInTheDocument();
     });
     expect(screen.getByText(/Status: active/)).toBeInTheDocument();
+  });
+
+  it("shows run status and stage metadata when a run exists", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Status: running/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Stage: SCRIPT_REVIEW/)).toBeInTheDocument();
   });
 
   // ---- Project with run in IDEA_READY ----

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -79,7 +79,7 @@ vi.mock("react-router-dom", async () => {
 
 function renderPage(projectId = "7") {
   return render(
-    <MemoryRouter initialEntries={[`/projects/${projectId}`]}>
+    <MemoryRouter initialEntries={[`/projects/${projectId}`]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Routes>
         <Route path="/projects/:projectId" element={<ProjectPage />} />
       </Routes>
@@ -228,7 +228,7 @@ describe("ProjectPage", () => {
   // ---- Invalid project ID ----
   it("shows invalid ID message for non-numeric id", () => {
     render(
-      <MemoryRouter initialEntries={["/projects/abc"]}>
+      <MemoryRouter initialEntries={["/projects/abc"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Routes>
           <Route path="/projects/:projectId" element={<ProjectPage />} />
         </Routes>

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -302,10 +302,11 @@ describe("ProjectPage", () => {
 
     // Switch to structured
     fireEvent.click(screen.getByRole("tab", { name: "Structured" }));
-
-    const stTab = screen.getByRole("tab", { name: "Structured" });
-    expect(stTab.getAttribute("aria-selected")).toBe("true");
-    expect(mdTab.getAttribute("aria-selected")).toBe("false");
+    await waitFor(() => {
+      const stTab = screen.getByRole("tab", { name: "Structured" });
+      expect(stTab.getAttribute("aria-selected")).toBe("true");
+      expect(mdTab.getAttribute("aria-selected")).toBe("false");
+    });
   });
 
   // ---- SCRIPT_GENERATING state ----

--- a/apps/studio-web/src/__tests__/ReviewPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ReviewPage.test.tsx
@@ -69,7 +69,7 @@ const MOCK_PREVIEW = {
 
 function renderPage(runId = "10") {
   return render(
-    <MemoryRouter initialEntries={[`/review/${runId}`]}>
+    <MemoryRouter initialEntries={[`/review/${runId}`]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Routes>
         <Route path="/review/:runId" element={<ReviewPage />} />
       </Routes>

--- a/apps/studio-web/src/__tests__/ReviewPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ReviewPage.test.tsx
@@ -160,7 +160,7 @@ beforeEach(() => {
 
 describe("ReviewPage", () => {
   it("shows loading state initially", () => {
-    mockFetchAll(MOCK_RUN_FINAL_REVIEW);
+    vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise(() => {}));
     renderPage();
     expect(screen.getByRole("status")).toHaveTextContent("Loading review");
   });

--- a/apps/studio-web/src/__tests__/ReviewPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ReviewPage.test.tsx
@@ -194,7 +194,7 @@ describe("ReviewPage", () => {
     });
 
     // Script section
-    expect(screen.getByText(/calm morning in Tokyo/)).toBeTruthy();
+    expect(screen.getAllByText(/calm morning in Tokyo/i).length).toBeGreaterThan(0);
 
     // Visual plan section
     expect(screen.getByTestId("review-visual-plan-section")).toBeTruthy();

--- a/apps/studio-web/src/__tests__/RouteSmoke.test.tsx
+++ b/apps/studio-web/src/__tests__/RouteSmoke.test.tsx
@@ -40,7 +40,7 @@ vi.mock("../pages/LibraryPage", () => ({
  */
 function renderApp(path: string) {
   return render(
-    <MemoryRouter initialEntries={[path]}>
+    <MemoryRouter initialEntries={[path]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Routes>
         <Route element={<AppShell />}>
           <Route path="/create" element={<StubPage testId="page-create" />} />

--- a/apps/studio-web/src/__tests__/RunsPage.test.tsx
+++ b/apps/studio-web/src/__tests__/RunsPage.test.tsx
@@ -9,6 +9,7 @@ const MOCK_PROJECTS = [
     title: "Morning Routine",
     source_type: "idea",
     status: "active",
+    latest_run: { run_id: 11, current_stage: "SCRIPT_REVIEW", status: "running" },
     created_at: "2025-03-15T10:00:00Z",
     updated_at: "2025-03-15T12:00:00Z",
   },
@@ -17,6 +18,7 @@ const MOCK_PROJECTS = [
     title: "Cooking Tips",
     source_type: "markdown",
     status: "draft",
+    latest_run: null,
     created_at: "2025-03-14T08:00:00Z",
     updated_at: "2025-03-14T09:00:00Z",
   },
@@ -25,6 +27,7 @@ const MOCK_PROJECTS = [
     title: null,
     source_type: "url",
     status: "completed",
+    latest_run: { run_id: 14, current_stage: "FINAL_REVIEW", status: "completed" },
     created_at: "2025-03-13T06:00:00Z",
     updated_at: "2025-03-13T07:00:00Z",
   },
@@ -164,10 +167,18 @@ describe("RunsPage", () => {
     mockFetchOk(MOCK_PROJECTS);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText("active")).toBeInTheDocument();
+      expect(screen.getByText("running")).toBeInTheDocument();
     });
     expect(screen.getByText("draft")).toBeInTheDocument();
     expect(screen.getByText("completed")).toBeInTheDocument();
+  });
+
+  it("shows latest run stage when available", async () => {
+    mockFetchOk(MOCK_PROJECTS);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("SCRIPT_REVIEW")).toBeInTheDocument();
+    });
   });
 
   it("renders formatted dates", async () => {

--- a/apps/studio-web/src/__tests__/RunsPage.test.tsx
+++ b/apps/studio-web/src/__tests__/RunsPage.test.tsx
@@ -276,7 +276,7 @@ describe("RunsPage", () => {
 
   // --- Header ---
   it("renders page heading", async () => {
-    mockFetchOk([]);
+    vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise(() => {}));
     renderPage();
     expect(screen.getByRole("heading", { name: "Projects" })).toBeInTheDocument();
   });

--- a/apps/studio-web/src/__tests__/RunsPage.test.tsx
+++ b/apps/studio-web/src/__tests__/RunsPage.test.tsx
@@ -38,7 +38,7 @@ vi.mock("react-router-dom", async () => {
 
 function renderPage() {
   return render(
-    <MemoryRouter initialEntries={["/runs"]}>
+    <MemoryRouter initialEntries={["/runs"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <RunsPage />
     </MemoryRouter>,
   );

--- a/apps/studio-web/src/components/creator/MarkdownScriptEditor.tsx
+++ b/apps/studio-web/src/components/creator/MarkdownScriptEditor.tsx
@@ -22,6 +22,12 @@ export interface MarkdownScriptEditorProps {
   onError?: (action: "load" | "save" | "parse", message: string) => void;
   /** Whether the editor should be read-only. */
   readOnly?: boolean;
+  /** Optional polling interval for reloading content while generation is in progress. */
+  pollIntervalMs?: number;
+  /** Treat missing draft as a waiting state instead of an error. */
+  suppressMissingDraftError?: boolean;
+  /** Message shown when the draft is not available yet. */
+  pendingMessage?: string;
 }
 
 // --------------- component ---------------
@@ -32,6 +38,9 @@ export default function MarkdownScriptEditor({
   onSuccess,
   onError,
   readOnly = false,
+  pollIntervalMs,
+  suppressMissingDraftError = false,
+  pendingMessage = "Waiting for generated script…",
 }: MarkdownScriptEditorProps) {
   const [markdown, setMarkdown] = useState("");
   const [savedMarkdown, setSavedMarkdown] = useState("");
@@ -40,44 +49,67 @@ export default function MarkdownScriptEditor({
   const [saving, setSaving] = useState(false);
   const [parsing, setParsing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingDraft, setPendingDraft] = useState(false);
 
   const isDirty = markdown !== savedMarkdown;
 
   // Load markdown on mount / runId change
-  useEffect(() => {
-    let cancelled = false;
-
-    async function load() {
-      setLoading(true);
+  const load = useCallback(
+    async (showLoading: boolean) => {
+      if (showLoading) setLoading(true);
       setError(null);
       try {
         const res = await fetch(`${apiBase}/runs/${runId}/script/markdown`);
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
-          throw new Error(body.detail ?? `Failed to load (${res.status})`);
+          const detail = body.detail ?? `Failed to load (${res.status})`;
+          if (
+            suppressMissingDraftError &&
+            typeof detail === "string" &&
+            detail.toLowerCase().includes("no script draft")
+          ) {
+            setMarkdown("");
+            setSavedMarkdown("");
+            setVersion(null);
+            setPendingDraft(true);
+            return;
+          }
+          throw new Error(detail);
         }
         const data = await res.json();
-        if (!cancelled) {
-          setMarkdown(data.markdown ?? "");
-          setSavedMarkdown(data.markdown ?? "");
-          setVersion(data.version ?? null);
-        }
+        setMarkdown(data.markdown ?? "");
+        setSavedMarkdown(data.markdown ?? "");
+        setVersion(data.version ?? null);
+        setPendingDraft(false);
       } catch (err) {
-        if (!cancelled) {
-          const msg = err instanceof Error ? err.message : "Failed to load script";
-          setError(msg);
-          onError?.("load", msg);
-        }
+        const msg = err instanceof Error ? err.message : "Failed to load script";
+        setError(msg);
+        onError?.("load", msg);
       } finally {
-        if (!cancelled) setLoading(false);
+        if (showLoading) setLoading(false);
       }
-    }
+    },
+    [apiBase, runId, suppressMissingDraftError, onError],
+  );
 
-    load();
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      await load(true);
+      if (cancelled) return;
+    })();
     return () => {
       cancelled = true;
     };
-  }, [apiBase, runId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [load]);
+
+  useEffect(() => {
+    if (!pollIntervalMs) return;
+    const timer = setInterval(() => {
+      void load(false);
+    }, pollIntervalMs);
+    return () => clearInterval(timer);
+  }, [pollIntervalMs, load]);
 
   // Save markdown
   const handleSave = useCallback(async () => {
@@ -161,6 +193,22 @@ export default function MarkdownScriptEditor({
           }}
         >
           {error}
+        </div>
+      )}
+
+      {pendingDraft && !error && (
+        <div
+          data-testid="markdown-pending"
+          style={{
+            padding: "8px 12px",
+            marginBottom: 12,
+            backgroundColor: "#eff6ff",
+            color: "#1e40af",
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {pendingMessage}
         </div>
       )}
 

--- a/apps/studio-web/src/components/creator/PipelineStepper.tsx
+++ b/apps/studio-web/src/components/creator/PipelineStepper.tsx
@@ -45,6 +45,8 @@ export interface PipelineStepperProps {
   currentStage: string;
   /** True when the run is in FAILED state. */
   failed?: boolean;
+  /** Entry source type for source-aware first-step label. */
+  sourceType?: "idea" | "markdown" | "url";
 }
 
 // --------------- styles ---------------
@@ -78,7 +80,11 @@ function getStepStatus(stepIdx: number, activeIdx: number, isFailed: boolean): S
 
 // --------------- component ---------------
 
-export default function PipelineStepper({ currentStage, failed = false }: PipelineStepperProps) {
+export default function PipelineStepper({
+  currentStage,
+  failed = false,
+  sourceType = "idea",
+}: PipelineStepperProps) {
   const activeIdx = resolveStepIndex(currentStage);
 
   // For PUBLISHED, bump activeIdx past all steps so all show completed.
@@ -100,6 +106,14 @@ export default function PipelineStepper({ currentStage, failed = false }: Pipeli
           const status = getStepStatus(idx, effectiveIdx, failed);
           const colors = COLORS[status];
           const isLast = idx === PIPELINE_STEPS.length - 1;
+          const label =
+            step.key === "idea"
+              ? sourceType === "markdown"
+                ? "Markdown"
+                : sourceType === "url"
+                  ? "URL"
+                  : step.label
+              : step.label;
 
           return (
             <li
@@ -144,7 +158,7 @@ export default function PipelineStepper({ currentStage, failed = false }: Pipeli
                     whiteSpace: "nowrap",
                   }}
                 >
-                  {step.label}
+                  {label}
                 </span>
               </div>
 

--- a/apps/studio-web/src/components/creator/StoryboardView.tsx
+++ b/apps/studio-web/src/components/creator/StoryboardView.tsx
@@ -33,6 +33,8 @@ export interface StoryboardViewProps {
   onRenderReady?: () => void;
   /** Polling interval in ms. Default 5000. */
   pollInterval?: number;
+  /** Current pipeline stage, used to keep polling during long-running stages. */
+  currentStage?: string;
   /** TTS model key passed from parent model selection */
   ttsModel?: string;
   /** Subtitle (STT) model key passed from parent model selection */
@@ -92,6 +94,7 @@ export default function StoryboardView({
   onStatusMessage,
   onRenderReady,
   pollInterval = 5000,
+  currentStage,
   ttsModel,
   subtitleModel,
 }: StoryboardViewProps) {
@@ -104,6 +107,7 @@ export default function StoryboardView({
   const hasGenerating = storyboard?.paragraphs.some(
     (p) => p.status.startsWith("generating_"),
   ) ?? false;
+  const stageImpliesPolling = currentStage === "AUDIO_GENERATING" || currentStage === "SUBTITLE_GENERATING" || currentStage === "RENDER_GENERATING";
 
   const loadStoryboard = useCallback(async () => {
     try {
@@ -124,12 +128,12 @@ export default function StoryboardView({
 
   // Polling while generating
   useEffect(() => {
-    if (!hasGenerating && !bulkGenerating) return;
+    if (!hasGenerating && !bulkGenerating && !stageImpliesPolling) return;
     const timer = setInterval(() => {
       loadStoryboard();
     }, pollInterval);
     return () => clearInterval(timer);
-  }, [hasGenerating, bulkGenerating, pollInterval, loadStoryboard]);
+  }, [hasGenerating, bulkGenerating, stageImpliesPolling, pollInterval, loadStoryboard]);
 
   // Notify when render-ready
   useEffect(() => {

--- a/apps/studio-web/src/components/creator/StructuredScriptEditor.tsx
+++ b/apps/studio-web/src/components/creator/StructuredScriptEditor.tsx
@@ -33,6 +33,9 @@ export interface StructuredScriptEditorProps {
   onSuccess?: (data: Record<string, unknown>) => void;
   onError?: (action: "load" | "save", message: string) => void;
   readOnly?: boolean;
+  pollIntervalMs?: number;
+  suppressMissingDraftError?: boolean;
+  pendingMessage?: string;
 }
 
 // --------------- helpers ---------------
@@ -244,6 +247,9 @@ export default function StructuredScriptEditor({
   onSuccess,
   onError,
   readOnly = false,
+  pollIntervalMs,
+  suppressMissingDraftError = false,
+  pendingMessage = "Waiting for generated sections…",
 }: StructuredScriptEditorProps) {
   const [sections, setSections] = useState<SectionData[]>([]);
   const [savedSections, setSavedSections] = useState<SectionData[]>([]);
@@ -251,41 +257,66 @@ export default function StructuredScriptEditor({
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingDraft, setPendingDraft] = useState(false);
 
   const isDirty = !deepEqual(sections, savedSections);
 
   // Load sections
-  useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      setLoading(true);
+  const load = useCallback(
+    async (showLoading: boolean) => {
+      if (showLoading) setLoading(true);
       setError(null);
       try {
         const res = await fetch(`${apiBase}/runs/${runId}/script/structured`);
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
-          throw new Error(body.detail ?? `Failed to load (${res.status})`);
+          const detail = body.detail ?? `Failed to load (${res.status})`;
+          if (
+            suppressMissingDraftError &&
+            typeof detail === "string" &&
+            detail.toLowerCase().includes("no script draft")
+          ) {
+            setSections([]);
+            setSavedSections([]);
+            setVersion(null);
+            setPendingDraft(true);
+            return;
+          }
+          throw new Error(detail);
         }
         const data = await res.json();
         const loaded = (data.sections ?? []) as SectionData[];
-        if (!cancelled) {
-          setSections(loaded);
-          setSavedSections(loaded);
-          setVersion(data.version ?? null);
-        }
+        setSections(loaded);
+        setSavedSections(loaded);
+        setVersion(data.version ?? null);
+        setPendingDraft(false);
       } catch (err) {
-        if (!cancelled) {
-          const msg = err instanceof Error ? err.message : "Failed to load sections";
-          setError(msg);
-          onError?.("load", msg);
-        }
+        const msg = err instanceof Error ? err.message : "Failed to load sections";
+        setError(msg);
+        onError?.("load", msg);
       } finally {
-        if (!cancelled) setLoading(false);
+        if (showLoading) setLoading(false);
       }
-    }
-    load();
+    },
+    [apiBase, runId, suppressMissingDraftError, onError],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      await load(true);
+      if (cancelled) return;
+    })();
     return () => { cancelled = true; };
-  }, [apiBase, runId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [load]);
+
+  useEffect(() => {
+    if (!pollIntervalMs) return;
+    const timer = setInterval(() => {
+      void load(false);
+    }, pollIntervalMs);
+    return () => clearInterval(timer);
+  }, [pollIntervalMs, load]);
 
   // Field change
   const handleChange = useCallback(
@@ -378,6 +409,22 @@ export default function StructuredScriptEditor({
           }}
         >
           {error}
+        </div>
+      )}
+
+      {pendingDraft && !error && (
+        <div
+          data-testid="structured-pending"
+          style={{
+            padding: "8px 12px",
+            marginBottom: 12,
+            backgroundColor: "#eff6ff",
+            color: "#1e40af",
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {pendingMessage}
         </div>
       )}
 

--- a/apps/studio-web/src/components/creator/VisualPlanEditor.tsx
+++ b/apps/studio-web/src/components/creator/VisualPlanEditor.tsx
@@ -34,6 +34,9 @@ export interface VisualPlanEditorProps {
   onSuccess?: (data: Record<string, unknown>) => void;
   onError?: (action: "load" | "save", message: string) => void;
   readOnly?: boolean;
+  pollIntervalMs?: number;
+  suppressMissingPlanError?: boolean;
+  pendingMessage?: string;
 }
 
 // --------------- styles ---------------
@@ -295,6 +298,9 @@ export default function VisualPlanEditor({
   onSuccess,
   onError,
   readOnly = false,
+  pollIntervalMs,
+  suppressMissingPlanError = false,
+  pendingMessage = "Waiting for generated scenes…",
 }: VisualPlanEditorProps) {
   const [scenes, setScenes] = useState<SceneData[]>([]);
   const [savedScenes, setSavedScenes] = useState<Record<string, SceneData>>({});
@@ -303,44 +309,70 @@ export default function VisualPlanEditor({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dirtyFields, setDirtyFields] = useState<Set<string>>(new Set());
+  const [pendingPlan, setPendingPlan] = useState(false);
 
   // Load plan
-  useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      setLoading(true);
+  const load = useCallback(
+    async (showLoading: boolean) => {
+      if (showLoading) setLoading(true);
       setError(null);
       try {
         const res = await fetch(`${apiBase}/runs/${runId}/visual-plan`);
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
-          throw new Error(body.detail ?? `Failed to load (${res.status})`);
+          const detail = body.detail ?? `Failed to load (${res.status})`;
+          if (
+            suppressMissingPlanError &&
+            typeof detail === "string" &&
+            detail.toLowerCase().includes("no visual plan")
+          ) {
+            setScenes([]);
+            setSavedScenes({});
+            setVersion(null);
+            setDirtyFields(new Set());
+            setPendingPlan(true);
+            return;
+          }
+          throw new Error(detail);
         }
         const data = await res.json();
         const loaded = (data.scenes ?? []) as SceneData[];
-        if (!cancelled) {
-          setScenes(loaded);
-          const saved: Record<string, SceneData> = {};
-          for (const s of loaded) {
-            saved[s.scene_id] = { ...s };
-          }
-          setSavedScenes(saved);
-          setVersion(data.version ?? null);
-          setDirtyFields(new Set());
+        setScenes(loaded);
+        const saved: Record<string, SceneData> = {};
+        for (const s of loaded) {
+          saved[s.scene_id] = { ...s };
         }
+        setSavedScenes(saved);
+        setVersion(data.version ?? null);
+        setDirtyFields(new Set());
+        setPendingPlan(false);
       } catch (err) {
-        if (!cancelled) {
-          const msg = err instanceof Error ? err.message : "Failed to load visual plan";
-          setError(msg);
-          onError?.("load", msg);
-        }
+        const msg = err instanceof Error ? err.message : "Failed to load visual plan";
+        setError(msg);
+        onError?.("load", msg);
       } finally {
-        if (!cancelled) setLoading(false);
+        if (showLoading) setLoading(false);
       }
-    }
-    load();
+    },
+    [apiBase, runId, suppressMissingPlanError, onError],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      await load(true);
+      if (cancelled) return;
+    })();
     return () => { cancelled = true; };
-  }, [apiBase, runId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [load]);
+
+  useEffect(() => {
+    if (!pollIntervalMs) return;
+    const timer = setInterval(() => {
+      void load(false);
+    }, pollIntervalMs);
+    return () => clearInterval(timer);
+  }, [pollIntervalMs, load]);
 
   // Mark scene dirty
   const markDirty = useCallback((sceneId: string) => {
@@ -474,6 +506,22 @@ export default function VisualPlanEditor({
           }}
         >
           {error}
+        </div>
+      )}
+
+      {pendingPlan && !error && (
+        <div
+          data-testid="visual-plan-pending"
+          style={{
+            padding: "8px 12px",
+            marginBottom: 12,
+            backgroundColor: "#eff6ff",
+            color: "#1e40af",
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {pendingMessage}
         </div>
       )}
 

--- a/apps/studio-web/src/pages/CreatePage.tsx
+++ b/apps/studio-web/src/pages/CreatePage.tsx
@@ -65,7 +65,16 @@ export default function CreatePage() {
   stylePresetRef.current = stylePreset;
 
   const handleModelChange = useCallback((category: string, modelKey: string) => {
-    setModelDefaults((prev) => ({ ...prev, [category]: modelKey }));
+    const fieldMap: Record<string, string> = {
+      script: "script_model",
+      image: "image_model",
+      tts: "tts_model",
+      stt: "subtitle_model",
+      render: "render_profile",
+    };
+    const field = fieldMap[category];
+    if (!field) return;
+    setModelDefaults((prev) => ({ ...prev, [field]: modelKey }));
   }, []);
 
   const handleFileUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/studio-web/src/pages/CreatePage.tsx
+++ b/apps/studio-web/src/pages/CreatePage.tsx
@@ -11,6 +11,11 @@ interface MarkdownFormState {
 }
 
 const API_BASE = "/api/creator";
+const RENDER_PROFILE_OPTIONS = [
+  { value: "shorts_default", label: "Shorts Default" },
+  { value: "high_quality", label: "High Quality" },
+  { value: "fast_preview", label: "Fast Preview" },
+];
 const MARKDOWN_TEMPLATE = `## Hook
 
 여러분, AI가 60초 만에 영상을 만들어준다면 믿으시겠어요?
@@ -74,6 +79,10 @@ export default function CreatePage() {
       }
     };
     reader.readAsText(file);
+  }, []);
+
+  const handleRenderProfileChange = useCallback((renderProfile: string) => {
+    setModelDefaults((prev) => ({ ...prev, render_profile: renderProfile }));
   }, []);
 
   const handleIdeaSubmit = useCallback(
@@ -306,6 +315,23 @@ export default function CreatePage() {
       <div style={{ marginTop: 24, padding: 16, background: "#f9f9f9", borderRadius: 8, border: "1px solid #eee" }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 12 }}>Model Defaults</h2>
         <ModelSelector categories={activeTab === "idea" ? ["script", "image"] : ["image"]} onSelectionChange={handleModelChange} />
+        <div style={{ marginTop: 12 }}>
+          <label htmlFor="render-profile" style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}>
+            Render Profile
+          </label>
+          <select
+            id="render-profile"
+            value={modelDefaults.render_profile ?? "shorts_default"}
+            onChange={(e) => handleRenderProfileChange(e.target.value)}
+            style={{ padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14 }}
+          >
+            {RENDER_PROFILE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
 
       {/* Shared: Style Preset */}

--- a/apps/studio-web/src/pages/CreatePage.tsx
+++ b/apps/studio-web/src/pages/CreatePage.tsx
@@ -305,7 +305,7 @@ export default function CreatePage() {
       {/* Shared: Model Defaults */}
       <div style={{ marginTop: 24, padding: 16, background: "#f9f9f9", borderRadius: 8, border: "1px solid #eee" }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 12 }}>Model Defaults</h2>
-        <ModelSelector categories={["script", "image"]} onSelectionChange={handleModelChange} />
+        <ModelSelector categories={activeTab === "idea" ? ["script", "image"] : ["image"]} onSelectionChange={handleModelChange} />
       </div>
 
       {/* Shared: Style Preset */}

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -36,6 +36,11 @@ interface ProjectDetail {
   title: string | null;
   source_type: string;
   status: string;
+  latest_run?: {
+    run_id: number;
+    current_stage: string | null;
+    status: string | null;
+  } | null;
 }
 
 interface ModelDefaults {
@@ -1188,7 +1193,8 @@ export default function ProjectPage() {
           {project.title || "Untitled Project"}
         </h1>
         <span style={{ fontSize: 12, color: "#6b7280" }}>
-          Source: {project.source_type} · Status: {project.status}
+          Source: {project.source_type} · Status: {run ? run.status : project.status}
+          {run ? ` · Stage: ${currentStage}` : ""}
         </span>
 
         {/* Stop / Resume / Delete actions */}
@@ -1254,7 +1260,11 @@ export default function ProjectPage() {
       {/* Pipeline stepper */}
       {run && (
         <div style={{ marginBottom: 24 }}>
-          <PipelineStepper currentStage={currentStage} failed={isFailed} />
+          <PipelineStepper
+            currentStage={currentStage}
+            failed={isFailed}
+            sourceType={project.source_type as "idea" | "markdown" | "url"}
+          />
         </div>
       )}
 

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -1289,51 +1289,25 @@ export default function ProjectPage() {
         </div>
       )}
 
-      {/* Generating indicator */}
-      {run && isGenerating && (
-        <div
-          data-testid="generating-indicator"
-          style={{
-            textAlign: "center",
-            padding: 32,
-            background: "#eff6ff",
-            borderRadius: 8,
-            border: "1px solid #bfdbfe",
-            color: "#1e40af",
-            marginBottom: 24,
-          }}
-        >
-          <p style={{ margin: "0 0 4px", fontWeight: 600 }}>Generating Script…</p>
-          <p style={{ margin: 0, fontSize: 13 }}>
-            The AI model is writing your script. This may take a moment.
-          </p>
-        </div>
-      )}
-
-      {/* Visual plan generating indicator */}
-      {run && isVPGenerating && (
-        <div
-          data-testid="vp-generating-indicator"
-          style={{
-            textAlign: "center",
-            padding: 32,
-            background: "#f0fdf4",
-            borderRadius: 8,
-            border: "1px solid #bbf7d0",
-            color: "#166534",
-            marginBottom: 24,
-          }}
-        >
-          <p style={{ margin: "0 0 4px", fontWeight: 600 }}>Generating Visual Plan…</p>
-          <p style={{ margin: 0, fontSize: 13 }}>
-            The AI model is creating scene descriptions. This may take a moment.
-          </p>
-        </div>
-      )}
-
       {/* Script editor area */}
-      {run && isScriptStage && !isGenerating && (
+      {run && isScriptStage && (
         <div style={{ marginBottom: 24 }}>
+          {isGenerating && (
+            <div
+              data-testid="generating-indicator"
+              style={{
+                padding: "10px 14px",
+                background: "#eff6ff",
+                borderRadius: 8,
+                border: "1px solid #bfdbfe",
+                color: "#1e40af",
+                marginBottom: 12,
+                fontSize: 13,
+              }}
+            >
+              Generating Script… Current draft will update automatically.
+            </div>
+          )}
           {/* Editor mode toggle */}
           <div
             role="tablist"
@@ -1392,6 +1366,8 @@ export default function ProjectPage() {
               <MarkdownScriptEditor
                 runId={run.id}
                 readOnly={!isEditable}
+                pollIntervalMs={isGenerating ? 3000 : undefined}
+                suppressMissingDraftError={isGenerating}
                 onSuccess={() => setStatusMessage("Script saved")}
                 onError={(_action, msg) => setStatusMessage(msg)}
               />
@@ -1404,6 +1380,8 @@ export default function ProjectPage() {
               <StructuredScriptEditor
                 runId={run.id}
                 readOnly={!isEditable}
+                pollIntervalMs={isGenerating ? 3000 : undefined}
+                suppressMissingDraftError={isGenerating}
                 onSuccess={() => setStatusMessage("Script saved")}
                 onError={(_action, msg) => setStatusMessage(msg)}
               />
@@ -1413,8 +1391,24 @@ export default function ProjectPage() {
       )}
 
       {/* Visual plan setup — paragraph→image mapping before generation */}
-      {run && isVPSetup && (
+      {run && (isVPSetup || (isVPGenerating && !run.restart_from)) && (
         <div style={{ marginBottom: 24 }}>
+          {isVPGenerating && (
+            <div
+              data-testid="vp-generating-indicator"
+              style={{
+                padding: "10px 14px",
+                background: "#f0fdf4",
+                borderRadius: 8,
+                border: "1px solid #bbf7d0",
+                color: "#166534",
+                marginBottom: 12,
+                fontSize: 13,
+              }}
+            >
+              Generating Visual Plan… Scene prompts will appear here automatically.
+            </div>
+          )}
           <div
             style={{
               padding: "16px 20px",
@@ -1450,11 +1444,29 @@ export default function ProjectPage() {
       )}
 
       {/* Visual plan editor area */}
-      {run && isVisualPlanStage && !isVPGenerating && !isVPSetup && (
+      {run && isVisualPlanStage && !(isVPSetup || (isVPGenerating && !run.restart_from)) && (
         <div style={{ marginBottom: 24 }}>
+          {isVPGenerating && (
+            <div
+              data-testid="vp-generating-indicator"
+              style={{
+                padding: "10px 14px",
+                background: "#f0fdf4",
+                borderRadius: 8,
+                border: "1px solid #bbf7d0",
+                color: "#166534",
+                marginBottom: 12,
+                fontSize: 13,
+              }}
+            >
+              Regenerating Visual Plan… Existing prompts stay visible until the new plan is ready.
+            </div>
+          )}
           <VisualPlanEditor
             runId={run.id}
             readOnly={currentStage !== "VISUAL_PLAN_REVIEW"}
+            pollIntervalMs={isVPGenerating ? 3000 : undefined}
+            suppressMissingPlanError={isVPGenerating}
             onSuccess={() => setStatusMessage("Visual plan saved")}
             onError={(_action, msg) => setStatusMessage(msg)}
           />
@@ -1810,6 +1822,7 @@ export default function ProjectPage() {
           <StoryboardView
             runId={run.id}
             readOnly={isRenderStage}
+            currentStage={currentStage}
             onStatusMessage={setStatusMessage}
             onRenderReady={() => {
               if (run) refreshRun(run.id);

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -5,7 +5,7 @@
  * - PipelineStepper (header progress bar)
  * - Editor area with markdown / structured toggle (during script stages)
  * - VisualPlanEditor (during visual plan stages)
- * - VisualAssetGrid + ProgressDialog (during visual asset stages)
+ * - VisualAssetGrid (during visual asset stages)
  * - Audio / subtitle / render generating indicators (automatic stages)
  * - Final review section with preview summary and review-page link
  * - StageActionBar (save / approve / generate / restart)
@@ -22,7 +22,6 @@ import MarkdownScriptEditor from "../components/creator/MarkdownScriptEditor";
 import StructuredScriptEditor from "../components/creator/StructuredScriptEditor";
 import VisualPlanEditor from "../components/creator/VisualPlanEditor";
 import VisualAssetGrid from "../components/creator/VisualAssetGrid";
-import ProgressDialog from "../components/creator/ProgressDialog";
 import ModelSelector from "../components/creator/ModelSelector";
 import StoryboardView from "../components/creator/StoryboardView";
 import ConfirmDialog from "../components/creator/ConfirmDialog";
@@ -85,6 +84,14 @@ const FINAL_REVIEW_STAGES = new Set(["FINAL_REVIEW"]);
 
 // Storyboard stages — show unified storyboard view instead of separate indicators
 const STORYBOARD_STAGES = new Set(["AUDIO_GENERATING", "SUBTITLE_GENERATING", "RENDER_GENERATING", "FINAL_REVIEW"]);
+const RUN_POLL_STAGES = new Set([
+  "SCRIPT_GENERATING",
+  "VISUAL_PLAN_GENERATING",
+  "VISUAL_ASSET_GENERATING",
+  "AUDIO_GENERATING",
+  "SUBTITLE_GENERATING",
+  "RENDER_GENERATING",
+]);
 
 // Stages where editing is allowed (not generating)
 const EDITABLE_STAGES = new Set(["SCRIPT_REVIEW", "VISUAL_PLAN_REVIEW"]);
@@ -304,10 +311,6 @@ export default function ProjectPage() {
   // Status toast
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
-  // Progress dialog state
-  const [progressOpen, setProgressOpen] = useState(false);
-  const [progressExpectedStage, setProgressExpectedStage] = useState("VISUAL_ASSET_GENERATING");
-
   // Scene regeneration model override
   const [regenModelKey, setRegenModelKey] = useState<string | null>(null);
 
@@ -399,6 +402,17 @@ export default function ProjectPage() {
       // silent — non-critical
     }
   }, []);
+
+  useEffect(() => {
+    if (!run || !RUN_POLL_STAGES.has(run.current_stage)) return;
+    const timer = setInterval(() => {
+      void refreshRun(run.id);
+      if (run.current_stage === "VISUAL_ASSET_GENERATING") {
+        setAssetRefreshKey((k) => k + 1);
+      }
+    }, 3000);
+    return () => clearInterval(timer);
+  }, [run, refreshRun]);
 
   // Initialize model selection from run.model_defaults on load
   useEffect(() => {
@@ -643,8 +657,8 @@ export default function ProjectPage() {
         throw new Error(body?.detail ?? `Generate assets failed (${res.status})`);
       }
       setStatusMessage("Visual asset generation started");
-      setProgressExpectedStage("VISUAL_ASSET_GENERATING");
-      setProgressOpen(true);
+      await refreshRun(run.id);
+      setAssetRefreshKey((k) => k + 1);
     } catch (err) {
       setStatusMessage(err instanceof Error ? err.message : "Generate assets failed");
     } finally {
@@ -776,8 +790,7 @@ export default function ProjectPage() {
         throw new Error(body?.detail ?? `Generate audio failed (${res.status})`);
       }
       setStatusMessage("Audio generation started");
-      setProgressExpectedStage("AUDIO_GENERATING");
-      setProgressOpen(true);
+      await refreshRun(run.id);
     } catch (err) {
       setStatusMessage(err instanceof Error ? err.message : "Generate audio failed");
     } finally {
@@ -802,8 +815,7 @@ export default function ProjectPage() {
         throw new Error(body?.detail ?? `Generate subtitles failed (${res.status})`);
       }
       setStatusMessage("Subtitle generation started");
-      setProgressExpectedStage("SUBTITLE_GENERATING");
-      setProgressOpen(true);
+      await refreshRun(run.id);
     } catch (err) {
       setStatusMessage(err instanceof Error ? err.message : "Generate subtitles failed");
     } finally {
@@ -828,37 +840,13 @@ export default function ProjectPage() {
         throw new Error(body?.detail ?? `Render failed (${res.status})`);
       }
       setStatusMessage("Render started");
-      setProgressExpectedStage("RENDER_GENERATING");
-      setProgressOpen(true);
+      await refreshRun(run.id);
     } catch (err) {
       setStatusMessage(err instanceof Error ? err.message : "Render failed");
     } finally {
       setGenerating(false);
     }
   }, [run, modelSelection.render_profile]);
-
-  // ---- progress dialog callbacks ----
-
-  const handleProgressComplete = useCallback(
-    (stage: string) => {
-      setProgressOpen(false);
-      setStatusMessage(`Generation complete — now at ${stage}`);
-      if (run) {
-        refreshRun(run.id);
-        setAssetRefreshKey((k) => k + 1);
-      }
-    },
-    [run, refreshRun],
-  );
-
-  const handleProgressFailed = useCallback(
-    (_stage: string) => {
-      setProgressOpen(false);
-      setStatusMessage("Generation failed");
-      if (run) refreshRun(run.id);
-    },
-    [run, refreshRun],
-  );
 
   // ---- stop / resume / delete actions ----
 
@@ -1476,8 +1464,8 @@ export default function ProjectPage() {
       {/* Visual asset area */}
       {run && isVisualAssetStage && (
         <div data-testid="visual-asset-section" style={{ marginBottom: 24 }}>
-          {/* Asset generating indicator (inline — ProgressDialog also available) */}
-          {isVAGenerating && !progressOpen && (
+          {/* Asset generating indicator */}
+          {isVAGenerating && (
             <div
               data-testid="va-generating-indicator"
               style={{
@@ -1875,19 +1863,6 @@ export default function ProjectPage() {
             </div>
           )}
         </div>
-      )}
-
-      {/* ProgressDialog for long-running generation */}
-      {run && (
-        <ProgressDialog
-          open={progressOpen}
-          runId={run.id}
-          expectedStage={progressExpectedStage}
-          apiBase={API_BASE}
-          onComplete={handleProgressComplete}
-          onFailed={handleProgressFailed}
-          onClose={() => setProgressOpen(false)}
-        />
       )}
 
       {/* Back navigation button */}

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -35,6 +35,9 @@ interface ProjectDetail {
   title: string | null;
   source_type: string;
   status: string;
+  idea_brief?: string | null;
+  markdown_source?: string | null;
+  url_source?: string | null;
   latest_run?: {
     run_id: number;
     current_stage: string | null;
@@ -910,6 +913,7 @@ export default function ProjectPage() {
   const currentStage = run?.current_stage ?? "IDEA_READY";
   const isFailed = run?.status === "failed";
   const isScriptStage = SCRIPT_STAGES.has(currentStage);
+  const isScriptWorkspace = currentStage === "IDEA_READY" || isScriptStage;
   const isVisualPlanStage = VISUAL_PLAN_STAGES.has(currentStage);
   const isVisualAssetStage = VISUAL_ASSET_STAGES.has(currentStage);
   const isEditable = EDITABLE_STAGES.has(currentStage);
@@ -1277,8 +1281,8 @@ export default function ProjectPage() {
         </div>
       )}
 
-      {/* Script editor area */}
-      {run && isScriptStage && (
+      {/* Script workspace */}
+      {run && isScriptWorkspace && (
         <div style={{ marginBottom: 24 }}>
           {isGenerating && (
             <div
@@ -1296,6 +1300,28 @@ export default function ProjectPage() {
               Generating Script… Current draft will update automatically.
             </div>
           )}
+
+          <div
+            style={{
+              padding: "14px 16px",
+              background: "#f9fafb",
+              border: "1px solid #e5e7eb",
+              borderRadius: 8,
+              marginBottom: 12,
+            }}
+          >
+            <div style={{ fontSize: 12, fontWeight: 600, color: "#6b7280", marginBottom: 6 }}>
+              Source Context
+            </div>
+            <div style={{ fontSize: 13, lineHeight: 1.5, color: "#374151", whiteSpace: "pre-wrap" }}>
+              {project.source_type === "idea"
+                ? (project.idea_brief || "No idea brief")
+                : project.source_type === "markdown"
+                  ? (project.markdown_source || "No markdown source")
+                  : (project.url_source || "No URL source")}
+            </div>
+          </div>
+
           {/* Editor mode toggle */}
           <div
             role="tablist"
@@ -1353,9 +1379,14 @@ export default function ProjectPage() {
             <div role="tabpanel" id="panel-markdown" aria-labelledby="tab-markdown">
               <MarkdownScriptEditor
                 runId={run.id}
-                readOnly={!isEditable}
-                pollIntervalMs={isGenerating ? 3000 : undefined}
-                suppressMissingDraftError={isGenerating}
+                readOnly={currentStage !== "SCRIPT_REVIEW"}
+                pollIntervalMs={currentStage === "IDEA_READY" || isGenerating ? 3000 : undefined}
+                suppressMissingDraftError={currentStage === "IDEA_READY" || isGenerating}
+                pendingMessage={
+                  currentStage === "IDEA_READY"
+                    ? "No script yet. Click Generate Script to start from this source."
+                    : "Waiting for generated script…"
+                }
                 onSuccess={() => setStatusMessage("Script saved")}
                 onError={(_action, msg) => setStatusMessage(msg)}
               />
@@ -1367,9 +1398,14 @@ export default function ProjectPage() {
             <div role="tabpanel" id="panel-structured" aria-labelledby="tab-structured">
               <StructuredScriptEditor
                 runId={run.id}
-                readOnly={!isEditable}
-                pollIntervalMs={isGenerating ? 3000 : undefined}
-                suppressMissingDraftError={isGenerating}
+                readOnly={currentStage !== "SCRIPT_REVIEW"}
+                pollIntervalMs={currentStage === "IDEA_READY" || isGenerating ? 3000 : undefined}
+                suppressMissingDraftError={currentStage === "IDEA_READY" || isGenerating}
+                pendingMessage={
+                  currentStage === "IDEA_READY"
+                    ? "No structured sections yet. Generate a script first."
+                    : "Waiting for generated sections…"
+                }
                 onSuccess={() => setStatusMessage("Script saved")}
                 onError={(_action, msg) => setStatusMessage(msg)}
               />
@@ -1378,10 +1414,10 @@ export default function ProjectPage() {
         </div>
       )}
 
-      {/* Visual plan setup — paragraph→image mapping before generation */}
-      {run && (isVPSetup || (isVPGenerating && !run.restart_from)) && (
+      {/* Visual plan workspace */}
+      {run && isVisualPlanStage && (
         <div style={{ marginBottom: 24 }}>
-          {isVPGenerating && (
+          {(isVPSetup || isVPGenerating) && (
             <div
               data-testid="vp-generating-indicator"
               style={{
@@ -1394,7 +1430,9 @@ export default function ProjectPage() {
                 fontSize: 13,
               }}
             >
-              Generating Visual Plan… Scene prompts will appear here automatically.
+              {isVPGenerating
+                ? "Generating Visual Plan… Scene prompts will appear here automatically."
+                : "Visual plan not generated yet. Review the source mapping below, then generate it in place."}
             </div>
           )}
           <div
@@ -1428,36 +1466,21 @@ export default function ProjectPage() {
 
           {/* Paragraph → Image cards */}
           <VisualPlanSetupCards runId={run.id} />
-        </div>
-      )}
-
-      {/* Visual plan editor area */}
-      {run && isVisualPlanStage && !(isVPSetup || (isVPGenerating && !run.restart_from)) && (
-        <div style={{ marginBottom: 24 }}>
-          {isVPGenerating && (
-            <div
-              data-testid="vp-generating-indicator"
-              style={{
-                padding: "10px 14px",
-                background: "#f0fdf4",
-                borderRadius: 8,
-                border: "1px solid #bbf7d0",
-                color: "#166534",
-                marginBottom: 12,
-                fontSize: 13,
-              }}
-            >
-              Regenerating Visual Plan… Existing prompts stay visible until the new plan is ready.
-            </div>
-          )}
-          <VisualPlanEditor
-            runId={run.id}
-            readOnly={currentStage !== "VISUAL_PLAN_REVIEW"}
-            pollIntervalMs={isVPGenerating ? 3000 : undefined}
-            suppressMissingPlanError={isVPGenerating}
-            onSuccess={() => setStatusMessage("Visual plan saved")}
-            onError={(_action, msg) => setStatusMessage(msg)}
-          />
+          <div style={{ marginTop: 16 }}>
+            <VisualPlanEditor
+              runId={run.id}
+              readOnly={currentStage !== "VISUAL_PLAN_REVIEW"}
+              pollIntervalMs={isVPSetup || isVPGenerating ? 3000 : undefined}
+              suppressMissingPlanError={isVPSetup || isVPGenerating}
+              pendingMessage={
+                isVPSetup
+                  ? "No visual plan yet. Generate it from the mapped script sections above."
+                  : "Waiting for generated scenes…"
+              }
+              onSuccess={() => setStatusMessage("Visual plan saved")}
+              onError={(_action, msg) => setStatusMessage(msg)}
+            />
+          </div>
         </div>
       )}
 

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -1419,16 +1419,16 @@ export default function ProjectPage() {
             </h3>
             <p style={{ margin: 0, fontSize: 13, color: "#4b5563", lineHeight: 1.5 }}>
               Review the paragraph-to-image mapping below. Each paragraph in your script will
-              generate one image. Select your preferred image model, then click
+              generate one image. Select the script model that will draft the visual plan, then click
               <strong> Generate Visual Plan</strong> to proceed.
             </p>
           </div>
 
-          {/* Image model selector */}
+          {/* Script model selector for visual-plan drafting */}
           <div style={{ marginBottom: 16 }}>
             <ModelSelector
-              categories={["image"]}
-              selectedModels={buildSelectedModels(["image"])}
+              categories={["script"]}
+              selectedModels={buildSelectedModels(["script"])}
               apiBase=""
               onSelectionChange={handleModelChange}
             />
@@ -1914,6 +1914,16 @@ export default function ProjectPage() {
         </div>
       )}
       {run && currentStage === "VISUAL_PLAN_REVIEW" && (
+        <div style={{ padding: "8px 16px" }}>
+          <ModelSelector
+            categories={["script"]}
+            selectedModels={buildSelectedModels(["script"])}
+            apiBase=""
+            onSelectionChange={handleModelChange}
+          />
+        </div>
+      )}
+      {run && currentStage === "VISUAL_ASSET_REVIEW" && (
         <div style={{ padding: "8px 16px" }}>
           <ModelSelector
             categories={["image"]}

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -108,6 +108,12 @@ const SD_SAMPLERS = [
   "DPM++ 2M", "DPM++ SDE", "DPM++ 2S a Karras",
   "Euler a", "Euler", "DDIM", "UniPC", "LMS Karras", "Heun",
 ];
+
+const RENDER_PROFILE_OPTIONS = [
+  { value: "shorts_default", label: "Shorts Default" },
+  { value: "high_quality", label: "High Quality" },
+  { value: "fast_preview", label: "Fast Preview" },
+];
 // --------------- Visual Plan Setup Cards ---------------
 
 interface ScriptSection {
@@ -956,7 +962,22 @@ export default function ProjectPage() {
 
     // Storyboard stages — audio/subtitle generation is handled by StoryboardView
     // Only show render button and restart in the action bar
-    if (isAudioStage || isSubtitleStage) {
+    if (isAudioStage) {
+      return {
+        save: { visible: false },
+        approve: { visible: false },
+        generate: { visible: false },
+        restart: {
+          visible: true,
+          disabled: restarting,
+          loading: restarting,
+          onClick: handleRestart,
+          label: "Restart from Script",
+        },
+      };
+    }
+
+    if (isSubtitleStage) {
       return {
         save: { visible: false },
         approve: { visible: false },
@@ -1151,6 +1172,10 @@ export default function ProjectPage() {
   }
 
   const actions = buildActionBar();
+  const showGoBack =
+    Boolean(run) &&
+    Boolean(STAGE_BACK_LABELS[currentStage]) &&
+    !(currentStage === "SCRIPT_REVIEW" && project.source_type !== "idea");
 
   return (
     <div style={{ maxWidth: 960, margin: "0 auto", padding: 24 }}>
@@ -1750,6 +1775,26 @@ export default function ProjectPage() {
                 apiBase=""
                 onSelectionChange={handleModelChange}
               />
+              <div style={{ marginTop: 12 }}>
+                <label
+                  htmlFor="project-render-profile"
+                  style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}
+                >
+                  Render Profile
+                </label>
+                <select
+                  id="project-render-profile"
+                  value={modelSelection.render_profile || "shorts_default"}
+                  onChange={(e) => handleModelChange("render", e.target.value)}
+                  style={{ padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14 }}
+                >
+                  {RENDER_PROFILE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
           )}
           <StoryboardView
@@ -1823,7 +1868,7 @@ export default function ProjectPage() {
       )}
 
       {/* Back navigation button */}
-      {run && STAGE_BACK_LABELS[currentStage] && (
+      {showGoBack && (
         <div style={{ display: "flex", justifyContent: "flex-start", padding: "8px 16px" }}>
           <button
             type="button"

--- a/apps/studio-web/src/pages/RunsPage.tsx
+++ b/apps/studio-web/src/pages/RunsPage.tsx
@@ -12,6 +12,11 @@ interface ProjectSummary {
   status: "draft" | "active" | "completed" | "archived";
   created_at: string;
   updated_at: string;
+  latest_run?: {
+    run_id: number;
+    current_stage: string | null;
+    status: string | null;
+  } | null;
 }
 
 interface ProjectListResponse {
@@ -26,6 +31,11 @@ const STATUS_COLORS: Record<string, { bg: string; fg: string }> = {
   active: { bg: "#dbeafe", fg: "#1e40af" },
   completed: { bg: "#dcfce7", fg: "#166534" },
   archived: { bg: "#f3f4f6", fg: "#6b7280" },
+  pending: { bg: "#fef3c7", fg: "#92400e" },
+  running: { bg: "#dbeafe", fg: "#1d4ed8" },
+  failed: { bg: "#fee2e2", fg: "#b91c1c" },
+  cancelled: { bg: "#f3f4f6", fg: "#6b7280" },
+  paused: { bg: "#ede9fe", fg: "#6d28d9" },
 };
 
 const SOURCE_LABELS: Record<string, string> = {
@@ -247,7 +257,8 @@ export default function RunsPage() {
             </thead>
             <tbody>
               {projects.map((proj) => {
-                const statusColor = STATUS_COLORS[proj.status] ?? STATUS_COLORS.draft;
+                const effectiveStatus = proj.latest_run?.status ?? proj.status;
+                const statusColor = STATUS_COLORS[effectiveStatus] ?? STATUS_COLORS.draft;
                 return (
                   <tr
                     key={proj.id}
@@ -289,8 +300,13 @@ export default function RunsPage() {
                           color: statusColor.fg,
                         }}
                       >
-                        {proj.status}
+                        {effectiveStatus}
                       </span>
+                      {proj.latest_run?.current_stage && (
+                        <div style={{ marginTop: 4, fontSize: 11, color: "#6b7280" }}>
+                          {proj.latest_run.current_stage}
+                        </div>
+                      )}
                     </td>
                     <td style={{ padding: "10px 12px", color: "#6b7280" }}>
                       {formatDate(proj.created_at)}

--- a/apps/worker-orchestrator/tasks/generate_audio.py
+++ b/apps/worker-orchestrator/tasks/generate_audio.py
@@ -36,8 +36,12 @@ _ALLOWED_STAGES = frozenset({RunStage.VISUAL_ASSET_REVIEW, RunStage.AUDIO_GENERA
 _ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
 
 # Stages where writing SUBTITLE_GENERATING or FAILED is safe — the run
-# hasn't advanced past audio generation.
-_SAFE_STAGES = frozenset({RunStage.AUDIO_GENERATING})
+# hasn't advanced past audio generation. The task may start directly from
+# VISUAL_ASSET_REVIEW or from AUDIO_GENERATING after API-side CAS.
+_SAFE_STAGES = frozenset({
+    RunStage.VISUAL_ASSET_REVIEW.value,
+    RunStage.AUDIO_GENERATING.value,
+})
 
 
 class _StageGuardError(ValueError):
@@ -56,6 +60,16 @@ def _get_redis_client() -> Any | None:
     if redis is None:
         return None
     return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+async def _remove_active_task_id_best_effort(run_id: int, task_id: str) -> None:
+    remover = getattr(_run_service.storage, "remove_active_task_id", None)
+    if not callable(remover):
+        return
+    try:
+        await remover(run_id, task_id)
+    except Exception:
+        logger.exception("Failed to remove active task id %s for run %d", task_id, run_id)
 
 
 @celery_app.task(bind=True, name="generate_audio")
@@ -79,116 +93,118 @@ def generate_audio(
     async def _run_task() -> dict[str, object]:
         nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
         nonlocal redis_client, lock_acquired
-
-        # 1. Stage guard — reject before any side effects.
-        run = await _run_service.storage.get_run(run_id)
-        if run is None:
-            raise _StageGuardError(f"Run {run_id} not found")
-
         try:
-            current = RunStage(run["current_stage"])
-        except ValueError as exc:
-            raise _StageGuardError(
-                f"Run {run_id} has invalid stage {run['current_stage']!r}"
-            ) from exc
-        if current not in _ALLOWED_STAGES:
-            raise _StageGuardError(
-                f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
-            )
+            # 1. Stage guard — reject before any side effects.
+            run = await _run_service.storage.get_run(run_id)
+            if run is None:
+                raise _StageGuardError(f"Run {run_id} not found")
 
-        # 2. Fetch approved script draft.
-        draft = await _script_service.get_active_draft(run_id)
-        if draft is None:
-            raise _StageGuardError(f"No script draft found for run {run_id}")
-
-        script_text = (draft.markdown_content or "").strip()
-        if not script_text and draft.structured_script:
-            script_text = "\n".join(
-                (section.display_text or section.text).strip()
-                for section in draft.structured_script
-                if (section.display_text or section.text).strip()
-            )
-
-        if not script_text:
-            raise _StageGuardError(f"Script draft for run {run_id} has no content")
-
-        # 3. Provider resolution (sync — blocks briefly, fine in Celery worker).
-        registry = ProviderRegistry.create_default()
-        entry = registry.resolve(tts_model)
-        provider = registry.get_provider(tts_model)
-
-        provider_type = entry.provider_type
-        endpoint = entry.endpoint
-
-        # 4. GPU lock acquisition (sync).
-        if entry.requires_gpu:
-            redis_client = _get_redis_client()
-            if redis_client is None:
-                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
-            acquire_gpu_lock(redis_client, task_id)
-            lock_acquired = True
-            gpu_lock_acquired_at = _utc_now_iso()
-
-        audio_path = f"{_ARTIFACT_ROOT}/{run_id}/audio/audio.wav"
-
-        try:
-            os.makedirs(os.path.dirname(audio_path), exist_ok=True)
-            # 5. Generate audio via provider.
-            params = dict(entry.default_params or {})
-            params["output_path"] = audio_path
-            await provider.generate(script_text, voice=voice, params=params)
-
-            # 6. Save audio artifact via service.
-            artifact = await _audio_service.create_artifact(
-                run_id=run_id,
-                path=audio_path,
-                model_used=tts_model,
-                provider_type=entry.provider_type,
-                voice=voice,
-            )
-
-            # 7. Atomic success transition.
-            applied, _ = await _run_service.storage.conditional_update_run(
-                run_id,
-                {
-                    "current_stage": RunStage.SUBTITLE_GENERATING,
-                    "status": "running",
-                },
-                expected_stages=_SAFE_STAGES,
-            )
-            if not applied:
-                logger.info(
-                    "Run %d stage changed during audio generation -- skipping transition",
-                    run_id,
+            try:
+                current = RunStage(run["current_stage"])
+            except ValueError as exc:
+                raise _StageGuardError(
+                    f"Run {run_id} has invalid stage {run['current_stage']!r}"
+                ) from exc
+            if current not in _ALLOWED_STAGES:
+                raise _StageGuardError(
+                    f"Run {run_id} is in stage {current.value}, "
+                    f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
                 )
+
+            # 2. Fetch approved script draft.
+            draft = await _script_service.get_active_draft(run_id)
+            if draft is None:
+                raise _StageGuardError(f"No script draft found for run {run_id}")
+
+            script_text = (draft.markdown_content or "").strip()
+            if not script_text and draft.structured_script:
+                script_text = "\n".join(
+                    (section.display_text or section.text).strip()
+                    for section in draft.structured_script
+                    if (section.display_text or section.text).strip()
+                )
+
+            if not script_text:
+                raise _StageGuardError(f"Script draft for run {run_id} has no content")
+
+            # 3. Provider resolution (sync — blocks briefly, fine in Celery worker).
+            registry = ProviderRegistry.create_default()
+            entry = registry.resolve(tts_model)
+            provider = registry.get_provider(tts_model)
+
+            provider_type = entry.provider_type
+            endpoint = entry.endpoint
+
+            # 4. GPU lock acquisition (sync).
+            if entry.requires_gpu:
+                redis_client = _get_redis_client()
+                if redis_client is None:
+                    raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+                acquire_gpu_lock(redis_client, task_id)
+                lock_acquired = True
+                gpu_lock_acquired_at = _utc_now_iso()
+
+            audio_path = f"{_ARTIFACT_ROOT}/{run_id}/audio/audio.wav"
+
+            try:
+                os.makedirs(os.path.dirname(audio_path), exist_ok=True)
+                # 5. Generate audio via provider.
+                params = dict(entry.default_params or {})
+                params["output_path"] = audio_path
+                await provider.generate(script_text, voice=voice, params=params)
+
+                # 6. Save audio artifact via service.
+                artifact = await _audio_service.create_artifact(
+                    run_id=run_id,
+                    path=audio_path,
+                    model_used=tts_model,
+                    provider_type=entry.provider_type,
+                    voice=voice,
+                )
+
+                # 7. Atomic success transition.
+                applied, _ = await _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.SUBTITLE_GENERATING,
+                        "status": "running",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+                if not applied:
+                    logger.info(
+                        "Run %d stage changed during audio generation -- skipping transition",
+                        run_id,
+                    )
+            finally:
+                if lock_acquired:
+                    try:
+                        release_gpu_lock(redis_client, task_id)
+                        gpu_lock_released_at = _utc_now_iso()
+                    except Exception:
+                        logger.exception("Failed to release GPU lock for task %s", task_id)
+
+            end_time = datetime.now(timezone.utc)
+            duration_seconds = (end_time - start_time).total_seconds()
+
+            return {
+                "task_id": task_id,
+                "run_id": run_id,
+                "tts_model": tts_model,
+                "voice": voice,
+                "provider_type": provider_type,
+                "endpoint": endpoint,
+                "gpu_lock_acquired_at": gpu_lock_acquired_at,
+                "gpu_lock_released_at": gpu_lock_released_at,
+                "audio_artifact_id": artifact.id,
+                "audio_path": artifact.path,
+                "start_time": start_iso,
+                "end_time": end_time.isoformat(),
+                "duration_seconds": duration_seconds,
+                "status": "success",
+            }
         finally:
-            if lock_acquired:
-                try:
-                    release_gpu_lock(redis_client, task_id)
-                    gpu_lock_released_at = _utc_now_iso()
-                except Exception:
-                    logger.exception("Failed to release GPU lock for task %s", task_id)
-
-        end_time = datetime.now(timezone.utc)
-        duration_seconds = (end_time - start_time).total_seconds()
-
-        return {
-            "task_id": task_id,
-            "run_id": run_id,
-            "tts_model": tts_model,
-            "voice": voice,
-            "provider_type": provider_type,
-            "endpoint": endpoint,
-            "gpu_lock_acquired_at": gpu_lock_acquired_at,
-            "gpu_lock_released_at": gpu_lock_released_at,
-            "audio_artifact_id": artifact.id,
-            "audio_path": artifact.path,
-            "start_time": start_iso,
-            "end_time": end_time.isoformat(),
-            "duration_seconds": duration_seconds,
-            "status": "success",
-        }
+            await _remove_active_task_id_best_effort(run_id, task_id)
 
     try:
         return asyncio.run(_run_task())

--- a/apps/worker-orchestrator/tasks/generate_scene_image.py
+++ b/apps/worker-orchestrator/tasks/generate_scene_image.py
@@ -20,6 +20,7 @@ import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 try:
     import redis
@@ -36,11 +37,29 @@ from creator_service.visual_plan_service import visual_plan_service as _visual_p
 
 logger = logging.getLogger(__name__)
 
-_ALLOWED_STAGES = frozenset({RunStage.VISUAL_PLAN_REVIEW, RunStage.VISUAL_ASSET_GENERATING})
+_ALLOWED_STAGES = frozenset({
+    RunStage.VISUAL_PLAN_REVIEW,
+    RunStage.VISUAL_ASSET_GENERATING,
+    RunStage.VISUAL_ASSET_REVIEW,
+})
 
-# Stages where writing VISUAL_ASSET_REVIEW or FAILED is safe — the run
-# hasn't advanced past image generation.
-_SAFE_STAGES = frozenset({RunStage.VISUAL_ASSET_GENERATING})
+# Stages where successful image generation can still safely land.
+# Batch generation starts from VISUAL_ASSET_GENERATING, while single-scene
+# generation/regeneration may be triggered from review stages without an
+# intermediate stage transition.
+_SAFE_SUCCESS_STAGES = frozenset({
+    RunStage.VISUAL_PLAN_REVIEW.value,
+    RunStage.VISUAL_ASSET_GENERATING.value,
+    RunStage.VISUAL_ASSET_REVIEW.value,
+})
+
+# FAILED should only be written while the run is still pre-review or actively
+# generating. Once a run has advanced to asset review, a stale failing task
+# must not downgrade it.
+_SAFE_FAILURE_STAGES = frozenset({
+    RunStage.VISUAL_PLAN_REVIEW.value,
+    RunStage.VISUAL_ASSET_GENERATING.value,
+})
 
 # Base directory for artifact storage (relative to project root).
 _ARTIFACTS_BASE = os.getenv("ARTIFACT_ROOT", "data/artifacts")
@@ -67,6 +86,16 @@ def _get_redis_client() -> Any | None:
 def _asset_dir(run_id: int) -> Path:
     """Return the directory for storing scene image assets."""
     return Path(_ARTIFACTS_BASE) / str(run_id) / "scenes"
+
+
+async def _remove_active_task_id_best_effort(run_id: int, task_id: str) -> None:
+    remover = getattr(_run_service.storage, "remove_active_task_id", None)
+    if not callable(remover):
+        return
+    try:
+        await remover(run_id, task_id)
+    except Exception:
+        logger.exception("Failed to remove active task id %s for run %d", task_id, run_id)
 
 
 @celery_app.task(bind=True, name="generate_scene_image")
@@ -102,212 +131,198 @@ def generate_scene_image(
 
     async def _run_task() -> dict[str, object]:
         nonlocal provider_type, endpoint
-
-        # 1. Stage guard — reject before any side effects.
-        run = await _run_service.storage.get_run(run_id)
-        if run is None:
-            raise _StageGuardError(f"Run {run_id} not found")
-
         try:
-            current = RunStage(run["current_stage"])
-        except ValueError as exc:
-            raise _StageGuardError(
-                f"Run {run_id} has invalid stage {run['current_stage']!r}"
-            ) from exc
-        if current not in _ALLOWED_STAGES:
-            raise _StageGuardError(
-                f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
-            )
-
-        # 2. Fetch active visual plan.
-        plan = await _visual_plan_service.get_active_plan(run_id)
-        if plan is None:
-            raise _StageGuardError(f"No active visual plan for run {run_id}")
-
-        # 3. Determine scenes to generate.
-        if scene_id is not None:
-            # Single-scene mode.
-            target_scenes = [s for s in plan.scenes if s.scene_id == scene_id]
-            if not target_scenes:
-                raise _StageGuardError(
-                    f"Scene '{scene_id}' not found in visual plan for run {run_id}"
-                )
-        else:
-            target_scenes = list(plan.scenes)
-
-        if not target_scenes:
-            raise _StageGuardError(f"Visual plan for run {run_id} has no scenes")
-
-        # 4. Provider resolution (sync — blocks briefly, fine in Celery worker).
-        registry = ProviderRegistry.create_default()
-        entry = registry.resolve(model_key)
-        provider = registry.get_provider(model_key)
-
-        provider_type = entry.provider_type
-        endpoint = entry.endpoint
-
-        # 5. Ensure artifact output directory exists.
-        asset_dir = _asset_dir(run_id)
-        asset_dir.mkdir(parents=True, exist_ok=True)
-
-        # 6. Generate images per scene.
-        results: list[dict[str, object]] = []
-        failed_scenes: list[dict[str, object]] = []
-        redis_client: Any | None = None
-
-        for target_scene in target_scenes:
-            scene_result: dict[str, object] = {
-                "scene_id": target_scene.scene_id,
-                "status": "pending",
-            }
-            lock_acquired = False
-            gpu_lock_acquired_at: str | None = None
-            gpu_lock_released_at: str | None = None
+            # 1. Stage guard — reject before any side effects.
+            run = await _run_service.storage.get_run(run_id)
+            if run is None:
+                raise _StageGuardError(f"Run {run_id} not found")
 
             try:
-                # Use prompt override for single-scene, otherwise scene prompt.
-                effective_prompt = (
-                    prompt_override
-                    if prompt_override is not None and scene_id is not None
-                    else target_scene.prompt
+                current = RunStage(run["current_stage"])
+            except ValueError as exc:
+                raise _StageGuardError(
+                    f"Run {run_id} has invalid stage {run['current_stage']!r}"
+                ) from exc
+            if current not in _ALLOWED_STAGES:
+                raise _StageGuardError(
+                    f"Run {run_id} is in stage {current.value}, "
+                    f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
                 )
 
-                # GPU lock (per-scene).
-                if entry.requires_gpu:
-                    redis_client = _get_redis_client()
-                    if redis_client is None:
-                        raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
-                    scene_task_id = f"{task_id}:{target_scene.scene_id}"
-                    acquire_gpu_lock(redis_client, scene_task_id)
-                    lock_acquired = True
-                    gpu_lock_acquired_at = _utc_now_iso()
+            # 2. Fetch active visual plan.
+            plan = await _visual_plan_service.get_active_plan(run_id)
+            if plan is None:
+                raise _StageGuardError(f"No active visual plan for run {run_id}")
+
+            # 3. Determine scenes to generate.
+            if scene_id is not None:
+                target_scenes = [s for s in plan.scenes if s.scene_id == scene_id]
+                if not target_scenes:
+                    raise _StageGuardError(
+                        f"Scene '{scene_id}' not found in visual plan for run {run_id}"
+                    )
+            else:
+                target_scenes = list(plan.scenes)
+
+            if not target_scenes:
+                raise _StageGuardError(f"Visual plan for run {run_id} has no scenes")
+
+            # 4. Provider resolution (sync — blocks briefly, fine in Celery worker).
+            registry = ProviderRegistry.create_default()
+            entry = registry.resolve(model_key)
+            provider = registry.get_provider(model_key)
+
+            provider_type = entry.provider_type
+            endpoint = entry.endpoint
+
+            # 5. Ensure artifact output directory exists.
+            asset_dir = _asset_dir(run_id)
+            asset_dir.mkdir(parents=True, exist_ok=True)
+
+            # 6. Generate images per scene.
+            results: list[dict[str, object]] = []
+            failed_scenes: list[dict[str, object]] = []
+            redis_client: Any | None = None
+
+            for target_scene in target_scenes:
+                scene_result: dict[str, object] = {
+                    "scene_id": target_scene.scene_id,
+                    "status": "pending",
+                }
+                lock_acquired = False
+                gpu_lock_acquired_at: str | None = None
+                gpu_lock_released_at: str | None = None
 
                 try:
-                    # Generate image via provider.
-                    params = dict(entry.default_params or {})
-                    # Merge per-request tuning overrides on top of registry defaults.
-                    if image_params:
-                        params.update(image_params)
-                    # Direct provider to write to the artifact directory
-                    # instead of a temp file.
-                    target_path = str(asset_dir / f"{target_scene.scene_id}.png")
-                    params["output_path"] = target_path
-                    image_result = await provider.generate(effective_prompt, params)
-
-                    # Use the artifact path — guaranteed to be in our
-                    # persistent storage, not a temp directory.
-                    asset_path = target_path
-
-                    # Save as visual asset via service.
-                    asset = await _visual_asset_service.create_asset(
-                        run_id=run_id,
-                        scene_id=target_scene.scene_id,
-                        asset_path=asset_path,
-                        prompt_snapshot=effective_prompt,
-                        model_used=model_key,
-                        provider_type=entry.provider_type,
-                        is_active=is_active,
+                    effective_prompt = (
+                        prompt_override
+                        if prompt_override is not None and scene_id is not None
+                        else target_scene.prompt
                     )
 
+                    if entry.requires_gpu:
+                        redis_client = _get_redis_client()
+                        if redis_client is None:
+                            raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+                        scene_task_id = f"{task_id}:{target_scene.scene_id}"
+                        acquire_gpu_lock(redis_client, scene_task_id)
+                        lock_acquired = True
+                        gpu_lock_acquired_at = _utc_now_iso()
+
+                    try:
+                        params = dict(entry.default_params or {})
+                        if image_params:
+                            params.update(image_params)
+                        target_path = str(asset_dir / f"{target_scene.scene_id}-{uuid4().hex}.png")
+                        params["output_path"] = target_path
+                        await provider.generate(effective_prompt, params)
+
+                        asset = await _visual_asset_service.create_asset(
+                            run_id=run_id,
+                            scene_id=target_scene.scene_id,
+                            asset_path=target_path,
+                            prompt_snapshot=effective_prompt,
+                            model_used=model_key,
+                            provider_type=entry.provider_type,
+                            is_active=is_active,
+                        )
+
+                        scene_result.update({
+                            "status": "success",
+                            "asset_id": asset.id,
+                            "asset_path": asset.asset_path,
+                            "version": asset.version,
+                            "gpu_lock_acquired_at": gpu_lock_acquired_at,
+                            "gpu_lock_released_at": None,
+                        })
+                    finally:
+                        if lock_acquired:
+                            try:
+                                scene_task_id = f"{task_id}:{target_scene.scene_id}"
+                                release_gpu_lock(redis_client, scene_task_id)
+                                gpu_lock_released_at = _utc_now_iso()
+                                scene_result["gpu_lock_released_at"] = gpu_lock_released_at
+                            except Exception:
+                                logger.exception(
+                                    "Failed to release GPU lock for scene %s",
+                                    target_scene.scene_id,
+                                )
+
+                    results.append(scene_result)
+
+                except Exception as exc:
                     scene_result.update({
-                        "status": "success",
-                        "asset_id": asset.id,
-                        "asset_path": asset.asset_path,
-                        "version": asset.version,
-                        "gpu_lock_acquired_at": gpu_lock_acquired_at,
-                        "gpu_lock_released_at": None,  # Set below
+                        "status": "failed",
+                        "error": str(exc),
                     })
-                finally:
-                    if lock_acquired:
-                        try:
-                            scene_task_id = f"{task_id}:{target_scene.scene_id}"
-                            release_gpu_lock(redis_client, scene_task_id)
-                            gpu_lock_released_at = _utc_now_iso()
-                            scene_result["gpu_lock_released_at"] = gpu_lock_released_at
-                        except Exception:
-                            logger.exception(
-                                "Failed to release GPU lock for scene %s",
-                                target_scene.scene_id,
-                            )
+                    failed_scenes.append(scene_result)
+                    logger.error(
+                        "Failed to generate image for scene %s in run %d: %s",
+                        target_scene.scene_id,
+                        run_id,
+                        exc,
+                    )
 
-                results.append(scene_result)
+            total = len(target_scenes)
+            succeeded = len(results)
+            failed = len(failed_scenes)
 
-            except Exception as exc:
-                scene_result.update({
-                    "status": "failed",
-                    "error": str(exc),
-                })
-                failed_scenes.append(scene_result)
-                logger.error(
-                    "Failed to generate image for scene %s in run %d: %s",
-                    target_scene.scene_id,
-                    run_id,
-                    exc,
-                )
-                # Continue to next scene — partial failure tolerance.
-
-        # 7. Determine overall status and stage transition.
-        total = len(target_scenes)
-        succeeded = len(results)
-        failed = len(failed_scenes)
-
-        if failed == total:
-            # All scenes failed — mark run as FAILED.
-            overall_status = "failed"
-            try:
+            if failed == total:
+                overall_status = "failed"
+                try:
+                    applied, _ = await _run_service.storage.conditional_update_run(
+                        run_id,
+                        {
+                            "current_stage": RunStage.FAILED,
+                            "status": "failed",
+                        },
+                        expected_stages=_SAFE_FAILURE_STAGES,
+                    )
+                    if not applied:
+                        logger.info(
+                            "Run %d stage changed during image generation -- skipping FAILED transition",
+                            run_id,
+                        )
+                except Exception:
+                    logger.exception("Failed to mark run %d as FAILED", run_id)
+                    raise
+            else:
+                overall_status = "success" if failed == 0 else "partial"
                 applied, _ = await _run_service.storage.conditional_update_run(
                     run_id,
                     {
-                        "current_stage": RunStage.FAILED,
-                        "status": "failed",
+                        "current_stage": RunStage.VISUAL_ASSET_REVIEW,
+                        "status": "running",
                     },
-                    expected_stages=_SAFE_STAGES,
+                    expected_stages=_SAFE_SUCCESS_STAGES,
                 )
                 if not applied:
                     logger.info(
-                        "Run %d stage changed during image generation -- skipping FAILED transition",
+                        "Run %d stage changed during image generation -- skipping transition",
                         run_id,
                     )
-            except Exception:
-                logger.exception("Failed to mark run %d as FAILED", run_id)
-                raise
-        else:
-            # At least some scenes succeeded — advance to VISUAL_ASSET_REVIEW.
-            overall_status = "success" if failed == 0 else "partial"
-            applied, _ = await _run_service.storage.conditional_update_run(
-                run_id,
-                {
-                    "current_stage": RunStage.VISUAL_ASSET_REVIEW,
-                    "status": "running",
-                },
-                expected_stages=_SAFE_STAGES,
-            )
-            if not applied:
-                logger.info(
-                    "Run %d stage changed during image generation -- skipping transition",
-                    run_id,
-                )
 
-        end_time = datetime.now(timezone.utc)
-        duration_seconds = (end_time - start_time).total_seconds()
+            end_time = datetime.now(timezone.utc)
+            duration_seconds = (end_time - start_time).total_seconds()
 
-        return {
-            "task_id": task_id,
-            "run_id": run_id,
-            "model_key": model_key,
-            "provider_type": provider_type,
-            "endpoint": endpoint,
-            "scene_id": scene_id,
-            "total_scenes": total,
-            "succeeded": succeeded,
-            "failed": failed,
-            "scene_results": results + failed_scenes,
-            "start_time": start_iso,
-            "end_time": end_time.isoformat(),
-            "duration_seconds": duration_seconds,
-            "status": overall_status,
-        }
+            return {
+                "task_id": task_id,
+                "run_id": run_id,
+                "model_key": model_key,
+                "provider_type": provider_type,
+                "endpoint": endpoint,
+                "scene_id": scene_id,
+                "total_scenes": total,
+                "succeeded": succeeded,
+                "failed": failed,
+                "scene_results": results + failed_scenes,
+                "start_time": start_iso,
+                "end_time": end_time.isoformat(),
+                "duration_seconds": duration_seconds,
+                "status": overall_status,
+            }
+        finally:
+            await _remove_active_task_id_best_effort(run_id, task_id)
 
     try:
         return asyncio.run(_run_task())
@@ -324,7 +339,7 @@ def generate_scene_image(
                         "current_stage": RunStage.FAILED,
                         "status": "failed",
                     },
-                    expected_stages=_SAFE_STAGES,
+                    expected_stages=_SAFE_FAILURE_STAGES,
                 )
             )
             if not applied:

--- a/apps/worker-orchestrator/tasks/generate_script.py
+++ b/apps/worker-orchestrator/tasks/generate_script.py
@@ -25,9 +25,12 @@ logger = logging.getLogger(__name__)
 _ALLOWED_STAGES = frozenset({RunStage.IDEA_READY, RunStage.SCRIPT_GENERATING})
 
 # Stages where writing SCRIPT_REVIEW or FAILED is safe — the run hasn't
-# advanced past generation.  Used as the expected_stages argument to
-# conditional_update_run for atomic compare-and-set.
-_SAFE_STAGES = frozenset({RunStage.SCRIPT_GENERATING.value})
+# advanced past generation. The task may start directly from IDEA_READY
+# or from SCRIPT_GENERATING after the API-side CAS.
+_SAFE_STAGES = frozenset({
+    RunStage.IDEA_READY.value,
+    RunStage.SCRIPT_GENERATING.value,
+})
 
 
 class _StageGuardError(ValueError):
@@ -60,6 +63,16 @@ def _get_redis_client() -> Any | None:
     return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
 
 
+async def _remove_active_task_id_best_effort(run_id: int, task_id: str) -> None:
+    remover = getattr(_run_service.storage, "remove_active_task_id", None)
+    if not callable(remover):
+        return
+    try:
+        await remover(run_id, task_id)
+    except Exception:
+        logger.exception("Failed to remove active task id %s for run %d", task_id, run_id)
+
+
 @celery_app.task(bind=True, name="generate_script")
 def generate_script(
     self,
@@ -83,91 +96,93 @@ def generate_script(
     async def _run_task() -> dict[str, object]:
         nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
         nonlocal redis_client, lock_acquired
-
-        # 1. Stage guard — reject before any side effects.
-        run = await _run_service.storage.get_run(run_id)
-        if run is None:
-            raise _StageGuardError(f"Run {run_id} not found")
-
         try:
-            current = RunStage(run["current_stage"])
-        except ValueError as exc:
-            raise _StageGuardError(
-                f"Run {run_id} has invalid stage {run['current_stage']!r}"
-            ) from exc
-        if current not in _ALLOWED_STAGES:
-            raise _StageGuardError(
-                f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
-            )
+            # 1. Stage guard — reject before any side effects.
+            run = await _run_service.storage.get_run(run_id)
+            if run is None:
+                raise _StageGuardError(f"Run {run_id} not found")
 
-        # 2. Provider resolution (sync — blocks briefly, fine in Celery worker).
-        registry = ProviderRegistry.create_default()
-        entry = registry.resolve(model_key)
-        provider = registry.get_provider(model_key)
-
-        provider_type = entry.provider_type
-        endpoint = entry.endpoint
-
-        # 3. GPU lock acquisition (sync).
-        if entry.requires_gpu:
-            redis_client = _get_redis_client()
-            if redis_client is None:
-                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
-            acquire_gpu_lock(redis_client, task_id)
-            lock_acquired = True
-            gpu_lock_acquired_at = _utc_now_iso()
-
-        try:
-            # 4. Generation, save, advance stage.
-            params = dict(entry.default_params or {})
-            generated = await provider.generate(prompt, params)
-            await _script_service.save_draft(
-                run_id=run_id,
-                source_type="generated_by_model",
-                markdown_content=generated,
-            )
-            # Atomic success transition: only advance if run is still in a
-            # generating-compatible stage. Uses compare-and-set at the storage
-            # layer — no TOCTOU gap.
-            applied, _ = await _run_service.storage.conditional_update_run(
-                run_id,
-                {
-                    "current_stage": RunStage.SCRIPT_REVIEW.value,
-                    "status": "running",
-                },
-                expected_stages=_SAFE_STAGES,
-            )
-            if not applied:
-                logger.info(
-                    "Run %d stage changed during generation -- skipping SCRIPT_REVIEW transition",
-                    run_id,
+            try:
+                current = RunStage(run["current_stage"])
+            except ValueError as exc:
+                raise _StageGuardError(
+                    f"Run {run_id} has invalid stage {run['current_stage']!r}"
+                ) from exc
+            if current not in _ALLOWED_STAGES:
+                raise _StageGuardError(
+                    f"Run {run_id} is in stage {current.value}, "
+                    f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
                 )
-        finally:
-            if lock_acquired:
-                try:
-                    release_gpu_lock(redis_client, task_id)
-                    gpu_lock_released_at = _utc_now_iso()
-                except Exception:
-                    logger.exception("Failed to release GPU lock for task %s", task_id)
 
-        end_time = datetime.now(timezone.utc)
-        duration_seconds = (end_time - start_time).total_seconds()
-        return {
-            "task_id": task_id,
-            "run_id": run_id,
-            "model_key": model_key,
-            "provider_type": provider_type,
-            "endpoint": endpoint,
-            "gpu_lock_acquired_at": gpu_lock_acquired_at,
-            "gpu_lock_released_at": gpu_lock_released_at,
-            "prompt_summary": idea_brief[:200],
-            "start_time": start_iso,
-            "end_time": end_time.isoformat(),
-            "duration_seconds": duration_seconds,
-            "status": "success",
-            "error": None,
-        }
+            # 2. Provider resolution (sync — blocks briefly, fine in Celery worker).
+            registry = ProviderRegistry.create_default()
+            entry = registry.resolve(model_key)
+            provider = registry.get_provider(model_key)
+
+            provider_type = entry.provider_type
+            endpoint = entry.endpoint
+
+            # 3. GPU lock acquisition (sync).
+            if entry.requires_gpu:
+                redis_client = _get_redis_client()
+                if redis_client is None:
+                    raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+                acquire_gpu_lock(redis_client, task_id)
+                lock_acquired = True
+                gpu_lock_acquired_at = _utc_now_iso()
+
+            try:
+                # 4. Generation, save, advance stage.
+                params = dict(entry.default_params or {})
+                generated = await provider.generate(prompt, params)
+                await _script_service.save_draft(
+                    run_id=run_id,
+                    source_type="generated_by_model",
+                    markdown_content=generated,
+                )
+                # Atomic success transition: only advance if run is still in a
+                # generating-compatible stage. Uses compare-and-set at the storage
+                # layer — no TOCTOU gap.
+                applied, _ = await _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.SCRIPT_REVIEW.value,
+                        "status": "running",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+                if not applied:
+                    logger.info(
+                        "Run %d stage changed during generation -- skipping SCRIPT_REVIEW transition",
+                        run_id,
+                    )
+            finally:
+                if lock_acquired:
+                    try:
+                        release_gpu_lock(redis_client, task_id)
+                        gpu_lock_released_at = _utc_now_iso()
+                    except Exception:
+                        logger.exception("Failed to release GPU lock for task %s", task_id)
+
+            end_time = datetime.now(timezone.utc)
+            duration_seconds = (end_time - start_time).total_seconds()
+            return {
+                "task_id": task_id,
+                "run_id": run_id,
+                "model_key": model_key,
+                "provider_type": provider_type,
+                "endpoint": endpoint,
+                "gpu_lock_acquired_at": gpu_lock_acquired_at,
+                "gpu_lock_released_at": gpu_lock_released_at,
+                "prompt_summary": idea_brief[:200],
+                "start_time": start_iso,
+                "end_time": end_time.isoformat(),
+                "duration_seconds": duration_seconds,
+                "status": "success",
+                "error": None,
+            }
+        finally:
+            await _remove_active_task_id_best_effort(run_id, task_id)
 
     try:
         return asyncio.run(_run_task())

--- a/apps/worker-orchestrator/tasks/generate_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_subtitles.py
@@ -37,8 +37,12 @@ _ALLOWED_STAGES = frozenset({RunStage.AUDIO_GENERATING, RunStage.SUBTITLE_GENERA
 _ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
 
 # Stages where writing RENDER_GENERATING or FAILED is safe — the run
-# hasn't advanced past subtitle generation.
-_SAFE_STAGES = frozenset({RunStage.SUBTITLE_GENERATING})
+# hasn't advanced past subtitle generation. The task may start directly
+# from AUDIO_GENERATING or from SUBTITLE_GENERATING after API-side CAS.
+_SAFE_STAGES = frozenset({
+    RunStage.AUDIO_GENERATING.value,
+    RunStage.SUBTITLE_GENERATING.value,
+})
 
 
 class _StageGuardError(ValueError):
@@ -57,6 +61,16 @@ def _get_redis_client() -> Any | None:
     if redis is None:
         return None
     return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+async def _remove_active_task_id_best_effort(run_id: int, task_id: str) -> None:
+    remover = getattr(_run_service.storage, "remove_active_task_id", None)
+    if not callable(remover):
+        return
+    try:
+        await remover(run_id, task_id)
+    except Exception:
+        logger.exception("Failed to remove active task id %s for run %d", task_id, run_id)
 
 
 @celery_app.task(bind=True, name="generate_subtitles")
@@ -80,124 +94,126 @@ def generate_subtitles(
     async def _run_task() -> dict[str, object]:
         nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
         nonlocal redis_client, lock_acquired
-
-        # 1. Stage guard — reject before any side effects.
-        run = await _run_service.storage.get_run(run_id)
-        if run is None:
-            raise _StageGuardError(f"Run {run_id} not found")
-
         try:
-            current = RunStage(run["current_stage"])
-        except ValueError as exc:
-            raise _StageGuardError(
-                f"Run {run_id} has invalid stage {run['current_stage']!r}"
-            ) from exc
-        if current not in _ALLOWED_STAGES:
-            raise _StageGuardError(
-                f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
-            )
+            # 1. Stage guard — reject before any side effects.
+            run = await _run_service.storage.get_run(run_id)
+            if run is None:
+                raise _StageGuardError(f"Run {run_id} not found")
 
-        # 2. Fetch approved script draft.
-        draft = await _script_service.get_active_draft(run_id)
-        if draft is None:
-            raise _StageGuardError(f"No script draft found for run {run_id}")
-
-        script_text = (draft.markdown_content or "").strip()
-        if not script_text and draft.structured_script:
-            script_text = "\n".join(
-                (section.display_text or section.text).strip()
-                for section in draft.structured_script
-                if (section.display_text or section.text).strip()
-            )
-
-        if not script_text:
-            raise _StageGuardError(f"Script draft for run {run_id} has no content")
-
-        # 3. Fetch latest audio artifact (optional timing context).
-        audio_artifact = await _audio_service.get_latest(run_id)
-        audio_path = audio_artifact.path if audio_artifact else None
-
-        # 4. Provider resolution (sync — blocks briefly, fine in Celery worker).
-        registry = ProviderRegistry.create_default()
-        entry = registry.resolve(subtitle_model)
-        provider = registry.get_provider(subtitle_model)
-
-        provider_type = entry.provider_type
-        endpoint = entry.endpoint
-
-        # 5. GPU lock acquisition (sync).
-        if entry.requires_gpu:
-            redis_client = _get_redis_client()
-            if redis_client is None:
-                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
-            acquire_gpu_lock(redis_client, task_id)
-            lock_acquired = True
-            gpu_lock_acquired_at = _utc_now_iso()
-
-        subtitle_path = f"{_ARTIFACT_ROOT}/{run_id}/subtitles/subtitles.{subtitle_format}"
-
-        try:
-            os.makedirs(os.path.dirname(subtitle_path), exist_ok=True)
-            # 6. Generate subtitles via provider.
-            params = dict(entry.default_params or {})
-            params["format"] = subtitle_format
-            params["output_path"] = subtitle_path
-            if not audio_path:
-                raise RuntimeError(f"No audio artifact found for run {run_id}; cannot transcribe")
-            await provider.transcribe(audio_path, params=params)
-
-            # 7. Save subtitle artifact via service.
-            artifact = await _subtitle_service.create_artifact(
-                run_id=run_id,
-                path=subtitle_path,
-                format=subtitle_format,
-                model_used=subtitle_model,
-                provider_type=entry.provider_type,
-            )
-
-            # 8. Atomic success transition.
-            applied, _ = await _run_service.storage.conditional_update_run(
-                run_id,
-                {
-                    "current_stage": RunStage.RENDER_GENERATING,
-                    "status": "running",
-                },
-                expected_stages=_SAFE_STAGES,
-            )
-            if not applied:
-                logger.info(
-                    "Run %d stage changed during subtitle generation -- skipping transition",
-                    run_id,
+            try:
+                current = RunStage(run["current_stage"])
+            except ValueError as exc:
+                raise _StageGuardError(
+                    f"Run {run_id} has invalid stage {run['current_stage']!r}"
+                ) from exc
+            if current not in _ALLOWED_STAGES:
+                raise _StageGuardError(
+                    f"Run {run_id} is in stage {current.value}, "
+                    f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
                 )
+
+            # 2. Fetch approved script draft.
+            draft = await _script_service.get_active_draft(run_id)
+            if draft is None:
+                raise _StageGuardError(f"No script draft found for run {run_id}")
+
+            script_text = (draft.markdown_content or "").strip()
+            if not script_text and draft.structured_script:
+                script_text = "\n".join(
+                    (section.display_text or section.text).strip()
+                    for section in draft.structured_script
+                    if (section.display_text or section.text).strip()
+                )
+
+            if not script_text:
+                raise _StageGuardError(f"Script draft for run {run_id} has no content")
+
+            # 3. Fetch latest audio artifact (optional timing context).
+            audio_artifact = await _audio_service.get_latest(run_id)
+            audio_path = audio_artifact.path if audio_artifact else None
+
+            # 4. Provider resolution (sync — blocks briefly, fine in Celery worker).
+            registry = ProviderRegistry.create_default()
+            entry = registry.resolve(subtitle_model)
+            provider = registry.get_provider(subtitle_model)
+
+            provider_type = entry.provider_type
+            endpoint = entry.endpoint
+
+            # 5. GPU lock acquisition (sync).
+            if entry.requires_gpu:
+                redis_client = _get_redis_client()
+                if redis_client is None:
+                    raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+                acquire_gpu_lock(redis_client, task_id)
+                lock_acquired = True
+                gpu_lock_acquired_at = _utc_now_iso()
+
+            subtitle_path = f"{_ARTIFACT_ROOT}/{run_id}/subtitles/subtitles.{subtitle_format}"
+
+            try:
+                os.makedirs(os.path.dirname(subtitle_path), exist_ok=True)
+                # 6. Generate subtitles via provider.
+                params = dict(entry.default_params or {})
+                params["format"] = subtitle_format
+                params["output_path"] = subtitle_path
+                if not audio_path:
+                    raise RuntimeError(f"No audio artifact found for run {run_id}; cannot transcribe")
+                await provider.transcribe(audio_path, params=params)
+
+                # 7. Save subtitle artifact via service.
+                artifact = await _subtitle_service.create_artifact(
+                    run_id=run_id,
+                    path=subtitle_path,
+                    format=subtitle_format,
+                    model_used=subtitle_model,
+                    provider_type=entry.provider_type,
+                )
+
+                # 8. Atomic success transition.
+                applied, _ = await _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.RENDER_GENERATING,
+                        "status": "running",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+                if not applied:
+                    logger.info(
+                        "Run %d stage changed during subtitle generation -- skipping transition",
+                        run_id,
+                    )
+            finally:
+                if lock_acquired:
+                    try:
+                        release_gpu_lock(redis_client, task_id)
+                        gpu_lock_released_at = _utc_now_iso()
+                    except Exception:
+                        logger.exception("Failed to release GPU lock for task %s", task_id)
+
+            end_time = datetime.now(timezone.utc)
+            duration_seconds = (end_time - start_time).total_seconds()
+
+            return {
+                "task_id": task_id,
+                "run_id": run_id,
+                "subtitle_model": subtitle_model,
+                "subtitle_format": subtitle_format,
+                "provider_type": provider_type,
+                "endpoint": endpoint,
+                "gpu_lock_acquired_at": gpu_lock_acquired_at,
+                "gpu_lock_released_at": gpu_lock_released_at,
+                "subtitle_artifact_id": artifact.id,
+                "subtitle_path": artifact.path,
+                "audio_path": audio_path,
+                "start_time": start_iso,
+                "end_time": end_time.isoformat(),
+                "duration_seconds": duration_seconds,
+                "status": "success",
+            }
         finally:
-            if lock_acquired:
-                try:
-                    release_gpu_lock(redis_client, task_id)
-                    gpu_lock_released_at = _utc_now_iso()
-                except Exception:
-                    logger.exception("Failed to release GPU lock for task %s", task_id)
-
-        end_time = datetime.now(timezone.utc)
-        duration_seconds = (end_time - start_time).total_seconds()
-
-        return {
-            "task_id": task_id,
-            "run_id": run_id,
-            "subtitle_model": subtitle_model,
-            "subtitle_format": subtitle_format,
-            "provider_type": provider_type,
-            "endpoint": endpoint,
-            "gpu_lock_acquired_at": gpu_lock_acquired_at,
-            "gpu_lock_released_at": gpu_lock_released_at,
-            "subtitle_artifact_id": artifact.id,
-            "subtitle_path": artifact.path,
-            "audio_path": audio_path,
-            "start_time": start_iso,
-            "end_time": end_time.isoformat(),
-            "duration_seconds": duration_seconds,
-            "status": "success",
-        }
+            await _remove_active_task_id_best_effort(run_id, task_id)
 
     try:
         return asyncio.run(_run_task())

--- a/apps/worker-orchestrator/tasks/generate_visual_plan.py
+++ b/apps/worker-orchestrator/tasks/generate_visual_plan.py
@@ -144,6 +144,16 @@ def _get_redis_client() -> Any | None:
     return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
 
 
+async def _remove_active_task_id_best_effort(run_id: int, task_id: str) -> None:
+    remover = getattr(_run_service.storage, "remove_active_task_id", None)
+    if not callable(remover):
+        return
+    try:
+        await remover(run_id, task_id)
+    except Exception:
+        logger.exception("Failed to remove active task id %s for run %d", task_id, run_id)
+
+
 @celery_app.task(bind=True, name="generate_visual_plan")
 def generate_visual_plan(
     self,
@@ -165,115 +175,115 @@ def generate_visual_plan(
     async def _run_task() -> dict[str, object]:
         nonlocal provider_type, endpoint, gpu_lock_acquired_at, gpu_lock_released_at
         nonlocal redis_client, lock_acquired
-
-        # 1. Stage guard — reject before any side effects.
-        run = await _run_service.storage.get_run(run_id)
-        if run is None:
-            raise _StageGuardError(f"Run {run_id} not found")
-
         try:
-            current = RunStage(run["current_stage"])
-        except ValueError as exc:
-            raise _StageGuardError(
-                f"Run {run_id} has invalid stage {run['current_stage']!r}"
-            ) from exc
-        if current not in _ALLOWED_STAGES:
-            raise _StageGuardError(
-                f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
-            )
+            # 1. Stage guard — reject before any side effects.
+            run = await _run_service.storage.get_run(run_id)
+            if run is None:
+                raise _StageGuardError(f"Run {run_id} not found")
 
-        # 2. Fetch approved script draft.
-        draft = await _script_service.get_active_draft(run_id)
-        if draft is None:
-            raise _StageGuardError(f"No script draft found for run {run_id}")
-
-        # Extract sections from the draft
-        sections: list[dict[str, Any]] = []
-        if draft.structured_script:
-            sections = [s.model_dump(mode="json") for s in draft.structured_script]
-        elif draft.markdown_content:
-            # Minimal fallback: single section from raw markdown
-            sections = [{"section_id": "sec-0", "type": "body", "text": draft.markdown_content}]
-
-        if not sections:
-            raise _StageGuardError(f"Script draft for run {run_id} has no content")
-
-        # 3. Provider resolution (sync — blocks briefly, fine in Celery worker).
-        registry = ProviderRegistry.create_default()
-        entry = registry.resolve(model_key)
-        provider = registry.get_provider(model_key)
-
-        provider_type = entry.provider_type
-        endpoint = entry.endpoint
-
-        # 4. GPU lock acquisition (sync).
-        if entry.requires_gpu:
-            redis_client = _get_redis_client()
-            if redis_client is None:
-                raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
-            acquire_gpu_lock(redis_client, task_id)
-            lock_acquired = True
-            gpu_lock_acquired_at = _utc_now_iso()
-
-        try:
-            # 5. Generation: send script sections to LLM for visual planning.
-            system_prompt = _build_system_prompt(style_preset)
-            sections_prompt = _build_sections_prompt(sections)
-            full_prompt = f"{system_prompt}\n\n---\nScript sections:\n{sections_prompt}"
-
-            params = dict(entry.default_params or {})
-            raw_response = await provider.generate(full_prompt, params)
-
-            # 6. Parse LLM response into VisualScene objects.
-            visual_scenes = _parse_llm_response(raw_response, sections)
-
-            # 7. Save visual plan via service.
-            await _visual_plan_service.save_plan(
-                run_id=run_id,
-                scenes=visual_scenes,
-            )
-
-            # 8. Atomic success transition: only advance if run is still in a
-            # generating-compatible stage.
-            applied, _ = await _run_service.storage.conditional_update_run(
-                run_id,
-                {
-                    "current_stage": RunStage.VISUAL_PLAN_REVIEW.value,
-                    "status": "running",
-                },
-                expected_stages=_SAFE_STAGES,
-            )
-            if not applied:
-                logger.info(
-                    "Run %d stage changed during visual plan generation -- skipping transition",
-                    run_id,
+            try:
+                current = RunStage(run["current_stage"])
+            except ValueError as exc:
+                raise _StageGuardError(
+                    f"Run {run_id} has invalid stage {run['current_stage']!r}"
+                ) from exc
+            if current not in _ALLOWED_STAGES:
+                raise _StageGuardError(
+                    f"Run {run_id} is in stage {current.value}, "
+                    f"expected one of {', '.join(s.value for s in _ALLOWED_STAGES)}"
                 )
-        finally:
-            if lock_acquired:
-                try:
-                    release_gpu_lock(redis_client, task_id)
-                    gpu_lock_released_at = _utc_now_iso()
-                except Exception:
-                    logger.exception("Failed to release GPU lock for task %s", task_id)
 
-        end_time = datetime.now(timezone.utc)
-        duration_seconds = (end_time - start_time).total_seconds()
-        return {
-            "task_id": task_id,
-            "run_id": run_id,
-            "model_key": model_key,
-            "provider_type": provider_type,
-            "endpoint": endpoint,
-            "gpu_lock_acquired_at": gpu_lock_acquired_at,
-            "gpu_lock_released_at": gpu_lock_released_at,
-            "scene_count": len(visual_scenes),
-            "start_time": start_iso,
-            "end_time": end_time.isoformat(),
-            "duration_seconds": duration_seconds,
-            "status": "success",
-            "error": None,
-        }
+            # 2. Fetch approved script draft.
+            draft = await _script_service.get_active_draft(run_id)
+            if draft is None:
+                raise _StageGuardError(f"No script draft found for run {run_id}")
+
+            sections: list[dict[str, Any]] = []
+            if draft.structured_script:
+                sections = [s.model_dump(mode="json") for s in draft.structured_script]
+            elif draft.markdown_content:
+                sections = [{"section_id": "sec-0", "type": "body", "text": draft.markdown_content}]
+
+            if not sections:
+                raise _StageGuardError(f"Script draft for run {run_id} has no content")
+
+            # 3. Provider resolution (sync — blocks briefly, fine in Celery worker).
+            registry = ProviderRegistry.create_default()
+            entry = registry.resolve(model_key)
+            provider = registry.get_provider(model_key)
+
+            provider_type = entry.provider_type
+            endpoint = entry.endpoint
+
+            # 4. GPU lock acquisition (sync).
+            if entry.requires_gpu:
+                redis_client = _get_redis_client()
+                if redis_client is None:
+                    raise RuntimeError("Redis client is unavailable; cannot acquire GPU lock")
+                acquire_gpu_lock(redis_client, task_id)
+                lock_acquired = True
+                gpu_lock_acquired_at = _utc_now_iso()
+
+            try:
+                # 5. Generation: send script sections to LLM for visual planning.
+                system_prompt = _build_system_prompt(style_preset)
+                sections_prompt = _build_sections_prompt(sections)
+                full_prompt = f"{system_prompt}\n\n---\nScript sections:\n{sections_prompt}"
+
+                params = dict(entry.default_params or {})
+                raw_response = await provider.generate(full_prompt, params)
+
+                # 6. Parse LLM response into VisualScene objects.
+                visual_scenes = _parse_llm_response(raw_response, sections)
+
+                # 7. Save visual plan via service.
+                await _visual_plan_service.save_plan(
+                    run_id=run_id,
+                    scenes=visual_scenes,
+                )
+
+                # 8. Atomic success transition: only advance if run is still in a
+                # generating-compatible stage.
+                applied, _ = await _run_service.storage.conditional_update_run(
+                    run_id,
+                    {
+                        "current_stage": RunStage.VISUAL_PLAN_REVIEW.value,
+                        "status": "running",
+                    },
+                    expected_stages=_SAFE_STAGES,
+                )
+                if not applied:
+                    logger.info(
+                        "Run %d stage changed during visual plan generation -- skipping transition",
+                        run_id,
+                    )
+            finally:
+                if lock_acquired:
+                    try:
+                        release_gpu_lock(redis_client, task_id)
+                        gpu_lock_released_at = _utc_now_iso()
+                    except Exception:
+                        logger.exception("Failed to release GPU lock for task %s", task_id)
+
+            end_time = datetime.now(timezone.utc)
+            duration_seconds = (end_time - start_time).total_seconds()
+            return {
+                "task_id": task_id,
+                "run_id": run_id,
+                "model_key": model_key,
+                "provider_type": provider_type,
+                "endpoint": endpoint,
+                "gpu_lock_acquired_at": gpu_lock_acquired_at,
+                "gpu_lock_released_at": gpu_lock_released_at,
+                "scene_count": len(visual_scenes),
+                "start_time": start_iso,
+                "end_time": end_time.isoformat(),
+                "duration_seconds": duration_seconds,
+                "status": "success",
+                "error": None,
+            }
+        finally:
+            await _remove_active_task_id_best_effort(run_id, task_id)
 
     try:
         return asyncio.run(_run_task())

--- a/apps/worker-orchestrator/tasks/render_video.py
+++ b/apps/worker-orchestrator/tasks/render_video.py
@@ -25,6 +25,7 @@ from creator_service.render_service import render_service as _render_service
 from creator_service.run_service import run_service as _run_service
 from creator_service.subtitle_service import subtitle_service as _subtitle_service
 from creator_service.visual_asset_service import visual_asset_service as _visual_asset_service
+from creator_service.visual_plan_service import visual_plan_service as _visual_plan_service
 from creator_service.script_service import script_service as _script_service
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,16 @@ def _resolve_profile(name: str) -> RenderProfile:
         return RenderProfile.default()
     return factory()
 
+
+async def _remove_active_task_id_best_effort(run_id: int, task_id: str) -> None:
+    remover = getattr(_run_service.storage, "remove_active_task_id", None)
+    if not callable(remover):
+        return
+    try:
+        await remover(run_id, task_id)
+    except Exception:
+        logger.exception("Failed to remove active task id %s for run %d", task_id, run_id)
+
 @celery_app.task(bind=True, name="render_video")
 def render_video(
     self,
@@ -63,186 +74,188 @@ def render_video(
     task_id = str(getattr(getattr(self, "request", None), "id", None) or f"run-{run_id}")
 
     async def _run_task() -> dict[str, object]:
-        run = await _run_service.storage.get_run(run_id)
-        if run is None:
-            raise _StageGuardError(f"Run {run_id} not found")
-
         try:
-            current = RunStage(run["current_stage"])
-        except ValueError as exc:
-            raise _StageGuardError(
-                f"Run {run_id} has invalid stage {run['current_stage']!r}"
-            ) from exc
-        if current not in _ALLOWED_STAGES:
-            raise _StageGuardError(
-                f"Run {run_id} is in stage {current.value}, "
-                f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
+            run = await _run_service.storage.get_run(run_id)
+            if run is None:
+                raise _StageGuardError(f"Run {run_id} not found")
+
+            try:
+                current = RunStage(run["current_stage"])
+            except ValueError as exc:
+                raise _StageGuardError(
+                    f"Run {run_id} has invalid stage {run['current_stage']!r}"
+                ) from exc
+            if current not in _ALLOWED_STAGES:
+                raise _StageGuardError(
+                    f"Run {run_id} is in stage {current.value}, "
+                    f"expected one of {', '.join(s for s in _ALLOWED_STAGES)}"
+                )
+
+            manifest = await _render_service.build_render_manifest(
+                run_id,
+                _visual_asset_service,
+                _audio_service,
+                _subtitle_service,
+                render_profile_name=render_profile,
             )
 
-        manifest = await _render_service.build_render_manifest(
-            run_id,
-            _visual_asset_service,
-            _audio_service,
-            _subtitle_service,
-            render_profile_name=render_profile,
-        )
+            active_plan = await _visual_plan_service.get_active_plan(run_id)
+            if active_plan is not None:
+                scenes_by_id = {scene["scene_id"]: scene for scene in manifest["scenes"]}
+                ordered_scenes = [
+                    scenes_by_id[scene.scene_id]
+                    for scene in active_plan.scenes
+                    if scene.scene_id in scenes_by_id
+                ]
+                remaining_scenes = [
+                    scene
+                    for scene in manifest["scenes"]
+                    if scene["scene_id"] not in {ordered["scene_id"] for ordered in ordered_scenes}
+                ]
+                manifest["scenes"] = ordered_scenes + remaining_scenes
 
-        if not manifest["scenes"]:
-            raise RuntimeError("No scenes found for render")
+            if not manifest["scenes"]:
+                raise RuntimeError("No scenes found for render")
 
-        profile_data = manifest["render_profile"]
-        scene_count = len(manifest["scenes"])
-        image_paths = [Path(scene["asset_path"]) for scene in manifest["scenes"]]
+            profile_data = manifest["render_profile"]
+            scene_count = len(manifest["scenes"])
+            image_paths = [Path(scene["asset_path"]) for scene in manifest["scenes"]]
 
-        resolved_profile = _resolve_profile(render_profile)
-        ffmpeg = FFmpegService(profile=resolved_profile)
+            resolved_profile = _resolve_profile(render_profile)
+            ffmpeg = FFmpegService(profile=resolved_profile)
 
-        # --- Per-paragraph audio/subtitle assembly (Phase 9) -----------------
-        # Try per-paragraph artifacts first; fall back to run-level.
-        paragraph_audio = await _audio_service.list_paragraph_audio(run_id)
-        paragraph_subtitles = await _subtitle_service.list_paragraph_subtitles(run_id)
+            paragraph_audio = await _audio_service.list_paragraph_audio(run_id)
+            paragraph_subtitles = await _subtitle_service.list_paragraph_subtitles(run_id)
 
-        audio_path: Path | None = None
-        subtitle_path: Path | None = None
-        scene_durations: list[float]
+            audio_path: Path | None = None
+            subtitle_path: Path | None = None
+            scene_durations: list[float]
 
-        if paragraph_audio:
-            # Build section_id -> audio mapping
-            audio_by_section: dict[str, Any] = {}
-            for a in paragraph_audio:
-                if a.section_id and a.section_id not in audio_by_section:
-                    audio_by_section[a.section_id] = a
+            if paragraph_audio:
+                audio_by_section: dict[str, Any] = {}
+                for a in paragraph_audio:
+                    if a.section_id and a.section_id not in audio_by_section:
+                        audio_by_section[a.section_id] = a
 
-            # Get section order from script
-            draft = await _script_service.get_active_draft(run_id)
-            if draft and draft.structured_script:
-                ordered_sections = [s.section_id for s in draft.structured_script]
-            else:
-                ordered_sections = sorted(audio_by_section.keys())
+                draft = await _script_service.get_active_draft(run_id)
+                if draft and draft.structured_script:
+                    ordered_sections = [s.section_id for s in draft.structured_script]
+                else:
+                    ordered_sections = list(audio_by_section.keys())
 
-            # Collect audio files and durations in section order
-            ordered_audio_paths: list[str] = []
-            ordered_durations: list[float] = []
-            for sid in ordered_sections:
-                art = audio_by_section.get(sid)
-                if art:
-                    ordered_audio_paths.append(art.path)
-                    try:
-                        dur = ffmpeg.get_audio_duration(art.path)
-                    except Exception:
-                        logger.warning(
-                            "Failed to probe duration for %s, using 5.0s fallback",
-                            art.path,
+                ordered_audio_paths: list[str] = []
+                duration_by_section: dict[str, float] = {}
+                for sid in ordered_sections:
+                    art = audio_by_section.get(sid)
+                    if art:
+                        ordered_audio_paths.append(art.path)
+                        try:
+                            duration_by_section[sid] = ffmpeg.get_audio_duration(art.path)
+                        except Exception:
+                            logger.warning(
+                                "Failed to probe duration for %s, using 5.0s fallback",
+                                art.path,
+                            )
+                            duration_by_section[sid] = 5.0
+
+                if ordered_audio_paths:
+                    concat_path = f"{_ARTIFACT_ROOT}/{run_id}/render/audio_concat.wav"
+                    ffmpeg.concatenate_audio(ordered_audio_paths, concat_path)
+                    audio_path = Path(concat_path)
+
+                    scene_durations = [
+                        duration_by_section[sid]
+                        for sid in ordered_sections
+                        if sid in duration_by_section
+                    ][:scene_count]
+                    if len(scene_durations) < scene_count:
+                        total_known = sum(scene_durations)
+                        remaining = max(0.0, profile_data["max_duration_seconds"] - total_known)
+                        missing = scene_count - len(scene_durations)
+                        pad_dur = remaining / missing if missing > 0 else 5.0
+                        scene_durations.extend([pad_dur] * missing)
+                else:
+                    scene_duration = profile_data["max_duration_seconds"] / scene_count
+                    scene_durations = [scene_duration] * scene_count
+
+                if paragraph_subtitles:
+                    sub_by_section: dict[str, Any] = {}
+                    for s in paragraph_subtitles:
+                        if s.section_id and s.section_id not in sub_by_section:
+                            sub_by_section[s.section_id] = s
+
+                    ordered_sub_paths: list[str] = []
+                    ordered_sub_durations: list[float] = []
+                    for sid in ordered_sections:
+                        sub = sub_by_section.get(sid)
+                        if sub:
+                            ordered_sub_paths.append(sub.path)
+                            ordered_sub_durations.append(duration_by_section.get(sid, 5.0))
+
+                    if ordered_sub_paths:
+                        merged_sub_path = f"{_ARTIFACT_ROOT}/{run_id}/render/subtitles_merged.srt"
+                        ffmpeg.merge_subtitles(
+                            ordered_sub_paths, ordered_sub_durations, merged_sub_path
                         )
-                        dur = 5.0
-                    ordered_durations.append(dur)
-
-            if ordered_audio_paths:
-                # Concatenate per-paragraph audio into a single file
-                concat_path = f"{_ARTIFACT_ROOT}/{run_id}/render/audio_concat.wav"
-                ffmpeg.concatenate_audio(ordered_audio_paths, concat_path)
-                audio_path = Path(concat_path)
-
-                # Use actual per-paragraph durations for scene timing
-                scene_durations = ordered_durations[:scene_count]
-                # If fewer durations than scenes, pad with equal split of remaining time
-                if len(scene_durations) < scene_count:
-                    total_known = sum(scene_durations)
-                    remaining = max(0.0, profile_data["max_duration_seconds"] - total_known)
-                    missing = scene_count - len(scene_durations)
-                    pad_dur = remaining / missing if missing > 0 else 5.0
-                    scene_durations.extend([pad_dur] * missing)
+                        subtitle_path = Path(merged_sub_path)
             else:
-                # No matched audio — fall back to equal split
+                run_audio_path = manifest["audio_path"]
+                audio_path = Path(run_audio_path) if run_audio_path else None
+                run_sub_path = manifest["subtitle_path"]
+                subtitle_path = Path(run_sub_path) if run_sub_path else None
                 scene_duration = profile_data["max_duration_seconds"] / scene_count
                 scene_durations = [scene_duration] * scene_count
 
-            # Merge per-paragraph subtitles if available
-            if paragraph_subtitles:
-                sub_by_section: dict[str, Any] = {}
-                for s in paragraph_subtitles:
-                    if s.section_id and s.section_id not in sub_by_section:
-                        sub_by_section[s.section_id] = s
-
-                ordered_sub_paths: list[str] = []
-                ordered_sub_durations: list[float] = []
-                for sid in ordered_sections:
-                    sub = sub_by_section.get(sid)
-                    if sub:
-                        ordered_sub_paths.append(sub.path)
-                        # Use same duration as audio
-                        art = audio_by_section.get(sid)
-                        ordered_sub_durations.append(
-                            ordered_durations[ordered_sections.index(sid)]
-                            if sid in audio_by_section and ordered_durations
-                            else 5.0
-                        )
-
-                if ordered_sub_paths:
-                    merged_sub_path = f"{_ARTIFACT_ROOT}/{run_id}/render/subtitles_merged.srt"
-                    ffmpeg.merge_subtitles(
-                        ordered_sub_paths, ordered_sub_durations, merged_sub_path
-                    )
-                    subtitle_path = Path(merged_sub_path)
-        else:
-            # No per-paragraph audio — fall back to run-level artifacts
-            run_audio_path = manifest["audio_path"]
-            audio_path = Path(run_audio_path) if run_audio_path else None
-            run_sub_path = manifest["subtitle_path"]
-            subtitle_path = Path(run_sub_path) if run_sub_path else None
-            scene_duration = profile_data["max_duration_seconds"] / scene_count
-            scene_durations = [scene_duration] * scene_count
-
-        render_input = RenderInput(
-            image_paths=image_paths,
-            audio_path=audio_path,
-            subtitle_path=subtitle_path,
-            scene_durations=scene_durations,
-        )
-
-        output_path = f"{_ARTIFACT_ROOT}/{run_id}/render/output.mp4"
-        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-        resolved_profile = _resolve_profile(render_profile)
-        ffmpeg = FFmpegService(profile=resolved_profile)
-        ffmpeg.render(render_input, Path(output_path))
-
-        artifact = await _render_service.create_artifact(
-            run_id=run_id,
-            path=output_path,
-            render_profile=render_profile,
-        )
-
-        applied, _ = await _run_service.storage.conditional_update_run(
-            run_id,
-            {
-                "current_stage": RunStage.FINAL_REVIEW,
-                "status": "running",
-            },
-            expected_stages=_SAFE_STAGES,
-        )
-        if not applied:
-            logger.info(
-                "Run %d stage changed during video render -- skipping transition",
-                run_id,
+            render_input = RenderInput(
+                image_paths=image_paths,
+                audio_path=audio_path,
+                subtitle_path=subtitle_path,
+                scene_durations=scene_durations,
             )
 
-        end_time = datetime.now(timezone.utc)
-        duration_seconds = (end_time - start_time).total_seconds()
+            output_path = f"{_ARTIFACT_ROOT}/{run_id}/render/output.mp4"
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            ffmpeg.render(render_input, Path(output_path))
 
-        return {
-            "task_id": task_id,
-            "run_id": run_id,
-            "render_profile": render_profile,
-            "video_artifact_id": artifact.id,
-            "video_path": artifact.path,
-            "scene_count": len(manifest["scenes"]),
-            "audio_path": manifest["audio_path"],
-            "subtitle_path": manifest["subtitle_path"],
-            "start_time": start_iso,
-            "end_time": end_time.isoformat(),
-            "duration_seconds": duration_seconds,
-            "status": "success",
-        }
+            artifact = await _render_service.create_artifact(
+                run_id=run_id,
+                path=output_path,
+                render_profile=render_profile,
+            )
+
+            applied, _ = await _run_service.storage.conditional_update_run(
+                run_id,
+                {
+                    "current_stage": RunStage.FINAL_REVIEW,
+                    "status": "running",
+                },
+                expected_stages=_SAFE_STAGES,
+            )
+            if not applied:
+                logger.info(
+                    "Run %d stage changed during video render -- skipping transition",
+                    run_id,
+                )
+
+            end_time = datetime.now(timezone.utc)
+            duration_seconds = (end_time - start_time).total_seconds()
+
+            return {
+                "task_id": task_id,
+                "run_id": run_id,
+                "render_profile": render_profile,
+                "video_artifact_id": artifact.id,
+                "video_path": artifact.path,
+                "scene_count": len(manifest["scenes"]),
+                "audio_path": manifest["audio_path"],
+                "subtitle_path": manifest["subtitle_path"],
+                "start_time": start_iso,
+                "end_time": end_time.isoformat(),
+                "duration_seconds": duration_seconds,
+                "status": "success",
+            }
+        finally:
+            await _remove_active_task_id_best_effort(run_id, task_id)
 
     try:
         return asyncio.run(_run_task())

--- a/apps/worker-orchestrator/tests/__init__.py
+++ b/apps/worker-orchestrator/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Test module for worker-orchestrator."""

--- a/apps/worker-orchestrator/tests/test_generate_audio.py
+++ b/apps/worker-orchestrator/tests/test_generate_audio.py
@@ -200,7 +200,7 @@ def test_generate_audio_success(monkeypatch: pytest.MonkeyPatch) -> None:
         }
     ]
     assert storage.calls == [(101, {"current_stage": "SUBTITLE_GENERATING", "status": "running"})]
-    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING"})
+    assert storage.cas_calls[0][2] == frozenset({"VISUAL_ASSET_REVIEW", "AUDIO_GENERATING"})
 
 
 def test_generate_audio_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -268,7 +268,7 @@ def test_generate_audio_provider_failure_marks_failed(monkeypatch: pytest.Monkey
 
     assert audio_service.calls == []
     assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
-    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING"})
+    assert storage.cas_calls[0][2] == frozenset({"VISUAL_ASSET_REVIEW", "AUDIO_GENERATING"})
 
 
 def test_generate_audio_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/worker-orchestrator/tests/test_generate_scene_image.py
+++ b/apps/worker-orchestrator/tests/test_generate_scene_image.py
@@ -854,3 +854,25 @@ def test_scene_results_contain_asset_info(monkeypatch: pytest.MonkeyPatch) -> No
     assert sr["asset_id"] == 1
     assert sr["version"] == 1
     assert "asset_path" in sr
+
+
+def test_regeneration_uses_unique_asset_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeImageProvider()
+    entry = FakeEntry(requires_gpu=False)
+    registry = FakeRegistry(entry=entry, provider=provider)
+    _patch_registry(monkeypatch, registry)
+
+    plan = FakeVisualPlan(run_id=703, scenes=[FakeVisualScene()])
+    vp_service = FakeVisualPlanService(plan=plan)
+    va_service = FakeVisualAssetService()
+    storage = _make_storage(run_id=703, stage="VISUAL_PLAN_REVIEW")
+    _patch_services(monkeypatch, vp_service, va_service, storage)
+
+    first = _invoke_task(run_id=703, scene_id="scene-sec-0")
+    second = _invoke_task(run_id=703, scene_id="scene-sec-0", prompt_override="New prompt")
+
+    first_path = first["scene_results"][0]["asset_path"]
+    second_path = second["scene_results"][0]["asset_path"]
+
+    assert first_path != second_path
+    assert va_service.calls[0]["asset_path"] != va_service.calls[1]["asset_path"]

--- a/apps/worker-orchestrator/tests/test_generate_subtitles.py
+++ b/apps/worker-orchestrator/tests/test_generate_subtitles.py
@@ -221,7 +221,7 @@ def test_generate_subtitles_success(monkeypatch: pytest.MonkeyPatch) -> None:
         }
     ]
     assert storage.calls == [(101, {"current_stage": "RENDER_GENERATING", "status": "running"})]
-    assert storage.cas_calls[0][2] == frozenset({"SUBTITLE_GENERATING"})
+    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING", "SUBTITLE_GENERATING"})
 
 
 def test_generate_subtitles_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -293,7 +293,7 @@ def test_generate_subtitles_provider_failure_marks_failed(monkeypatch: pytest.Mo
 
     assert subtitle_service.calls == []
     assert storage.calls == [(104, {"current_stage": "FAILED", "status": "failed"})]
-    assert storage.cas_calls[0][2] == frozenset({"SUBTITLE_GENERATING"})
+    assert storage.cas_calls[0][2] == frozenset({"AUDIO_GENERATING", "SUBTITLE_GENERATING"})
 
 
 def test_generate_subtitles_with_audio_path(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/worker-orchestrator/tests/test_render_video.py
+++ b/apps/worker-orchestrator/tests/test_render_video.py
@@ -60,27 +60,82 @@ class FakeVisualAssetService:
 @dataclass
 class FakeAudioArtifact:
     path: str
+    section_id: str | None = None
 
 
 class FakeAudioService:
-    def __init__(self, artifact: FakeAudioArtifact | None = None) -> None:
+    def __init__(
+        self,
+        artifact: FakeAudioArtifact | None = None,
+        paragraph_artifacts: list[FakeAudioArtifact] | None = None,
+    ) -> None:
         self.artifact = artifact
+        self.paragraph_artifacts = paragraph_artifacts or []
 
     async def get_latest(self, _run_id: int) -> FakeAudioArtifact | None:
         return self.artifact
+
+    async def list_paragraph_audio(self, _run_id: int) -> list[FakeAudioArtifact]:
+        return self.paragraph_artifacts
 
 
 @dataclass
 class FakeSubtitleArtifact:
     path: str
+    section_id: str | None = None
 
 
 class FakeSubtitleService:
-    def __init__(self, artifact: FakeSubtitleArtifact | None = None) -> None:
+    def __init__(
+        self,
+        artifact: FakeSubtitleArtifact | None = None,
+        paragraph_artifacts: list[FakeSubtitleArtifact] | None = None,
+    ) -> None:
         self.artifact = artifact
+        self.paragraph_artifacts = paragraph_artifacts or []
 
     async def get_latest(self, _run_id: int) -> FakeSubtitleArtifact | None:
         return self.artifact
+
+    async def list_paragraph_subtitles(self, _run_id: int) -> list[FakeSubtitleArtifact]:
+        return self.paragraph_artifacts
+
+
+@dataclass
+class FakePlanScene:
+    scene_id: str
+    section_id: str
+
+
+@dataclass
+class FakeVisualPlan:
+    scenes: list[FakePlanScene]
+
+
+class FakeVisualPlanService:
+    def __init__(self, plan: FakeVisualPlan | None = None) -> None:
+        self.plan = plan
+
+    async def get_active_plan(self, _run_id: int) -> FakeVisualPlan | None:
+        return self.plan
+
+
+@dataclass
+class FakeScriptSection:
+    section_id: str
+
+
+@dataclass
+class FakeScriptDraft:
+    structured_script: list[FakeScriptSection] | None
+
+
+class FakeScriptService:
+    def __init__(self, draft: FakeScriptDraft | None = None) -> None:
+        self.draft = draft
+
+    async def get_active_draft(self, _run_id: int) -> FakeScriptDraft | None:
+        return self.draft
 
 
 @dataclass
@@ -141,11 +196,30 @@ class FakeFFmpegService:
     def __init__(self, error: Exception | None = None) -> None:
         self.error = error
         self.calls: list[tuple[Any, Path]] = []
+        self.concatenate_calls: list[tuple[list[str], str]] = []
+        self.merge_calls: list[tuple[list[str], list[float], str]] = []
+        self.duration_map: dict[str, float] = {}
 
     def render(self, render_input: Any, output_path: Path) -> Path:
         self.calls.append((render_input, output_path))
         if self.error is not None:
             raise self.error
+        return output_path
+
+    def get_audio_duration(self, path: str) -> float:
+        return self.duration_map[path]
+
+    def concatenate_audio(self, input_paths: list[str], output_path: str) -> str:
+        self.concatenate_calls.append((input_paths, output_path))
+        return output_path
+
+    def merge_subtitles(
+        self,
+        input_paths: list[str],
+        durations: list[float],
+        output_path: str,
+    ) -> str:
+        self.merge_calls.append((input_paths, durations, output_path))
         return output_path
 
 
@@ -193,12 +267,24 @@ def _patch_services(
     fake_audio: FakeAudioService,
     fake_subtitle: FakeSubtitleService,
     fake_ffmpeg: FakeFFmpegService,
+    fake_visual_plan: FakeVisualPlanService | None = None,
+    fake_script: FakeScriptService | None = None,
 ) -> None:
     monkeypatch.setattr(render_video_module, "_run_service", SimpleNamespace(storage=storage))
     monkeypatch.setattr(render_video_module, "_render_service", fake_render_service)
     monkeypatch.setattr(render_video_module, "_visual_asset_service", fake_vas)
     monkeypatch.setattr(render_video_module, "_audio_service", fake_audio)
     monkeypatch.setattr(render_video_module, "_subtitle_service", fake_subtitle)
+    monkeypatch.setattr(
+        render_video_module,
+        "_visual_plan_service",
+        fake_visual_plan or FakeVisualPlanService(),
+    )
+    monkeypatch.setattr(
+        render_video_module,
+        "_script_service",
+        fake_script or FakeScriptService(),
+    )
     monkeypatch.setattr(render_video_module, "FFmpegService", lambda profile=None: fake_ffmpeg)
 
 
@@ -506,3 +592,127 @@ def test_render_video_profile_propagated_to_ffmpeg(monkeypatch: pytest.MonkeyPat
     assert profile.name == "high_quality"
     assert profile.crf == 18
     assert profile.preset == "slow"
+
+
+def test_render_video_reorders_scenes_from_active_visual_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = 209
+    storage = _make_storage(run_id=run_id, stage="RENDER_GENERATING")
+    fake_render_service = FakeRenderService(
+        manifest=_manifest(
+            run_id=run_id,
+            scenes=[
+                {"scene_id": "scene-10", "asset_path": "data/artifacts/209/visual/scene-10.png"},
+                {"scene_id": "scene-2", "asset_path": "data/artifacts/209/visual/scene-2.png"},
+            ],
+        ),
+        artifact_path="data/artifacts/209/render/output.mp4",
+    )
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService()
+    fake_subtitle = FakeSubtitleService()
+    fake_ffmpeg = FakeFFmpegService()
+    fake_visual_plan = FakeVisualPlanService(
+        FakeVisualPlan(
+            scenes=[
+                FakePlanScene(scene_id="scene-2", section_id="sec-2"),
+                FakePlanScene(scene_id="scene-10", section_id="sec-10"),
+            ]
+        )
+    )
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+        fake_visual_plan=fake_visual_plan,
+    )
+
+    result = _invoke_task(run_id=run_id)
+
+    assert result["status"] == "success"
+    render_input, _ = fake_ffmpeg.calls[0]
+    assert render_input.image_paths == [
+        Path("data/artifacts/209/visual/scene-2.png"),
+        Path("data/artifacts/209/visual/scene-10.png"),
+    ]
+
+
+def test_render_video_handles_sparse_paragraph_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = 210
+    storage = _make_storage(run_id=run_id, stage="RENDER_GENERATING")
+    fake_render_service = FakeRenderService(
+        manifest=_manifest(
+            run_id=run_id,
+            scenes=[
+                {"scene_id": "scene-1", "asset_path": "data/artifacts/210/visual/scene-1.png"},
+                {"scene_id": "scene-2", "asset_path": "data/artifacts/210/visual/scene-2.png"},
+            ],
+        ),
+        artifact_path="data/artifacts/210/render/output.mp4",
+    )
+    fake_vas = FakeVisualAssetService()
+    fake_audio = FakeAudioService(
+        paragraph_artifacts=[
+            FakeAudioArtifact(path="data/artifacts/210/audio/sec-2.wav", section_id="sec-2")
+        ]
+    )
+    fake_subtitle = FakeSubtitleService(
+        paragraph_artifacts=[
+            FakeSubtitleArtifact(path="data/artifacts/210/subtitles/sec-2.srt", section_id="sec-2")
+        ]
+    )
+    fake_ffmpeg = FakeFFmpegService()
+    fake_ffmpeg.duration_map["data/artifacts/210/audio/sec-2.wav"] = 7.5
+    fake_visual_plan = FakeVisualPlanService(
+        FakeVisualPlan(
+            scenes=[
+                FakePlanScene(scene_id="scene-1", section_id="sec-1"),
+                FakePlanScene(scene_id="scene-2", section_id="sec-2"),
+            ]
+        )
+    )
+    fake_script = FakeScriptService(
+        FakeScriptDraft(
+            structured_script=[
+                FakeScriptSection(section_id="sec-1"),
+                FakeScriptSection(section_id="sec-2"),
+            ]
+        )
+    )
+    _patch_services(
+        monkeypatch,
+        storage=storage,
+        fake_render_service=fake_render_service,
+        fake_vas=fake_vas,
+        fake_audio=fake_audio,
+        fake_subtitle=fake_subtitle,
+        fake_ffmpeg=fake_ffmpeg,
+        fake_visual_plan=fake_visual_plan,
+        fake_script=fake_script,
+    )
+
+    result = _invoke_task(run_id=run_id)
+
+    assert result["status"] == "success"
+    render_input, _ = fake_ffmpeg.calls[0]
+    assert render_input.scene_durations == [7.5, 22.5]
+    assert fake_ffmpeg.concatenate_calls == [
+        (
+            ["data/artifacts/210/audio/sec-2.wav"],
+            "data/artifacts/210/render/audio_concat.wav",
+        )
+    ]
+    assert fake_ffmpeg.merge_calls == [
+        (
+            ["data/artifacts/210/subtitles/sec-2.srt"],
+            [7.5],
+            "data/artifacts/210/render/subtitles_merged.srt",
+        )
+    ]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -43,6 +43,9 @@ docker compose up -d
 
 Studio Web UI에서 **"Create New Project"** 버튼을 클릭하면 두 가지 탭이 제공됩니다:
 
+> 현재 제품 UI에서 지원하는 시작 방식은 **Idea** 와 **Markdown** 두 가지입니다.
+> `URL` source는 레거시/내부 계약에는 남아 있을 수 있지만, 현재 사용자 플로우에서는 지원하지 않습니다.
+
 ### 탭 1: Start from Idea
 
 아이디어에서 AI가 자동으로 스크립트를 생성합니다.

--- a/packages/creator-service/creator_service/postgres_run_storage.py
+++ b/packages/creator-service/creator_service/postgres_run_storage.py
@@ -123,6 +123,51 @@ class PostgresRunStorage:
         if row is None:
             raise ValueError(f"Run {run_id} not found")
         return row
+
+    async def append_active_task_id(self, run_id: int, task_id: str) -> dict[str, Any]:
+        row = await fetch_one(
+            "UPDATE creator_runs "
+            "SET active_task_id = ("
+            "  COALESCE("
+            "    CASE WHEN active_task_id IS NOT NULL "
+            "         AND left(active_task_id, 1) = '[' "
+            "    THEN active_task_id::jsonb "
+            "    ELSE '[]'::jsonb "
+            "    END, '[]'::jsonb"
+            "  ) || to_jsonb($2::text)"
+            ")::text "
+            "WHERE id = $1 RETURNING *",
+            run_id,
+            task_id,
+        )
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+        return row
+
+    async def remove_active_task_id(self, run_id: int, task_id: str) -> dict[str, Any]:
+        row = await fetch_one(
+            "UPDATE creator_runs "
+            "SET active_task_id = COALESCE(("
+            "  SELECT jsonb_agg(value) "
+            "  FROM jsonb_array_elements_text("
+            "    CASE WHEN active_task_id IS NOT NULL "
+            "              AND left(active_task_id, 1) = '[' "
+            "         THEN active_task_id::jsonb "
+            "         WHEN active_task_id IS NULL "
+            "         THEN '[]'::jsonb "
+            "         ELSE jsonb_build_array(active_task_id) "
+            "    END"
+            "  ) AS value "
+            "  WHERE value <> $2"
+            "), '[]'::jsonb)::text "
+            "WHERE id = $1 RETURNING *",
+            run_id,
+            task_id,
+        )
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+        return row
+
     async def list_runs_by_project(self, project_id: int) -> list[dict[str, Any]]:
         return await fetch_all(
             "SELECT * FROM creator_runs WHERE project_id = $1 ORDER BY id DESC",

--- a/packages/creator-service/creator_service/postgres_visual_plan_storage.py
+++ b/packages/creator-service/creator_service/postgres_visual_plan_storage.py
@@ -65,3 +65,50 @@ class PostgresVisualPlanStorage:
             """,
             run_id,
         )
+
+    async def save_plan_if_version(
+        self,
+        row: dict[str, Any],
+        expected_version: int,
+    ) -> tuple[bool, dict[str, Any] | None, int | None]:
+        run_id = row["run_id"]
+        pool = await get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock($1::int, $2::int)",
+                    6102,
+                    run_id,
+                )
+                current = await connection.fetchrow(
+                    """
+                    SELECT *
+                    FROM creator_visual_plans
+                    WHERE run_id = $1
+                    ORDER BY version DESC
+                    LIMIT 1
+                    FOR UPDATE
+                    """,
+                    run_id,
+                )
+                actual_version = int(current["version"]) if current is not None else 0
+                if actual_version != expected_version:
+                    return False, dict(current) if current is not None else None, actual_version
+
+                saved = await connection.fetchrow(
+                    """
+                    INSERT INTO creator_visual_plans (
+                        run_id,
+                        scenes_json,
+                        version
+                    )
+                    VALUES ($1, $2, $3)
+                    RETURNING *
+                    """,
+                    run_id,
+                    row.get("scenes_json"),
+                    actual_version + 1,
+                )
+        if saved is None:
+            raise ValueError("Failed to save visual plan")
+        return True, dict(saved), expected_version

--- a/packages/creator-service/creator_service/project_service.py
+++ b/packages/creator-service/creator_service/project_service.py
@@ -93,13 +93,30 @@ class InMemoryProjectStorage:
         return False
     async def fetch_latest_run_summary(self, project_id: int) -> LatestRunSummary | None:
         runs = self._runs_by_project.get(project_id, [])
-        if not runs:
+        if runs:
+            latest = max(runs, key=lambda run: run["id"])
+            return {
+                "run_id": latest["id"],
+                "current_stage": latest["current_stage"],
+                "status": latest["status"],
+            }
+
+        # In real local/dev flow, runs are created through RunService, not via
+        # this storage's insert_run helper. Fall back to the shared in-memory
+        # run service so latest_run stays accurate outside Postgres mode.
+        try:
+            from creator_service.run_service import run_service
+
+            persisted_runs = await run_service.list_runs_by_project(project_id)
+        except Exception:
             return None
-        latest = max(runs, key=lambda run: run["id"])
+        if not persisted_runs:
+            return None
+        latest_run = persisted_runs[0]
         return {
-            "run_id": latest["id"],
-            "current_stage": latest["current_stage"],
-            "status": latest["status"],
+            "run_id": latest_run.id,
+            "current_stage": latest_run.current_stage,
+            "status": latest_run.status,
         }
 
     async def insert_run(

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -181,7 +181,14 @@ class RunService:
         model_defaults: dict[str, Any] | Any | None,
         style_preset: str,
         metadata: dict[str, Any] | None = None,
+        current_stage: str = RunStage.IDEA_READY.value,
+        status: str = "pending",
     ) -> PipelineRun:
+        try:
+            normalized_stage = RunStage(current_stage).value
+        except ValueError as exc:
+            raise ValueError(f"Invalid stage '{current_stage}'") from exc
+
         model_defaults_payload: str | None = None
         if model_defaults is not None:
             model_dump = getattr(model_defaults, "model_dump", None)
@@ -197,8 +204,8 @@ class RunService:
         row = await self.storage.create_run(
             {
                 "project_id": project_id,
-                "current_stage": RunStage.IDEA_READY.value,
-                "status": "pending",
+                "current_stage": normalized_stage,
+                "status": status,
                 "review_stage": None,
                 "restart_from": None,
                 "model_defaults_json": model_defaults_payload,

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -47,6 +47,14 @@ class RunStorageBackend(Protocol):
         """Atomically merge JSON updates into model_defaults_json."""
         ...
 
+    async def append_active_task_id(self, run_id: int, task_id: str) -> dict[str, Any]:
+        """Atomically append a task id to active_task_id."""
+        ...
+
+    async def remove_active_task_id(self, run_id: int, task_id: str) -> dict[str, Any]:
+        """Atomically remove a task id from active_task_id."""
+        ...
+
 class InMemoryRunStorage:
     def __init__(self) -> None:
         self._rows: dict[int, dict[str, Any]] = {}
@@ -119,11 +127,49 @@ class InMemoryRunStorage:
         row["updated_at"] = datetime.now(timezone.utc)
         self._rows[run_id] = row
         return dict(row)
+
+    async def append_active_task_id(self, run_id: int, task_id: str) -> dict[str, Any]:
+        row = self._rows.get(run_id)
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+        current = row.get("active_task_id")
+        task_ids = self._parse_active_task_ids(current)
+        task_ids.append(task_id)
+        row["active_task_id"] = json.dumps(task_ids)
+        row["updated_at"] = datetime.now(timezone.utc)
+        self._rows[run_id] = row
+        return dict(row)
+
+    async def remove_active_task_id(self, run_id: int, task_id: str) -> dict[str, Any]:
+        row = self._rows.get(run_id)
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+        current = row.get("active_task_id")
+        task_ids = [tid for tid in self._parse_active_task_ids(current) if tid != task_id]
+        row["active_task_id"] = json.dumps(task_ids)
+        row["updated_at"] = datetime.now(timezone.utc)
+        self._rows[run_id] = row
+        return dict(row)
+
     async def delete_runs_by_project(self, project_id: int) -> int:
         to_delete = [rid for rid, r in self._rows.items() if r.get("project_id") == project_id]
         for rid in to_delete:
             del self._rows[rid]
         return len(to_delete)
+
+    @staticmethod
+    def _parse_active_task_ids(raw: Any) -> list[str]:
+        if not raw:
+            return []
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return [str(raw)]
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed if item]
+        if isinstance(parsed, str):
+            return [parsed] if parsed else []
+        return []
 
 class RunService:
     def __init__(self, storage: RunStorageBackend):

--- a/packages/creator-service/creator_service/visual_plan_service.py
+++ b/packages/creator-service/creator_service/visual_plan_service.py
@@ -73,6 +73,14 @@ class VisualPlanStorageBackend(Protocol):
         """List all plan versions for a run, newest first."""
         ...
 
+    async def save_plan_if_version(
+        self,
+        row: dict[str, Any],
+        expected_version: int,
+    ) -> tuple[bool, dict[str, Any] | None, int | None]:
+        """Atomically save only if the current active version matches expected_version."""
+        ...
+
 
 # ---------------------------------------------------------------------------
 # In-Memory Storage
@@ -113,6 +121,31 @@ class InMemoryVisualPlanStorage:
     async def list_plan_versions(self, run_id: int) -> list[dict[str, Any]]:
         plans = self._plans.get(run_id, [])
         return [dict(p) for p in sorted(plans, key=lambda p: p["version"], reverse=True)]
+
+    async def save_plan_if_version(
+        self,
+        row: dict[str, Any],
+        expected_version: int,
+    ) -> tuple[bool, dict[str, Any] | None, int | None]:
+        run_id = row["run_id"]
+        lock = self._run_locks.setdefault(run_id, asyncio.Lock())
+        async with lock:
+            plans = self._plans.setdefault(run_id, [])
+            actual_version = max((p["version"] for p in plans), default=0)
+            if actual_version != expected_version:
+                current = max(plans, key=lambda p: p["version"]) if plans else None
+                return False, dict(current) if current is not None else None, actual_version
+
+            now = datetime.now(timezone.utc)
+            saved = {
+                "id": self._next_id,
+                "created_at": now,
+                "version": actual_version + 1,
+                **row,
+            }
+            self._next_id += 1
+            plans.append(saved)
+            return True, dict(saved), actual_version
 
 
 # ---------------------------------------------------------------------------
@@ -181,7 +214,6 @@ class VisualPlanService:
         if active_row is None:
             raise ValueError(f"No active visual plan for run {run_id}")
 
-        # Optimistic concurrency check
         active_version = active_row.get("version", 1)
         if expected_version is not None and active_version != expected_version:
             raise VersionConflictError(run_id, expected_version, active_version)
@@ -202,7 +234,34 @@ class VisualPlanService:
                 f"Scene '{scene_id}' not found in visual plan for run {run_id}"
             )
 
-        return await self.save_plan(run_id, scenes)
+        scenes_json = json.dumps(
+            [scene.model_dump(mode="json") for scene in scenes]
+        )
+        if expected_version is None:
+            row = await self.storage.save_plan(
+                {
+                    "run_id": run_id,
+                    "scenes_json": scenes_json,
+                }
+            )
+            return self._row_to_plan(row)
+
+        applied, row, actual_version = await self.storage.save_plan_if_version(
+            {
+                "run_id": run_id,
+                "scenes_json": scenes_json,
+            },
+            expected_version,
+        )
+        if not applied:
+            raise VersionConflictError(
+                run_id,
+                expected_version,
+                actual_version if actual_version is not None else 0,
+            )
+        if row is None:
+            raise ValueError(f"No active visual plan for run {run_id}")
+        return self._row_to_plan(row)
 
     # -- Reads --------------------------------------------------------------
 

--- a/packages/creator-service/tests/test_model_catalog_service.py
+++ b/packages/creator-service/tests/test_model_catalog_service.py
@@ -152,7 +152,15 @@ class TestModelCatalogService:
 
         result = await service.list_models()
 
-        required_fields = {"key", "label", "provider_type", "is_local", "requires_gpu", "status"}
+        required_fields = {
+            "key",
+            "label",
+            "provider_type",
+            "is_local",
+            "requires_gpu",
+            "status",
+            "default_params",
+        }
         all_entries = (
             result["script_models"]
             + result["image_models"]

--- a/packages/creator-service/tests/test_project_service.py
+++ b/packages/creator-service/tests/test_project_service.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 import pytest
 
 from creator_service.project_service import InMemoryProjectStorage, ProjectService
+from creator_service.run_service import InMemoryRunStorage, RunService
 
 def run(coro):
     return asyncio.run(coro)
@@ -121,6 +122,51 @@ def test_get_and_list_include_latest_run_summary(
         "current_stage": "script_review",
         "status": "paused",
     }
+
+
+def test_get_and_list_include_latest_run_summary_from_run_service(
+    service: ProjectService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = run(service.create_project(title="With Real Run", source_type="idea", idea_brief="test idea"))
+
+    run_service = RunService(InMemoryRunStorage())
+    first = run(
+        run_service.create_run(
+            project_id=project.id,
+            model_defaults=None,
+            style_preset="default",
+        )
+    )
+    second = run(
+        run_service.create_run(
+            project_id=project.id,
+            model_defaults=None,
+            style_preset="default",
+        )
+    )
+
+    run(run_service.advance_stage(second.id, "SCRIPT_GENERATING"))
+
+    import creator_service.run_service as run_service_module
+
+    monkeypatch.setattr(run_service_module, "run_service", run_service)
+
+    detailed = run(service.get_project(project.id))
+    listed = run(service.list_projects())
+
+    assert detailed is not None
+    assert detailed.model_dump()["latest_run"] == {
+        "run_id": second.id,
+        "current_stage": "SCRIPT_GENERATING",
+        "status": "pending",
+    }
+    assert listed[0].model_dump()["latest_run"] == {
+        "run_id": second.id,
+        "current_stage": "SCRIPT_GENERATING",
+        "status": "pending",
+    }
+    assert first.id != second.id
 
 
 def test_create_project_with_markdown_missing_source_raises_value_error(service: ProjectService) -> None:

--- a/packages/creator-service/tests/test_run_service.py
+++ b/packages/creator-service/tests/test_run_service.py
@@ -45,6 +45,23 @@ def test_create_run_stores_metadata_in_metadata_json() -> None:
     assert row["metadata_json"] == json.dumps(metadata)
 
 
+def test_create_run_allows_custom_stage_and_status() -> None:
+    service = RunService(InMemoryRunStorage())
+
+    run = asyncio.run(
+        service.create_run(
+            project_id=15,
+            model_defaults=None,
+            style_preset="default",
+            current_stage=RunStage.SCRIPT_REVIEW.value,
+            status="running",
+        )
+    )
+
+    assert run.current_stage == RunStage.SCRIPT_REVIEW.value
+    assert run.status == "running"
+
+
 def test_get_run_returns_none_for_missing() -> None:
     service = RunService(InMemoryRunStorage())
 

--- a/packages/creator-service/tests/test_visual_plan_service.py
+++ b/packages/creator-service/tests/test_visual_plan_service.py
@@ -208,6 +208,37 @@ def test_patch_scene_skips_version_check_when_none(service: VisualPlanService) -
     assert plan.scenes[0].prompt == "No version check"
 
 
+@pytest.mark.asyncio
+async def test_patch_scene_expected_version_is_atomic() -> None:
+    storage = InMemoryVisualPlanStorage()
+    service_a = VisualPlanService(storage)
+    service_b = VisualPlanService(storage)
+
+    await service_a.save_plan(run_id=213, scenes=[_make_scene(prompt="Base")])
+
+    async def patch(service: VisualPlanService, prompt: str) -> str:
+        plan = await service.patch_scene(
+            run_id=213,
+            scene_id="sc-1",
+            updates={"prompt": prompt},
+            expected_version=1,
+        )
+        return plan.scenes[0].prompt
+
+    results = await asyncio.gather(
+        patch(service_a, "A"),
+        patch(service_b, "B"),
+        return_exceptions=True,
+    )
+
+    successes = [result for result in results if not isinstance(result, Exception)]
+    failures = [result for result in results if isinstance(result, Exception)]
+
+    assert len(successes) == 1
+    assert len(failures) == 1
+    assert isinstance(failures[0], VersionConflictError)
+
+
 # -- patch_scene: field allowlist ----------------------------------------------
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+addopts = --import-mode=importlib
+asyncio_mode = auto
+pythonpath =
+    apps/api/src
+    apps/worker-orchestrator
+    packages/creator-domain
+    packages/creator-service
+    packages/creator-provider


### PR DESCRIPTION
## Summary
- move `active_task_id` append/remove into run storage so dispatch and worker cleanup work in both Postgres and in-memory modes
- preserve unique scene image files across regenerations, make visual-plan patch CAS atomic, and stabilize render ordering/timing for sparse paragraph artifacts
- validate run creation against existing projects, keep in-memory `latest_run` summaries aligned with real runs, opt into React Router v7 future flags, and refactor the frontend into in-place workspaces that stay visible during generation

## Changes
- `packages/creator-service/creator_service/run_service.py`, `packages/creator-service/creator_service/postgres_run_storage.py`, `apps/api/src/shorts_api/routes/creator_runs.py`: add storage-backed active task append/remove operations, validate project existence before run creation, and expose more accurate storyboard generation states
- `apps/api/src/shorts_api/routes/creator_script.py`, `packages/creator-service/creator_service/run_service.py`: create markdown-import runs directly in `SCRIPT_REVIEW` so authored scripts do not re-enter idea-first generation
- `apps/api/src/shorts_api/routes/creator_projects.py`: remove `url` from the public create-project contract while keeping legacy read compatibility
- `apps/worker-orchestrator/tasks/*.py`: remove active task ids on task completion, preserve unique image file paths, and harden render assembly against scene-order and sparse-artifact edge cases
- `packages/creator-service/creator_service/visual_plan_service.py`, `packages/creator-service/creator_service/postgres_visual_plan_storage.py`: add atomic expected-version save path for visual plan patches
- `packages/creator-service/creator_service/project_service.py`: source in-memory `latest_run` summaries from real run storage when shadow state is empty
- `pytest.ini` and test package cleanup: make root `python3 -m pytest -q` work without per-suite `PYTHONPATH` hacks or `tests.conftest` collisions
- `apps/studio-web/src/App.tsx`, `CreatePage.tsx`, `ProjectPage.tsx`, `RunsPage.tsx`, `PipelineStepper.tsx`, and related tests: enable React Router future flags, send create-time model defaults with backend field names, prefer latest run state in UX, make the stepper source-aware, expose render profile selection, hide impossible render CTAs, and keep script/visual-plan/storyboard workspaces visible while generation is in progress
- `apps/studio-web/src/components/creator/*.tsx`: add polling + pending-state support, remove modal progress dependency, and keep visual-plan/script workspaces mounted instead of swapping to blocking generating screens
- `docs/USAGE.md`: document supported entry modes and distinguish 완전 무료 vs 무료 티어 usage

## Verification
- `python3 -m pytest -q`: 517 passed
- `npm test` in `apps/studio-web`: 275 passed

Closes #239
Closes #255
Closes #256
Closes #257
Closes #259
Closes #260
Closes #261
Closes #262
Closes #263
Closes #264
Closes #265
Closes #266
Closes #267
Closes #268
Closes #269
Closes #270