### PR TITLE
feat: scene-centric ProjectPage redesign

### DIFF
--- a/apps/studio-web/src/__tests__/AssetSlot.test.tsx
+++ b/apps/studio-web/src/__tests__/AssetSlot.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import AssetSlot from "../components/creator/AssetSlot";
+import type { AssetType, AssetStatus } from "../components/creator/AssetSlot";
+
+describe("AssetSlot", () => {
+  // ---- empty state ----
+
+  describe("empty state", () => {
+    it.each(["image", "audio", "subtitle"] as AssetType[])(
+      "renders %s with empty placeholder",
+      (type) => {
+        render(<AssetSlot type={type} status="empty" />);
+        const slot = screen.getByTestId(`asset-slot-${type}`);
+        expect(slot).toBeInTheDocument();
+        expect(slot).toHaveAttribute("data-status", "empty");
+      },
+    );
+
+    it("does not show regenerate button when empty", () => {
+      const onRegen = vi.fn();
+      render(<AssetSlot type="image" status="empty" onRegenerate={onRegen} />);
+      expect(screen.queryByTestId("regen-image")).not.toBeInTheDocument();
+    });
+  });
+
+  // ---- loading state ----
+
+  describe("loading state", () => {
+    it.each(["image", "audio", "subtitle"] as AssetType[])(
+      "renders %s with loading/shimmer indicator",
+      (type) => {
+        render(<AssetSlot type={type} status="loading" />);
+        const slot = screen.getByTestId(`asset-slot-${type}`);
+        expect(slot).toHaveAttribute("data-status", "loading");
+        expect(slot).toHaveTextContent("Generating…");
+      },
+    );
+  });
+
+  // ---- ready state ----
+
+  describe("ready state — image", () => {
+    it("renders thumbnail when image URL provided", () => {
+      render(
+        <AssetSlot
+          type="image"
+          status="ready"
+          url="/data/artifacts/img/scene-0.png"
+        />,
+      );
+      const slot = screen.getByTestId("asset-slot-image");
+      expect(slot).toHaveAttribute("data-status", "ready");
+      const img = slot.querySelector("img");
+      expect(img).toBeInTheDocument();
+      expect(img!.src).toContain("/artifacts/img/scene-0.png");
+    });
+
+    it("shows Ready label", () => {
+      render(<AssetSlot type="image" status="ready" url="/img.png" />);
+      expect(screen.getByTestId("asset-slot-image")).toHaveTextContent("✓ Ready");
+    });
+  });
+
+  describe("ready state — audio", () => {
+    it("shows formatted duration", () => {
+      render(
+        <AssetSlot
+          type="audio"
+          status="ready"
+          url="/data/artifacts/audio/sec-0.wav"
+          duration={65.3}
+        />,
+      );
+      expect(screen.getByTestId("asset-slot-audio")).toHaveTextContent("1:05");
+    });
+
+    it("shows seconds-only for short durations", () => {
+      render(
+        <AssetSlot type="audio" status="ready" url="/a.wav" duration={8.7} />
+      );
+      expect(screen.getByTestId("asset-slot-audio")).toHaveTextContent("9s");
+    });
+
+    it("renders hidden audio element for inline play", () => {
+      render(
+        <AssetSlot type="audio" status="ready" url="/audio.wav" duration={5} />,
+      );
+      expect(screen.getByTestId("audio-element-audio")).toBeInTheDocument();
+    });
+  });
+
+  describe("ready state — subtitle", () => {
+    it("shows cue count", () => {
+      render(
+        <AssetSlot
+          type="subtitle"
+          status="ready"
+          url="/subs.srt"
+          subtitleCount={12}
+        />,
+      );
+      expect(screen.getByTestId("asset-slot-subtitle")).toHaveTextContent("12 cues");
+    });
+
+    it("shows singular cue label for 1", () => {
+      render(
+        <AssetSlot
+          type="subtitle"
+          status="ready"
+          url="/subs.srt"
+          subtitleCount={1}
+        />,
+      );
+      expect(screen.getByTestId("asset-slot-subtitle")).toHaveTextContent("1 cue");
+    });
+  });
+
+  // ---- regenerate button ----
+
+  describe("regenerate button", () => {
+    it("shows on hover when onRegenerate provided and status is ready", () => {
+      const onRegen = vi.fn();
+      render(
+        <AssetSlot
+          type="image"
+          status="ready"
+          url="/img.png"
+          onRegenerate={onRegen}
+        />,
+      );
+      const slot = screen.getByTestId("asset-slot-image");
+      fireEvent.mouseEnter(slot);
+      const btn = screen.getByTestId("regen-image");
+      expect(btn).toBeInTheDocument();
+      fireEvent.click(btn);
+      expect(onRegen).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not show regen button when disabled", () => {
+      const onRegen = vi.fn();
+      render(
+        <AssetSlot
+          type="audio"
+          status="ready"
+          url="/a.wav"
+          onRegenerate={onRegen}
+          disabled
+        />,
+      );
+      expect(screen.queryByTestId("regen-audio")).not.toBeInTheDocument();
+    });
+  });
+
+  // ---- preview ----
+
+  describe("preview callback", () => {
+    it("calls onPreview when image slot is clicked", () => {
+      const onPreview = vi.fn();
+      render(
+        <AssetSlot
+          type="image"
+          status="ready"
+          url="/img.png"
+          onPreview={onPreview}
+        />,
+      );
+      fireEvent.click(screen.getByTestId("asset-slot-image"));
+      expect(onPreview).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onPreview for subtitle slot", () => {
+      const onPreview = vi.fn();
+      render(
+        <AssetSlot
+          type="subtitle"
+          status="ready"
+          url="/subs.srt"
+          subtitleCount={5}
+          onPreview={onPreview}
+        />,
+      );
+      fireEvent.click(screen.getByTestId("asset-slot-subtitle"));
+      expect(onPreview).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onPreview when disabled", () => {
+      const onPreview = vi.fn();
+      render(
+        <AssetSlot
+          type="image"
+          status="ready"
+          url="/img.png"
+          onPreview={onPreview}
+          disabled
+        />,
+      );
+      fireEvent.click(screen.getByTestId("asset-slot-image"));
+      expect(onPreview).not.toHaveBeenCalled();
+    });
+
+    it("does not call onPreview when empty", () => {
+      const onPreview = vi.fn();
+      render(<AssetSlot type="image" status="empty" onPreview={onPreview} />);
+      fireEvent.click(screen.getByTestId("asset-slot-image"));
+      expect(onPreview).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/studio-web/src/__tests__/BulkActionBar.test.tsx
+++ b/apps/studio-web/src/__tests__/BulkActionBar.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import BulkActionBar from "../components/creator/BulkActionBar";
+import type { StoryboardParagraph } from "../api/storyboard";
+
+function makeParagraph(overrides: Partial<StoryboardParagraph> = {}): StoryboardParagraph {
+  return {
+    section_id: "sec-0",
+    order: 0,
+    text: "Test",
+    display_text: null,
+    image_prompt: null,
+    image_url: null,
+    audio_url: null,
+    audio_duration: null,
+    subtitles_url: null,
+    subtitle_entries: null,
+    status: "idle",
+    stale_flags: null,
+    scene_id: "scene-0",
+    image_asset_id: null,
+    audio_artifact_id: null,
+    subtitle_artifact_id: null,
+    ...overrides,
+  };
+}
+
+describe("BulkActionBar", () => {
+  it("renders nothing when no paragraphs", () => {
+    const { container } = render(<BulkActionBar paragraphs={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows remaining counts for all types", () => {
+    const paragraphs = [
+      makeParagraph({ section_id: "s0", image_url: "/img.png" }),
+      makeParagraph({ section_id: "s1" }),
+      makeParagraph({ section_id: "s2" }),
+    ];
+    render(<BulkActionBar paragraphs={paragraphs} />);
+    expect(screen.getByTestId("bulk-gen-images")).toHaveTextContent("Generate All Images (2)");
+    expect(screen.getByTestId("bulk-gen-audio")).toHaveTextContent("Generate All Audio (3)");
+    expect(screen.getByTestId("bulk-gen-subtitles")).toHaveTextContent("Generate All Subtitles (3)");
+  });
+
+  it("shows Done label when all complete", () => {
+    const paragraphs = [
+      makeParagraph({
+        section_id: "s0",
+        image_url: "/i.png",
+        audio_url: "/a.wav",
+        subtitles_url: "/s.srt",
+      }),
+    ];
+    render(<BulkActionBar paragraphs={paragraphs} />);
+    expect(screen.getByTestId("bulk-gen-images")).toHaveTextContent("All Images Done ✓");
+    expect(screen.getByTestId("bulk-gen-audio")).toHaveTextContent("All Audio Done ✓");
+    expect(screen.getByTestId("bulk-gen-subtitles")).toHaveTextContent("All Subtitles Done ✓");
+  });
+
+  it("disables buttons when generating prop is true", () => {
+    const paragraphs = [makeParagraph()];
+    render(<BulkActionBar paragraphs={paragraphs} generating />);
+    expect(screen.getByTestId("bulk-gen-images")).toBeDisabled();
+    expect(screen.getByTestId("bulk-gen-audio")).toBeDisabled();
+    expect(screen.getByTestId("bulk-gen-subtitles")).toBeDisabled();
+  });
+
+  it("disables buttons when any paragraph is generating", () => {
+    const paragraphs = [makeParagraph({ status: "generating_audio" })];
+    render(<BulkActionBar paragraphs={paragraphs} />);
+    expect(screen.getByTestId("bulk-gen-images")).toBeDisabled();
+  });
+
+  it("calls onGenerateAllImages when clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <BulkActionBar
+        paragraphs={[makeParagraph()]}
+        onGenerateAllImages={onClick}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("bulk-gen-images"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onGenerateAllAudio when clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <BulkActionBar
+        paragraphs={[makeParagraph()]}
+        onGenerateAllAudio={onClick}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("bulk-gen-audio"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onGenerateAllSubtitles when clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <BulkActionBar
+        paragraphs={[makeParagraph()]}
+        onGenerateAllSubtitles={onClick}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("bulk-gen-subtitles"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables done buttons (0 remaining)", () => {
+    const onClick = vi.fn();
+    const paragraphs = [
+      makeParagraph({ image_url: "/i.png", audio_url: "/a.wav", subtitles_url: "/s.srt" }),
+    ];
+    render(
+      <BulkActionBar
+        paragraphs={paragraphs}
+        onGenerateAllImages={onClick}
+      />,
+    );
+    expect(screen.getByTestId("bulk-gen-images")).toBeDisabled();
+  });
+});

--- a/apps/studio-web/src/__tests__/PipelineOverviewBar.test.tsx
+++ b/apps/studio-web/src/__tests__/PipelineOverviewBar.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PipelineOverviewBar from "../components/creator/PipelineOverviewBar";
+import type { StoryboardParagraph } from "../api/storyboard";
+
+function makeParagraph(overrides: Partial<StoryboardParagraph> = {}): StoryboardParagraph {
+  return {
+    section_id: "sec-0",
+    order: 0,
+    text: "Test",
+    display_text: null,
+    image_prompt: null,
+    image_url: null,
+    audio_url: null,
+    audio_duration: null,
+    subtitles_url: null,
+    subtitle_entries: null,
+    status: "idle",
+    stale_flags: null,
+    scene_id: "scene-0",
+    image_asset_id: null,
+    audio_artifact_id: null,
+    subtitle_artifact_id: null,
+    ...overrides,
+  };
+}
+
+describe("PipelineOverviewBar", () => {
+  it("renders per-type stats", () => {
+    const paragraphs = [
+      makeParagraph({ section_id: "s0", image_url: "/i.png", audio_url: "/a.wav" }),
+      makeParagraph({ section_id: "s1", image_url: "/i2.png" }),
+      makeParagraph({ section_id: "s2" }),
+    ];
+    render(
+      <PipelineOverviewBar
+        paragraphs={paragraphs}
+        totalParagraphs={3}
+        readyParagraphs={0}
+        renderReady={false}
+      />,
+    );
+    expect(screen.getByTestId("stat-images")).toHaveTextContent("2/3");
+    expect(screen.getByTestId("stat-audio")).toHaveTextContent("1/3");
+    expect(screen.getByTestId("stat-subtitles")).toHaveTextContent("0/3");
+  });
+
+  it("shows ready count", () => {
+    render(
+      <PipelineOverviewBar
+        paragraphs={[]}
+        totalParagraphs={5}
+        readyParagraphs={3}
+        renderReady={false}
+      />,
+    );
+    expect(screen.getByTestId("pipeline-overview-bar")).toHaveTextContent("3/5 ready");
+  });
+
+  it("render button is disabled when not ready", () => {
+    render(
+      <PipelineOverviewBar
+        paragraphs={[]}
+        totalParagraphs={5}
+        readyParagraphs={2}
+        renderReady={false}
+      />,
+    );
+    expect(screen.getByTestId("render-btn")).toBeDisabled();
+  });
+
+  it("render button is enabled when render ready", () => {
+    const onRender = vi.fn();
+    render(
+      <PipelineOverviewBar
+        paragraphs={[]}
+        totalParagraphs={5}
+        readyParagraphs={5}
+        renderReady={true}
+        onRender={onRender}
+      />,
+    );
+    const btn = screen.getByTestId("render-btn");
+    expect(btn).not.toBeDisabled();
+    fireEvent.click(btn);
+    expect(onRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("render button shows Rendering when rendering prop is true", () => {
+    render(
+      <PipelineOverviewBar
+        paragraphs={[]}
+        totalParagraphs={5}
+        readyParagraphs={5}
+        renderReady={true}
+        rendering
+      />,
+    );
+    expect(screen.getByTestId("render-btn")).toHaveTextContent("Rendering…");
+    expect(screen.getByTestId("render-btn")).toBeDisabled();
+  });
+
+  it("progress bar exists", () => {
+    render(
+      <PipelineOverviewBar
+        paragraphs={[]}
+        totalParagraphs={10}
+        readyParagraphs={5}
+        renderReady={false}
+      />,
+    );
+    expect(screen.getByTestId("progress-bar")).toBeInTheDocument();
+  });
+});

--- a/apps/studio-web/src/__tests__/ProjectPage.test.tsx
+++ b/apps/studio-web/src/__tests__/ProjectPage.test.tsx
@@ -10,6 +10,7 @@ const MOCK_PROJECT: {
   title: string | null;
   source_type: string;
   status: string;
+  idea_brief?: string | null;
   latest_run?: { run_id: number; current_stage: string | null; status: string | null } | null;
   created_at: string;
   updated_at: string;
@@ -18,6 +19,7 @@ const MOCK_PROJECT: {
   title: "My Short",
   source_type: "idea",
   status: "active",
+  idea_brief: "A cool idea",
   latest_run: { run_id: 1, current_stage: "IDEA_READY", status: "pending" },
   created_at: "2025-03-15T10:00:00Z",
   updated_at: "2025-03-15T12:00:00Z",
@@ -71,6 +73,54 @@ const MOCK_RUN_VP_REVIEW = {
   restart_from: null,
 };
 
+const MOCK_RUN_VA_GENERATING = {
+  id: 1,
+  project_id: 7,
+  current_stage: "VISUAL_ASSET_GENERATING",
+  status: "running",
+  restart_from: null,
+};
+
+const MOCK_RUN_VA_REVIEW = {
+  id: 1,
+  project_id: 7,
+  current_stage: "VISUAL_ASSET_REVIEW",
+  status: "running",
+  restart_from: null,
+};
+
+const MOCK_RUN_AUDIO_GENERATING = {
+  id: 1,
+  project_id: 7,
+  current_stage: "AUDIO_GENERATING",
+  status: "running",
+  restart_from: null,
+};
+
+const MOCK_RUN_SUBTITLE_GENERATING = {
+  id: 1,
+  project_id: 7,
+  current_stage: "SUBTITLE_GENERATING",
+  status: "running",
+  restart_from: null,
+};
+
+const MOCK_RUN_RENDER_GENERATING = {
+  id: 1,
+  project_id: 7,
+  current_stage: "RENDER_GENERATING",
+  status: "running",
+  restart_from: null,
+};
+
+const MOCK_RUN_FINAL_REVIEW = {
+  id: 1,
+  project_id: 7,
+  current_stage: "FINAL_REVIEW",
+  status: "running",
+  restart_from: null,
+};
+
 // ---- helpers ----
 
 const mockNavigate = vi.fn();
@@ -81,7 +131,10 @@ vi.mock("react-router-dom", async () => {
 
 function renderPage(projectId = "7") {
   return render(
-    <MemoryRouter initialEntries={[`/projects/${projectId}`]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+    <MemoryRouter
+      initialEntries={[`/projects/${projectId}`]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
       <Routes>
         <Route path="/projects/:projectId" element={<ProjectPage />} />
       </Routes>
@@ -106,7 +159,7 @@ function mockFetchProjectAndRuns(
       } as Response);
     }
     // GET /projects/:id
-    if (url.includes("/projects/")) {
+    if (url.includes("/projects/") && !url.includes("/runs")) {
       if (!project) {
         return Promise.resolve({
           ok: false,
@@ -119,8 +172,6 @@ function mockFetchProjectAndRuns(
         json: () => Promise.resolve(project),
       } as Response);
     }
-    // GET /runs/:id (for refreshRun)
-    // GET /runs/:id/visual-assets
     // GET /runs/:id/preview
     if (url.includes("/preview")) {
       return Promise.resolve({
@@ -129,16 +180,14 @@ function mockFetchProjectAndRuns(
           Promise.resolve({
             run_id: 1,
             current_stage: "FINAL_REVIEW",
-            video: { id: 1, path: "data/artifacts/1/render/output.mp4", render_profile: "shorts_default" },
-            audio: { id: 2, path: "data/artifacts/1/audio/audio.wav", model_used: "qwen3-tts" },
-            subtitle: { id: 3, path: "data/artifacts/1/subtitles/subtitles.srt", format: "srt" },
+            video: {
+              id: 1,
+              path: "data/artifacts/1/render/output.mp4",
+              render_profile: "shorts_default",
+            },
+            audio: { id: 2, path: "data/artifacts/1/audio/audio.wav" },
+            subtitle: { id: 3, path: "data/artifacts/1/subtitles/subtitles.srt" },
           }),
-      } as Response);
-    }
-    if (url.includes("/visual-assets")) {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ run_id: 1, scenes: {}, total_scenes: 0, total_assets: 0 }),
       } as Response);
     }
     // GET /api/creator/models
@@ -146,7 +195,12 @@ function mockFetchProjectAndRuns(
       return Promise.resolve({
         ok: true,
         json: () =>
-          Promise.resolve({ script_models: [], image_models: [], tts_models: [], stt_models: [] }),
+          Promise.resolve({
+            script_models: [],
+            image_models: [],
+            tts_models: [],
+            stt_models: [],
+          }),
       } as Response);
     }
     // GET /runs/:id/storyboard
@@ -182,6 +236,22 @@ function mockFetchProjectAndRuns(
           }),
       } as Response);
     }
+    // GET /runs/:id/script/structured
+    if (url.includes("/script/structured")) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ sections: [] }),
+      } as Response);
+    }
+    // GET /runs/:id/script/markdown
+    if (url.includes("/script/markdown")) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ markdown: "# Test Script" }),
+      } as Response);
+    }
     // GET /runs/:id (for refreshRun)
     if (url.includes("/runs/")) {
       const latestRun = runs[0];
@@ -192,7 +262,10 @@ function mockFetchProjectAndRuns(
         } as Response);
       }
     }
-    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response);
   });
 }
 
@@ -202,14 +275,14 @@ beforeEach(() => {
 });
 
 describe("ProjectPage", () => {
-  // ---- Loading ----
+  // ═══════════════ Loading / Error / Edge Cases ═══════════════
+
   it("shows loading state initially", () => {
     vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise(() => {}));
     renderPage();
     expect(screen.getByRole("status")).toHaveTextContent("Loading project");
   });
 
-  // ---- Error ----
   it("shows error when project not found", async () => {
     mockFetchProjectAndRuns(null);
     renderPage();
@@ -227,10 +300,12 @@ describe("ProjectPage", () => {
     });
   });
 
-  // ---- Invalid project ID ----
   it("shows invalid ID message for non-numeric id", () => {
     render(
-      <MemoryRouter initialEntries={["/projects/abc"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter
+        initialEntries={["/projects/abc"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
         <Routes>
           <Route path="/projects/:projectId" element={<ProjectPage />} />
         </Routes>
@@ -239,7 +314,6 @@ describe("ProjectPage", () => {
     expect(screen.getByText("Invalid project ID.")).toBeInTheDocument();
   });
 
-  // ---- Project loaded, no runs ----
   it("shows project title and no-run state", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, []);
     renderPage();
@@ -268,133 +342,25 @@ describe("ProjectPage", () => {
     expect(screen.getByText(/Stage: SCRIPT_REVIEW/)).toBeInTheDocument();
   });
 
-  // ---- Project with run in IDEA_READY ----
-  it("shows stepper and Generate Script button for IDEA_READY", async () => {
+  it("shows 'Untitled Project' for null title", async () => {
+    mockFetchProjectAndRuns(
+      { ...MOCK_PROJECT, title: null as unknown as string },
+      [],
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Untitled Project")).toBeInTheDocument();
+    });
+  });
+
+  it("renders back link to projects", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_IDEA]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText("My Short")).toBeInTheDocument();
-    });
-    // Stepper should be present (PipelineStepper renders step labels)
-    expect(screen.getByText("Idea")).toBeInTheDocument();
-    expect(screen.getByText("Script")).toBeInTheDocument();
-    // Generate button visible
-    expect(screen.getByRole("button", { name: "Generate Script" })).toBeInTheDocument();
-    // Approve and Regenerate should not be visible
-    expect(screen.queryByRole("button", { name: "Approve Script" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Regenerate Script" })).not.toBeInTheDocument();
-  });
-
-  // ---- Project with run in SCRIPT_REVIEW ----
-  it("shows editor tabs and action buttons for SCRIPT_REVIEW", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByText("My Short")).toBeInTheDocument();
-    });
-    // Editor tabs
-    expect(screen.getByRole("tab", { name: "Markdown" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Structured" })).toBeInTheDocument();
-    // Approve + Regenerate Script  visible
-    expect(screen.getByRole("button", { name: "Approve Script" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Regenerate Script" })).toBeInTheDocument();
-  });
-
-  it("switches between markdown and structured tabs", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "Markdown" })).toBeInTheDocument();
-    });
-
-    // Default: Markdown tab selected
-    const mdTab = screen.getByRole("tab", { name: "Markdown" });
-    expect(mdTab.getAttribute("aria-selected")).toBe("true");
-
-    // Switch to structured
-    fireEvent.click(screen.getByRole("tab", { name: "Structured" }));
-    await waitFor(() => {
-      const stTab = screen.getByRole("tab", { name: "Structured" });
-      expect(stTab.getAttribute("aria-selected")).toBe("true");
-      expect(mdTab.getAttribute("aria-selected")).toBe("false");
+      expect(screen.getByText(/Projects/)).toBeInTheDocument();
     });
   });
 
-  // ---- SCRIPT_GENERATING state ----
-  it("shows generating indicator for SCRIPT_GENERATING", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_GENERATING]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByTestId("generating-indicator")).toBeInTheDocument();
-    });
-    expect(screen.getByText(/Generating Script/i)).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Markdown" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Structured" })).toBeInTheDocument();
-  });
-
-  // ---- Approve action ----
-  it("calls approve endpoint and shows status", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Approve Script" })).toBeInTheDocument();
-    });
-
-    // Override fetch for the approve call
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-
-    fireEvent.click(screen.getByRole("button", { name: "Approve Script" }));
-
-    await waitFor(() => {
-      // Verify approve endpoint was called
-      const calls = fetchSpy.mock.calls.map(([url]) =>
-        typeof url === "string" ? url : (url as Request).url,
-      );
-      expect(calls.some((u) => u.includes("/approve-script"))).toBe(true);
-    });
-  });
-
-  // ---- Generate action ----
-  it("calls generate endpoint on button click", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_IDEA]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Generate Script" })).toBeInTheDocument();
-    });
-
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-
-    fireEvent.click(screen.getByRole("button", { name: "Generate Script" }));
-
-    await waitFor(() => {
-      const calls = fetchSpy.mock.calls.map(([url]) =>
-        typeof url === "string" ? url : (url as Request).url,
-      );
-      expect(calls.some((u) => u.includes("/generate-script"))).toBe(true);
-    });
-  });
-
-  // ---- Restart action ----
-  it("calls restart endpoint on Regenerate click", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Regenerate Script" })).toBeInTheDocument();
-    });
-
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-
-    fireEvent.click(screen.getByRole("button", { name: "Regenerate Script" }));
-
-    await waitFor(() => {
-      const calls = fetchSpy.mock.calls.map(([url]) =>
-        typeof url === "string" ? url : (url as Request).url,
-      );
-      expect(calls.some((u) => u.includes("/restart"))).toBe(true);
-    });
-  });
-
-  // ---- API calls ----
   it("fetches project and runs on mount", async () => {
     const spy = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
       const url = typeof input === "string" ? input : (input as Request).url;
@@ -416,35 +382,160 @@ describe("ProjectPage", () => {
       const calls = spy.mock.calls.map(([url]) =>
         typeof url === "string" ? url : (url as Request).url,
       );
-      expect(calls.some((u) => u.includes("/projects/7") && !u.includes("/runs"))).toBe(true);
+      expect(
+        calls.some((u) => u.includes("/projects/7") && !u.includes("/runs")),
+      ).toBe(true);
       expect(calls.some((u) => u.includes("/projects/7/runs"))).toBe(true);
     });
   });
 
-  // ---- Untitled project ----
-  it("shows 'Untitled Project' for null title", async () => {
-    mockFetchProjectAndRuns({ ...MOCK_PROJECT, title: null as unknown as string }, []);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByText("Untitled Project")).toBeInTheDocument();
-    });
-  });
+  // ═══════════════ Script Stages (via ScriptComposer) ═══════════════
 
-  // ---- Back link ----
-  it("renders back link to projects", async () => {
+  it("renders ScriptComposer for IDEA_READY with Generate button", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_IDEA]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText("← Projects")).toBeInTheDocument();
+      expect(screen.getByTestId("script-composer")).toBeInTheDocument();
+    });
+    // Stepper visible
+    expect(screen.getByText("Idea")).toBeInTheDocument();
+    expect(screen.getByText("Script")).toBeInTheDocument();
+    // Generate Script button visible
+    expect(
+      screen.getByRole("button", { name: "Generate Script" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows editor tabs for SCRIPT_REVIEW via ScriptComposer", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("script-composer")).toBeInTheDocument();
+    });
+    // Editor tabs
+    expect(screen.getByRole("tab", { name: "Markdown" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Structured" }),
+    ).toBeInTheDocument();
+    // Confirm + Regenerate buttons visible (ScriptComposer labels)
+    expect(
+      screen.getByRole("button", {
+        name: "Confirm & Generate Visual Plan",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Regenerate" }),
+    ).toBeInTheDocument();
+  });
+
+  it("switches between markdown and structured tabs", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("tab", { name: "Markdown" }),
+      ).toBeInTheDocument();
+    });
+
+    const mdTab = screen.getByRole("tab", { name: "Markdown" });
+    expect(mdTab.getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Structured" }));
+    await waitFor(() => {
+      const stTab = screen.getByRole("tab", { name: "Structured" });
+      expect(stTab.getAttribute("aria-selected")).toBe("true");
+      expect(mdTab.getAttribute("aria-selected")).toBe("false");
     });
   });
 
-  // ---- Action error display ----
+  it("shows generating indicator for SCRIPT_GENERATING", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_GENERATING]);
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("script-generating-indicator"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Generating Script/i)).toBeInTheDocument();
+  });
+
+  it("calls generate-script endpoint on Generate Script click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_IDEA]);
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Generate Script" }),
+      ).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Generate Script" }),
+    );
+
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/generate-script"))).toBe(true);
+    });
+  });
+
+  it("calls approve-script endpoint on Confirm click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "Confirm & Generate Visual Plan",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Confirm & Generate Visual Plan",
+      }),
+    );
+
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/approve-script"))).toBe(true);
+    });
+  });
+
+  it("calls restart endpoint on Regenerate click", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Regenerate" }),
+      ).toBeInTheDocument();
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
+
+    await waitFor(() => {
+      const calls = fetchSpy.mock.calls.map(([url]) =>
+        typeof url === "string" ? url : (url as Request).url,
+      );
+      expect(calls.some((u) => u.includes("/restart"))).toBe(true);
+    });
+  });
+
   it("shows error status when approve fails", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_REVIEW]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Approve Script" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", {
+          name: "Confirm & Generate Visual Plan",
+        }),
+      ).toBeInTheDocument();
     });
 
     // Override fetch to fail on approve
@@ -457,26 +548,34 @@ describe("ProjectPage", () => {
           json: () => Promise.resolve({ detail: "Stage conflict" }),
         } as Response);
       }
-      // Fallback for other calls
       return Promise.resolve({
         ok: true,
         json: () => Promise.resolve(MOCK_RUN_REVIEW),
       } as Response);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Approve Script" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Confirm & Generate Visual Plan",
+      }),
+    );
 
     await waitFor(() => {
-      expect(screen.getByText("Stage conflict")).toBeInTheDocument();
+      expect(screen.getByTestId("status-toast")).toHaveTextContent(
+        "Stage conflict",
+      );
     });
   });
-  // ---- Visual Plan stages ----
+
+  // ═══════════════ Visual Plan Stages ═══════════════
 
   it("shows VP generating indicator for VISUAL_PLAN_GENERATING", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("vp-generating-indicator")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("vp-generating-indicator"),
+      ).toBeInTheDocument();
     });
     expect(screen.getByText(/Generating Visual Plan/i)).toBeInTheDocument();
     expect(screen.getByText("Visual Plan Setup")).toBeInTheDocument();
@@ -486,33 +585,39 @@ describe("ProjectPage", () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_REVIEW]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("visual-plan-editor")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("visual-plan-editor"),
+      ).toBeInTheDocument();
     });
-    expect(screen.getAllByText("Script Model").length).toBeGreaterThan(0);
-    // Approve and Regenerate Plan visible
-    expect(screen.getByRole("button", { name: "Approve Visual Plan" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Regenerate Plan" })).toBeInTheDocument();
-    // Script actions should not be visible
-    expect(screen.queryByRole("button", { name: "Approve Script" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Generate Script" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Approve Visual Plan" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Regenerate Plan" }),
+    ).toBeInTheDocument();
   });
 
   it("calls approve-visual-plan endpoint on Approve Visual Plan click", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_REVIEW]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Approve Visual Plan" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Approve Visual Plan" }),
+      ).toBeInTheDocument();
     });
 
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-
-    fireEvent.click(screen.getByRole("button", { name: "Approve Visual Plan" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Approve Visual Plan" }),
+    );
 
     await waitFor(() => {
       const calls = fetchSpy.mock.calls.map(([url]) =>
         typeof url === "string" ? url : (url as Request).url,
       );
-      expect(calls.some((u) => u.includes("/approve-visual-plan"))).toBe(true);
+      expect(calls.some((u) => u.includes("/approve-visual-plan"))).toBe(
+        true,
+      );
     });
   });
 
@@ -520,28 +625,33 @@ describe("ProjectPage", () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_SETUP]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Generate Visual Plan" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Generate Visual Plan" }),
+      ).toBeInTheDocument();
     });
-    expect(screen.getByText("Script Model")).toBeInTheDocument();
-    expect(screen.queryByText("Image Model")).not.toBeInTheDocument();
   });
 
   it("calls generate-visual-plan endpoint from VISUAL_PLAN_SETUP", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_SETUP]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Generate Visual Plan" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Generate Visual Plan" }),
+      ).toBeInTheDocument();
     });
 
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-
-    fireEvent.click(screen.getByRole("button", { name: "Generate Visual Plan" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Generate Visual Plan" }),
+    );
 
     await waitFor(() => {
       const calls = fetchSpy.mock.calls.map(([url]) =>
         typeof url === "string" ? url : (url as Request).url,
       );
-      expect(calls.some((u) => u.includes("/generate-visual-plan"))).toBe(true);
+      expect(calls.some((u) => u.includes("/generate-visual-plan"))).toBe(
+        true,
+      );
     });
   });
 
@@ -549,12 +659,15 @@ describe("ProjectPage", () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_REVIEW]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Regenerate Plan" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Regenerate Plan" }),
+      ).toBeInTheDocument();
     });
 
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-
-    fireEvent.click(screen.getByRole("button", { name: "Regenerate Plan" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Regenerate Plan" }),
+    );
 
     await waitFor(() => {
       const calls = fetchSpy.mock.calls;
@@ -568,279 +681,188 @@ describe("ProjectPage", () => {
     });
   });
 
-  // ---- Visual Asset Stages ----
+  // ═══════════════ Storyboard Workspace Stages ═══════════════
 
-  const MOCK_RUN_VA_GENERATING = {
-    id: 1,
-    project_id: 7,
-    current_stage: "VISUAL_ASSET_GENERATING",
-    status: "running",
-    restart_from: null,
-  };
-
-  const MOCK_RUN_VA_REVIEW = {
-    id: 1,
-    project_id: 7,
-    current_stage: "VISUAL_ASSET_REVIEW",
-    status: "running",
-    restart_from: null,
-  };
-
-  const MOCK_RUN_AUDIO_GENERATING = {
-    id: 1,
-    project_id: 7,
-    current_stage: "AUDIO_GENERATING",
-    status: "running",
-    restart_from: null,
-  };
-
-  const MOCK_RUN_SUBTITLE_GENERATING = {
-    id: 1,
-    project_id: 7,
-    current_stage: "SUBTITLE_GENERATING",
-    status: "running",
-    restart_from: null,
-  };
-
-  const MOCK_RUN_RENDER_GENERATING = {
-    id: 1,
-    project_id: 7,
-    current_stage: "RENDER_GENERATING",
-    status: "running",
-    restart_from: null,
-  };
-
-  const MOCK_RUN_FINAL_REVIEW = {
-    id: 1,
-    project_id: 7,
-    current_stage: "FINAL_REVIEW",
-    status: "running",
-    restart_from: null,
-  };
-
-  it("shows VA generating indicator for VISUAL_ASSET_GENERATING", async () => {
+  it("renders StoryboardWorkspace for VISUAL_ASSET_GENERATING", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("va-generating-indicator")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("storyboard-workspace"),
+      ).toBeInTheDocument();
     });
-    expect(screen.getByText("Generating Visual Assets…")).toBeInTheDocument();
   });
 
-  it("shows visual-asset-section for VISUAL_ASSET_REVIEW", async () => {
+  it("renders StoryboardWorkspace for VISUAL_ASSET_REVIEW", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("visual-asset-section")).toBeInTheDocument();
-    });
-    expect(screen.getAllByText("Image Model").length).toBeGreaterThan(0);
-  });
-
-  it("shows scene regen controls in VISUAL_ASSET_REVIEW", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByTestId("scene-regen-controls")).toBeInTheDocument();
-    });
-    expect(screen.getByTestId("scene-id-input")).toBeInTheDocument();
-    expect(screen.getByTestId("regen-scene-btn")).toBeInTheDocument();
-    expect(screen.getByTestId("generate-scene-btn")).toBeInTheDocument();
-  });
-
-  it("hides scene regen controls during VISUAL_ASSET_GENERATING", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_GENERATING]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByTestId("visual-asset-section")).toBeInTheDocument();
-    });
-    expect(screen.queryByTestId("scene-regen-controls")).not.toBeInTheDocument();
-  });
-
-  it("shows Approve Assets button in VISUAL_ASSET_REVIEW", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Approve Assets" })).toBeInTheDocument();
+      expect(
+        screen.getByTestId("storyboard-workspace"),
+      ).toBeInTheDocument();
     });
   });
 
-  it("calls approve-visual-assets endpoint on Approve Assets click", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Approve Assets" })).toBeInTheDocument();
-    });
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    fireEvent.click(screen.getByRole("button", { name: "Approve Assets" }));
-    await waitFor(() => {
-      const calls = fetchSpy.mock.calls.map(([url]) =>
-        typeof url === "string" ? url : (url as Request).url,
-      );
-      expect(calls.some((u) => u.includes("/approve-visual-assets"))).toBe(true);
-    });
-  });
-
-  it("calls generate-visual-assets endpoint on Regenerate All click", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Regenerate All" })).toBeInTheDocument();
-    });
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    fireEvent.click(screen.getByRole("button", { name: "Regenerate All" }));
-    await waitFor(() => {
-      const calls = fetchSpy.mock.calls.map(([url]) =>
-        typeof url === "string" ? url : (url as Request).url,
-      );
-      expect(calls.some((u) => u.includes("/generate-visual-assets"))).toBe(true);
-    });
-  });
-
-  it("calls restart with VISUAL_ASSET_GENERATING stage on Restart Assets click", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Restart Assets" })).toBeInTheDocument();
-    });
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    fireEvent.click(screen.getByRole("button", { name: "Restart Assets" }));
-    await waitFor(() => {
-      const calls = fetchSpy.mock.calls;
-      const restartCall = calls.find(([url]) => {
-        const u = typeof url === "string" ? url : (url as Request).url;
-        return u.includes("/restart");
-      });
-      expect(restartCall).toBeDefined();
-      const body = JSON.parse(restartCall![1]!.body as string);
-      expect(body.stage).toBe("VISUAL_ASSET_GENERATING");
-    });
-  });
-
-  it("calls regenerate-image endpoint when scene regen button clicked", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByTestId("scene-regen-controls")).toBeInTheDocument();
-    });
-    const input = screen.getByTestId("scene-id-input") as HTMLInputElement;
-    fireEvent.change(input, { target: { value: "scene-0" } });
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    fireEvent.click(screen.getByTestId("regen-scene-btn"));
-    await waitFor(() => {
-      const calls = fetchSpy.mock.calls.map(([url]) =>
-        typeof url === "string" ? url : (url as Request).url,
-      );
-      expect(calls.some((u) => u.includes("/scenes/scene-0/regenerate-image"))).toBe(true);
-    });
-  });
-
-  it("calls generate-image endpoint when generate-scene button clicked", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VA_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByTestId("scene-regen-controls")).toBeInTheDocument();
-    });
-    const input = screen.getByTestId("scene-id-input") as HTMLInputElement;
-    fireEvent.change(input, { target: { value: "scene-1" } });
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    fireEvent.click(screen.getByTestId("generate-scene-btn"));
-    await waitFor(() => {
-      const calls = fetchSpy.mock.calls.map(([url]) =>
-        typeof url === "string" ? url : (url as Request).url,
-      );
-      expect(calls.some((u) => u.includes("/scenes/scene-1/generate-image"))).toBe(true);
-    });
-  });
-
-  // ---- Audio / Subtitle / Render / Final Review Stages ----
-
-  it("shows storyboard view for AUDIO_GENERATING", async () => {
+  it("renders StoryboardWorkspace for AUDIO_GENERATING", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_AUDIO_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("storyboard-workspace"),
+      ).toBeInTheDocument();
     });
-    // Render should not be offered before subtitle stage
-    expect(screen.queryByRole("button", { name: "Render Video" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Restart from Script" })).toBeInTheDocument();
   });
 
-  it("shows storyboard view for SUBTITLE_GENERATING", async () => {
+  it("renders StoryboardWorkspace for SUBTITLE_GENERATING", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_SUBTITLE_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("storyboard-workspace"),
+      ).toBeInTheDocument();
     });
-    expect(screen.getByRole("button", { name: "Render Video" })).toBeInTheDocument();
-    expect(screen.getByLabelText(/Render Profile/)).toBeInTheDocument();
   });
 
-  it("shows storyboard view for RENDER_GENERATING", async () => {
+  it("renders StoryboardWorkspace for RENDER_GENERATING", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_RENDER_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("storyboard-workspace"),
+      ).toBeInTheDocument();
     });
-    // During render, storyboard should be read-only (no generate buttons in storyboard)
-    expect(screen.getByRole("button", { name: "Restart from Script" })).toBeInTheDocument();
   });
 
-  it("shows final review section with storyboard and review link for FINAL_REVIEW", async () => {
+  it("shows final review section with review link for FINAL_REVIEW", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_FINAL_REVIEW]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("storyboard-workspace"),
+      ).toBeInTheDocument();
     });
     expect(screen.getByTestId("final-review-section")).toBeInTheDocument();
     expect(screen.getByText("Pipeline Complete")).toBeInTheDocument();
     expect(screen.getByTestId("review-link")).toBeInTheDocument();
-    expect(screen.getByTestId("review-link").getAttribute("href")).toBe("/review/1");
+    expect(screen.getByTestId("review-link").getAttribute("href")).toBe(
+      "/review/1",
+    );
   });
 
-  it("shows Restart from Script button in FINAL_REVIEW", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_FINAL_REVIEW]);
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Restart from Script" })).toBeInTheDocument();
-    });
-  });
-
-  it("hides approve button during AUDIO_GENERATING", async () => {
+  it("shows scene cards inside StoryboardWorkspace", async () => {
     mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_AUDIO_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByTestId("storyboard-view")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("storyboard-workspace"),
+      ).toBeInTheDocument();
     });
-    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    // The storyboard workspace should render a scene card for sec-0
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-card-sec-0")).toBeInTheDocument();
+    });
   });
 
-  it("hides idea-only go-back action for markdown-source script review", async () => {
-    mockFetchProjectAndRuns({ ...MOCK_PROJECT, source_type: "markdown" }, [MOCK_RUN_REVIEW]);
+  it("shows pipeline overview bar in StoryboardWorkspace", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_AUDIO_GENERATING]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Approve Script" })).toBeInTheDocument();
+      expect(
+        screen.getByTestId("pipeline-overview-bar"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows bulk action bar in StoryboardWorkspace", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_AUDIO_GENERATING]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-action-bar")).toBeInTheDocument();
+    });
+  });
+
+  // ═══════════════ Go-Back Navigation ═══════════════
+
+  it("shows go-back button for VISUAL_PLAN_SETUP", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_VP_SETUP]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("go-back-btn")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("go-back-btn")).toHaveTextContent(
+      "Back to Script Review",
+    );
+  });
+
+  it("hides go-back for markdown-source SCRIPT_REVIEW", async () => {
+    mockFetchProjectAndRuns(
+      { ...MOCK_PROJECT, source_type: "markdown" },
+      [MOCK_RUN_REVIEW],
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("script-composer")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("go-back-btn")).not.toBeInTheDocument();
   });
 
-  it("uses selected render profile when rendering from subtitle stage", async () => {
-    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_SUBTITLE_GENERATING]);
+  // ═══════════════ Stop / Resume / Delete ═══════════════
+
+  it("shows Stop button for running run", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [
+      { ...MOCK_RUN_IDEA, status: "running" },
+    ]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Render Video" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Stop/ }),
+      ).toBeInTheDocument();
     });
+  });
 
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    fireEvent.change(screen.getByLabelText(/Render Profile/), { target: { value: "high_quality" } });
-    fireEvent.click(screen.getByRole("button", { name: "Render Video" }));
-
+  it("shows Resume button for cancelled run", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [
+      { ...MOCK_RUN_IDEA, status: "cancelled" },
+    ]);
+    renderPage();
     await waitFor(() => {
-      const renderCall = fetchSpy.mock.calls.find(([url]) =>
-        (typeof url === "string" ? url : (url as Request).url).includes("/render")
-      );
-      expect(renderCall).toBeTruthy();
-      const body = JSON.parse((renderCall![1] as RequestInit).body as string);
-      expect(body.render_profile).toBe("high_quality");
+      expect(
+        screen.getByRole("button", { name: /Resume/ }),
+      ).toBeInTheDocument();
     });
+  });
+
+  it("shows Delete Project button", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_IDEA]);
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Delete Project/ }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ═══════════════ Max Width ═══════════════
+
+  it("uses wider max-width for storyboard stages", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_AUDIO_GENERATING]);
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("storyboard-workspace"),
+      ).toBeInTheDocument();
+    });
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.maxWidth).toBe("1200px");
+  });
+
+  it("uses narrower max-width for script stages", async () => {
+    mockFetchProjectAndRuns(MOCK_PROJECT, [MOCK_RUN_IDEA]);
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("script-composer")).toBeInTheDocument();
+    });
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.maxWidth).toBe("960px");
   });
 });

--- a/apps/studio-web/src/__tests__/SceneCard.test.tsx
+++ b/apps/studio-web/src/__tests__/SceneCard.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SceneCard from "../components/creator/SceneCard";
+import type { StoryboardParagraph } from "../api/storyboard";
+
+// --------------- test helpers ---------------
+
+function makeParagraph(overrides: Partial<StoryboardParagraph> = {}): StoryboardParagraph {
+  return {
+    section_id: "sec-0",
+    order: 0,
+    text: "Hello world, this is a test paragraph for the scene card.",
+    display_text: null,
+    image_prompt: "A beautiful sunset",
+    image_url: null,
+    audio_url: null,
+    audio_duration: null,
+    subtitles_url: null,
+    subtitle_entries: null,
+    status: "idle",
+    stale_flags: null,
+    scene_id: "scene-0",
+    image_asset_id: null,
+    audio_artifact_id: null,
+    subtitle_artifact_id: null,
+    ...overrides,
+  };
+}
+
+describe("SceneCard", () => {
+  // ---- rendering ----
+
+  it("renders scene number and text", () => {
+    const p = makeParagraph({ order: 2, text: "Test narration text" });
+    render(<SceneCard paragraph={p} />);
+    expect(screen.getByTestId("scene-card-sec-0")).toBeInTheDocument();
+    expect(screen.getByText("Scene 3")).toBeInTheDocument();
+    expect(screen.getByTestId("scene-text-sec-0")).toHaveTextContent("Test narration text");
+  });
+
+  it("prefers display_text over text", () => {
+    const p = makeParagraph({ text: "raw", display_text: "Displayed version" });
+    render(<SceneCard paragraph={p} />);
+    expect(screen.getByTestId("scene-text-sec-0")).toHaveTextContent("Displayed version");
+  });
+
+  // ---- status badges ----
+
+  it("shows Idle badge when no assets", () => {
+    const p = makeParagraph();
+    render(<SceneCard paragraph={p} />);
+    expect(screen.getByTestId("scene-badge-sec-0")).toHaveTextContent("Idle");
+    expect(screen.getByTestId("scene-card-sec-0")).toHaveAttribute("data-status", "idle");
+  });
+
+  it("shows Partial badge when some assets present", () => {
+    const p = makeParagraph({ image_url: "/img.png" });
+    render(<SceneCard paragraph={p} />);
+    expect(screen.getByTestId("scene-badge-sec-0")).toHaveTextContent("Partial");
+  });
+
+  it("shows Ready badge when all 3 assets present", () => {
+    const p = makeParagraph({
+      image_url: "/img.png",
+      audio_url: "/audio.wav",
+      subtitles_url: "/subs.srt",
+    });
+    render(<SceneCard paragraph={p} />);
+    expect(screen.getByTestId("scene-badge-sec-0")).toHaveTextContent("Ready");
+    expect(screen.getByTestId("scene-card-sec-0")).toHaveAttribute("data-status", "ready");
+  });
+
+  it("shows Generating badge during generation", () => {
+    const p = makeParagraph({ status: "generating_audio" });
+    render(<SceneCard paragraph={p} />);
+    expect(screen.getByTestId("scene-badge-sec-0")).toHaveTextContent("Generating…");
+  });
+
+  // ---- asset slots ----
+
+  it("renders 3 asset slots", () => {
+    const p = makeParagraph();
+    render(<SceneCard paragraph={p} />);
+    expect(screen.getByTestId("asset-slot-image")).toBeInTheDocument();
+    expect(screen.getByTestId("asset-slot-audio")).toBeInTheDocument();
+    expect(screen.getByTestId("asset-slot-subtitle")).toBeInTheDocument();
+  });
+
+  it("sets correct asset status for each slot", () => {
+    const p = makeParagraph({
+      image_url: "/img.png",
+      audio_url: null,
+      subtitles_url: null,
+    });
+    render(<SceneCard paragraph={p} />);
+    expect(screen.getByTestId("asset-slot-image")).toHaveAttribute("data-status", "ready");
+    expect(screen.getByTestId("asset-slot-audio")).toHaveAttribute("data-status", "empty");
+    expect(screen.getByTestId("asset-slot-subtitle")).toHaveAttribute("data-status", "empty");
+  });
+
+  it("shows loading status for the slot being generated", () => {
+    const p = makeParagraph({ status: "generating_audio", image_url: "/img.png" });
+    render(<SceneCard paragraph={p} />);
+    expect(screen.getByTestId("asset-slot-image")).toHaveAttribute("data-status", "ready");
+    expect(screen.getByTestId("asset-slot-audio")).toHaveAttribute("data-status", "loading");
+    expect(screen.getByTestId("asset-slot-subtitle")).toHaveAttribute("data-status", "empty");
+  });
+
+  // ---- action buttons ----
+
+  it("shows Gen Image button when image missing and scene_id exists", () => {
+    const onGenImage = vi.fn();
+    const p = makeParagraph({ scene_id: "scene-0" });
+    render(<SceneCard paragraph={p} onGenerateImage={onGenImage} />);
+    const btn = screen.getByTestId("gen-image-sec-0");
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onGenImage).toHaveBeenCalledWith("scene-0");
+  });
+
+  it("shows Gen Audio button when image exists but audio missing", () => {
+    const onGenAudio = vi.fn();
+    const p = makeParagraph({ image_url: "/img.png" });
+    render(<SceneCard paragraph={p} onGenerateAudio={onGenAudio} />);
+    const btn = screen.getByTestId("gen-audio-sec-0");
+    fireEvent.click(btn);
+    expect(onGenAudio).toHaveBeenCalledWith("sec-0");
+  });
+
+  it("shows Gen Subtitles button when audio exists but subtitles missing", () => {
+    const onGenSubs = vi.fn();
+    const p = makeParagraph({ image_url: "/img.png", audio_url: "/audio.wav" });
+    render(<SceneCard paragraph={p} onGenerateSubtitles={onGenSubs} />);
+    const btn = screen.getByTestId("gen-subs-sec-0");
+    fireEvent.click(btn);
+    expect(onGenSubs).toHaveBeenCalledWith("sec-0");
+  });
+
+  it("hides all action buttons when disabled", () => {
+    const p = makeParagraph({ scene_id: "scene-0" });
+    render(
+      <SceneCard
+        paragraph={p}
+        onGenerateImage={vi.fn()}
+        onGenerateAudio={vi.fn()}
+        onGenerateSubtitles={vi.fn()}
+        disabled
+      />,
+    );
+    expect(screen.queryByTestId("gen-image-sec-0")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("gen-audio-sec-0")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("gen-subs-sec-0")).not.toBeInTheDocument();
+  });
+
+  it("hides action buttons during generation", () => {
+    const p = makeParagraph({ status: "generating_image", scene_id: "scene-0" });
+    render(
+      <SceneCard paragraph={p} onGenerateImage={vi.fn()} />,
+    );
+    expect(screen.queryByTestId("gen-image-sec-0")).not.toBeInTheDocument();
+  });
+
+  // ---- text expand/collapse ----
+
+  it("toggles text expansion on click", () => {
+    const p = makeParagraph({ text: "A".repeat(200) });
+    render(<SceneCard paragraph={p} />);
+    const textEl = screen.getByTestId("scene-text-sec-0");
+    // Initially clamped (has -webkit-line-clamp style)
+    fireEvent.click(textEl);
+    // After click, expanded — we just verify it doesn't crash and re-renders
+    fireEvent.click(textEl);
+  });
+});

--- a/apps/studio-web/src/__tests__/SceneCardGrid.test.tsx
+++ b/apps/studio-web/src/__tests__/SceneCardGrid.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SceneCardGrid from "../components/creator/SceneCardGrid";
+import type { StoryboardParagraph } from "../api/storyboard";
+
+function makeParagraph(overrides: Partial<StoryboardParagraph> = {}): StoryboardParagraph {
+  return {
+    section_id: "sec-0",
+    order: 0,
+    text: "Test text",
+    display_text: null,
+    image_prompt: null,
+    image_url: null,
+    audio_url: null,
+    audio_duration: null,
+    subtitles_url: null,
+    subtitle_entries: null,
+    status: "idle",
+    stale_flags: null,
+    scene_id: "scene-0",
+    image_asset_id: null,
+    audio_artifact_id: null,
+    subtitle_artifact_id: null,
+    ...overrides,
+  };
+}
+
+function makeNParagraphs(n: number): StoryboardParagraph[] {
+  return Array.from({ length: n }, (_, i) =>
+    makeParagraph({ section_id: `sec-${i}`, order: i, scene_id: `scene-${i}`, text: `Paragraph ${i + 1}` }),
+  );
+}
+
+describe("SceneCardGrid", () => {
+  it("shows empty state when no paragraphs", () => {
+    render(<SceneCardGrid paragraphs={[]} />);
+    expect(screen.getByTestId("scene-card-grid-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("scene-card-grid-empty")).toHaveTextContent("No scenes");
+  });
+
+  it("renders 1 scene card", () => {
+    render(<SceneCardGrid paragraphs={makeNParagraphs(1)} />);
+    expect(screen.getByTestId("scene-card-grid")).toBeInTheDocument();
+    expect(screen.getByTestId("scene-card-sec-0")).toBeInTheDocument();
+  });
+
+  it("renders 5 scene cards", () => {
+    render(<SceneCardGrid paragraphs={makeNParagraphs(5)} />);
+    for (let i = 0; i < 5; i++) {
+      expect(screen.getByTestId(`scene-card-sec-${i}`)).toBeInTheDocument();
+    }
+  });
+
+  it("renders 10 scene cards", () => {
+    render(<SceneCardGrid paragraphs={makeNParagraphs(10)} />);
+    const grid = screen.getByTestId("scene-card-grid");
+    expect(grid.children).toHaveLength(10);
+  });
+
+  it("passes disabled prop to all cards", () => {
+    const onGenImage = vi.fn();
+    const paragraphs = [makeParagraph({ scene_id: "scene-0" })];
+    render(
+      <SceneCardGrid
+        paragraphs={paragraphs}
+        onGenerateImage={onGenImage}
+        disabled
+      />,
+    );
+    // When disabled, action buttons should not be rendered
+    expect(screen.queryByTestId("gen-image-sec-0")).not.toBeInTheDocument();
+  });
+
+  it("renders grid container with correct test id", () => {
+    render(<SceneCardGrid paragraphs={makeNParagraphs(3)} />);
+    expect(screen.getByTestId("scene-card-grid")).toBeInTheDocument();
+  });
+});

--- a/apps/studio-web/src/__tests__/ScriptComposer.test.tsx
+++ b/apps/studio-web/src/__tests__/ScriptComposer.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ScriptComposer from "../components/creator/ScriptComposer";
+
+// Mock child editors to avoid complex setup
+vi.mock("../components/creator/MarkdownScriptEditor", () => ({
+  default: (props: Record<string, unknown>) => (
+    <div data-testid="markdown-editor" data-readonly={String(props.readOnly)}>
+      MarkdownEditor
+    </div>
+  ),
+}));
+
+vi.mock("../components/creator/StructuredScriptEditor", () => ({
+  default: (props: Record<string, unknown>) => (
+    <div data-testid="structured-editor" data-readonly={String(props.readOnly)}>
+      StructuredEditor
+    </div>
+  ),
+}));
+
+vi.mock("../components/creator/ModelSelector", () => ({
+  default: () => <div data-testid="model-selector">ModelSelector</div>,
+}));
+
+describe("ScriptComposer", () => {
+  it("renders script composer container", () => {
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="IDEA_READY"
+        sourceType="idea"
+      />,
+    );
+    expect(screen.getByTestId("script-composer")).toBeInTheDocument();
+  });
+
+  it("shows Generate Script button in IDEA_READY stage", () => {
+    const onGenerate = vi.fn();
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="IDEA_READY"
+        sourceType="idea"
+        onGenerate={onGenerate}
+      />,
+    );
+    const btn = screen.getByTestId("btn-generate-script");
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows Confirm and Regenerate buttons in SCRIPT_REVIEW stage", () => {
+    const onConfirm = vi.fn();
+    const onRegenerate = vi.fn();
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="SCRIPT_REVIEW"
+        sourceType="idea"
+        onConfirm={onConfirm}
+        onRegenerate={onRegenerate}
+      />,
+    );
+    expect(screen.getByTestId("btn-confirm-script")).toBeInTheDocument();
+    expect(screen.getByTestId("btn-regenerate-script")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("btn-confirm-script"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows generating indicator during SCRIPT_GENERATING", () => {
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="SCRIPT_GENERATING"
+        sourceType="idea"
+      />,
+    );
+    expect(screen.getByTestId("script-generating-indicator")).toBeInTheDocument();
+  });
+
+  it("shows source context when provided", () => {
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="IDEA_READY"
+        sourceType="idea"
+        sourceContext="A video about cats"
+      />,
+    );
+    expect(screen.getByText("A video about cats")).toBeInTheDocument();
+  });
+
+  it("switches editor mode tabs", () => {
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="SCRIPT_REVIEW"
+        sourceType="idea"
+      />,
+    );
+    // Default is markdown
+    expect(screen.getByTestId("markdown-editor")).toBeInTheDocument();
+    // Click structured tab
+    fireEvent.click(screen.getByText("Structured"));
+    expect(screen.getByTestId("structured-editor")).toBeInTheDocument();
+    // Click back to markdown
+    fireEvent.click(screen.getByText("Markdown"));
+    expect(screen.getByTestId("markdown-editor")).toBeInTheDocument();
+  });
+
+  it("passes readOnly=false to editor in SCRIPT_REVIEW stage", () => {
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="SCRIPT_REVIEW"
+        sourceType="idea"
+      />,
+    );
+    expect(screen.getByTestId("markdown-editor")).toHaveAttribute("data-readonly", "false");
+  });
+
+  it("passes readOnly=true to editor in IDEA_READY stage", () => {
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="IDEA_READY"
+        sourceType="idea"
+      />,
+    );
+    expect(screen.getByTestId("markdown-editor")).toHaveAttribute("data-readonly", "true");
+  });
+
+  it("disables buttons when disabled prop is true", () => {
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="IDEA_READY"
+        sourceType="idea"
+        onGenerate={vi.fn()}
+        disabled
+      />,
+    );
+    expect(screen.getByTestId("btn-generate-script")).toBeDisabled();
+  });
+
+  it("hides generate button in SCRIPT_REVIEW", () => {
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="SCRIPT_REVIEW"
+        sourceType="idea"
+      />,
+    );
+    expect(screen.queryByTestId("btn-generate-script")).not.toBeInTheDocument();
+  });
+
+  it("hides confirm/regenerate in IDEA_READY", () => {
+    render(
+      <ScriptComposer
+        runId={1}
+        currentStage="IDEA_READY"
+        sourceType="idea"
+      />,
+    );
+    expect(screen.queryByTestId("btn-confirm-script")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("btn-regenerate-script")).not.toBeInTheDocument();
+  });
+});

--- a/apps/studio-web/src/__tests__/StoryboardWorkspace.test.tsx
+++ b/apps/studio-web/src/__tests__/StoryboardWorkspace.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import StoryboardWorkspace from "../components/creator/StoryboardWorkspace";
+import type { StoryboardResponse } from "../api/storyboard";
+
+// Mock the storyboard API
+vi.mock("../api/storyboard", () => ({
+  fetchStoryboard: vi.fn(),
+  generateParagraphAudio: vi.fn(),
+  generateParagraphSubtitles: vi.fn(),
+  generateAllParagraphAudio: vi.fn().mockResolvedValue({ dispatched: 3 }),
+  generateAllParagraphSubtitles: vi.fn().mockResolvedValue({ dispatched: 3 }),
+}));
+
+import { fetchStoryboard } from "../api/storyboard";
+const mockFetchStoryboard = fetchStoryboard as ReturnType<typeof vi.fn>;
+
+const MOCK_STORYBOARD: StoryboardResponse = {
+  run_id: 1,
+  paragraphs: [
+    {
+      section_id: "sec-0",
+      order: 0,
+      text: "First scene text",
+      display_text: null,
+      image_prompt: "A sunrise",
+      image_url: "/img/0.png",
+      audio_url: "/audio/0.wav",
+      audio_duration: 5.2,
+      subtitles_url: null,
+      subtitle_entries: null,
+      status: "idle",
+      stale_flags: null,
+      scene_id: "scene-0",
+      image_asset_id: 1,
+      audio_artifact_id: 2,
+      subtitle_artifact_id: null,
+    },
+    {
+      section_id: "sec-1",
+      order: 1,
+      text: "Second scene text",
+      display_text: null,
+      image_prompt: "A sunset",
+      image_url: null,
+      audio_url: null,
+      audio_duration: null,
+      subtitles_url: null,
+      subtitle_entries: null,
+      status: "idle",
+      stale_flags: null,
+      scene_id: "scene-1",
+      image_asset_id: null,
+      audio_artifact_id: null,
+      subtitle_artifact_id: null,
+    },
+  ],
+  render_ready: false,
+  total_paragraphs: 2,
+  ready_paragraphs: 0,
+};
+
+describe("StoryboardWorkspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton initially", () => {
+    mockFetchStoryboard.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<StoryboardWorkspace runId={1} />);
+    expect(screen.getByTestId("storyboard-workspace-loading")).toBeInTheDocument();
+  });
+
+  it("renders storyboard after loading", async () => {
+    mockFetchStoryboard.mockResolvedValue(MOCK_STORYBOARD);
+    render(<StoryboardWorkspace runId={1} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("storyboard-workspace")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("pipeline-overview-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-action-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("scene-card-grid")).toBeInTheDocument();
+  });
+
+  it("shows error state on fetch failure", async () => {
+    mockFetchStoryboard.mockRejectedValue(new Error("Network error"));
+    render(<StoryboardWorkspace runId={1} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("storyboard-workspace-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("storyboard-workspace-error")).toHaveTextContent("Network error");
+  });
+
+  it("renders correct number of scene cards", async () => {
+    mockFetchStoryboard.mockResolvedValue(MOCK_STORYBOARD);
+    render(<StoryboardWorkspace runId={1} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("scene-card-sec-0")).toBeInTheDocument();
+      expect(screen.getByTestId("scene-card-sec-1")).toBeInTheDocument();
+    });
+  });
+
+  it("shows per-type stats in overview bar", async () => {
+    mockFetchStoryboard.mockResolvedValue(MOCK_STORYBOARD);
+    render(<StoryboardWorkspace runId={1} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("stat-images")).toHaveTextContent("1/2");
+      expect(screen.getByTestId("stat-audio")).toHaveTextContent("1/2");
+      expect(screen.getByTestId("stat-subtitles")).toHaveTextContent("0/2");
+    });
+  });
+
+  it("render button is disabled when not ready", async () => {
+    mockFetchStoryboard.mockResolvedValue(MOCK_STORYBOARD);
+    render(<StoryboardWorkspace runId={1} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("render-btn")).toBeDisabled();
+    });
+  });
+
+  it("render button enabled when all ready", async () => {
+    const allReady = {
+      ...MOCK_STORYBOARD,
+      render_ready: true,
+      ready_paragraphs: 2,
+      paragraphs: MOCK_STORYBOARD.paragraphs.map((p) => ({
+        ...p,
+        image_url: "/img.png",
+        audio_url: "/audio.wav",
+        subtitles_url: "/subs.srt",
+        status: "ready" as const,
+      })),
+    };
+    mockFetchStoryboard.mockResolvedValue(allReady);
+    render(<StoryboardWorkspace runId={1} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("render-btn")).not.toBeDisabled();
+    });
+  });
+});

--- a/apps/studio-web/src/components/creator/AssetSlot.tsx
+++ b/apps/studio-web/src/components/creator/AssetSlot.tsx
@@ -1,0 +1,300 @@
+/**
+ * AssetSlot — reusable compact slot for image / audio / subtitle within a SceneCard.
+ *
+ * Three visual states:
+ *   - empty: placeholder icon + label
+ *   - loading: shimmer pulse animation
+ *   - ready: content preview (thumbnail / play button / subtitle badge)
+ *
+ * Hover reveals a regenerate icon-button.
+ */
+
+import { useState, useRef } from "react";
+
+// --------------- types ---------------
+
+export type AssetType = "image" | "audio" | "subtitle";
+export type AssetStatus = "empty" | "loading" | "ready";
+
+export interface AssetSlotProps {
+  type: AssetType;
+  status: AssetStatus;
+  /** URL of the asset when ready. */
+  url?: string | null;
+  /** Audio duration in seconds (audio type only). */
+  duration?: number | null;
+  /** Subtitle entry count (subtitle type only). */
+  subtitleCount?: number | null;
+  /** Called when the user clicks regenerate. */
+  onRegenerate?: () => void;
+  /** Called when the user clicks to preview the asset. */
+  onPreview?: () => void;
+  /** Whether interaction is disabled (e.g. during bulk generation). */
+  disabled?: boolean;
+}
+
+// --------------- icons (inline SVG strings) ---------------
+
+const ICONS: Record<AssetType, string> = {
+  image: "🖼️",
+  audio: "🔊",
+  subtitle: "💬",
+};
+
+const LABELS: Record<AssetType, string> = {
+  image: "Image",
+  audio: "Audio",
+  subtitle: "Subtitles",
+};
+
+// --------------- helpers ---------------
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return m > 0 ? `${m}:${s.toString().padStart(2, "0")}` : `${s}s`;
+}
+
+/** Convert API artifact path → browser URL via Vite proxy. */
+function artifactUrl(path: string): string {
+  const match = path.match(/data\/artifacts\/(.*)/);
+  return match ? `/artifacts/${match[1]}` : `/artifacts/${path}`;
+}
+
+// --------------- styles ---------------
+
+const slotBase: React.CSSProperties = {
+  position: "relative",
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "6px 10px",
+  borderRadius: 6,
+  border: "1px solid #e5e7eb",
+  background: "#fff",
+  minHeight: 36,
+  cursor: "default",
+  transition: "background 0.15s, border-color 0.15s",
+  overflow: "hidden",
+};
+
+const emptyStyle: React.CSSProperties = {
+  ...slotBase,
+  background: "#f9fafb",
+  borderStyle: "dashed",
+};
+
+const loadingStyle: React.CSSProperties = {
+  ...slotBase,
+  background: "linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%)",
+  backgroundSize: "200% 100%",
+  animation: "assetSlotShimmer 1.5s ease-in-out infinite",
+};
+
+const readyStyle: React.CSSProperties = {
+  ...slotBase,
+  background: "#f0fdf4",
+  borderColor: "#bbf7d0",
+};
+
+const iconStyle: React.CSSProperties = {
+  fontSize: 14,
+  lineHeight: 1,
+  flexShrink: 0,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "#6b7280",
+  fontWeight: 500,
+  flex: 1,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const readyLabelStyle: React.CSSProperties = {
+  ...labelStyle,
+  color: "#166534",
+  fontWeight: 600,
+};
+
+const regenBtnStyle: React.CSSProperties = {
+  position: "absolute",
+  right: 4,
+  top: "50%",
+  transform: "translateY(-50%)",
+  width: 22,
+  height: 22,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  borderRadius: 4,
+  border: "1px solid #d1d5db",
+  background: "#fff",
+  cursor: "pointer",
+  fontSize: 11,
+  color: "#6b7280",
+  opacity: 0,
+  transition: "opacity 0.15s",
+  padding: 0,
+};
+
+const thumbnailStyle: React.CSSProperties = {
+  width: 32,
+  height: 20,
+  objectFit: "cover",
+  borderRadius: 3,
+  flexShrink: 0,
+};
+
+// --------------- keyframes (injected once) ---------------
+
+let shimmerInjected = false;
+function ensureShimmerKeyframes() {
+  if (shimmerInjected || typeof document === "undefined") return;
+  shimmerInjected = true;
+  const style = document.createElement("style");
+  style.textContent = `@keyframes assetSlotShimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }`;
+  document.head.appendChild(style);
+}
+
+// --------------- component ---------------
+
+export default function AssetSlot({
+  type,
+  status,
+  url,
+  duration,
+  subtitleCount,
+  onRegenerate,
+  onPreview,
+  disabled = false,
+}: AssetSlotProps) {
+  ensureShimmerKeyframes();
+
+  const [hovered, setHovered] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [playing, setPlaying] = useState(false);
+
+  const handleClick = () => {
+    if (disabled) return;
+    if (status !== "ready" || !url) return;
+
+    if (type === "audio") {
+      // Toggle inline play
+      if (audioRef.current) {
+        if (playing) {
+          audioRef.current.pause();
+          audioRef.current.currentTime = 0;
+          setPlaying(false);
+        } else {
+          audioRef.current.play().catch(() => {});
+          setPlaying(true);
+        }
+      }
+      return;
+    }
+
+    onPreview?.();
+  };
+
+  const resolvedUrl = url ? artifactUrl(url) : null;
+
+  // ---- empty ----
+  if (status === "empty") {
+    return (
+      <div
+        style={emptyStyle}
+        data-testid={`asset-slot-${type}`}
+        data-status="empty"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        <span style={iconStyle}>{ICONS[type]}</span>
+        <span style={labelStyle}>{LABELS[type]}</span>
+      </div>
+    );
+  }
+
+  // ---- loading ----
+  if (status === "loading") {
+    return (
+      <div
+        style={loadingStyle}
+        data-testid={`asset-slot-${type}`}
+        data-status="loading"
+      >
+        <span style={iconStyle}>{ICONS[type]}</span>
+        <span style={{ ...labelStyle, color: "#9ca3af" }}>Generating…</span>
+      </div>
+    );
+  }
+
+  // ---- ready ----
+  const readyLabel = (() => {
+    if (type === "audio" && duration != null) {
+      return `${playing ? "▶ " : ""}${formatDuration(duration)}`;
+    }
+    if (type === "subtitle" && subtitleCount != null) {
+      return `${subtitleCount} cue${subtitleCount !== 1 ? "s" : ""}`;
+    }
+    return "✓ Ready";
+  })();
+
+  return (
+    <div
+      style={{
+        ...readyStyle,
+        cursor: status === "ready" && (type === "audio" || onPreview) ? "pointer" : "default",
+      }}
+      data-testid={`asset-slot-${type}`}
+      data-status="ready"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={handleClick}
+      role={type === "audio" || onPreview ? "button" : undefined}
+      tabIndex={type === "audio" || onPreview ? 0 : undefined}
+    >
+      {/* Thumbnail for image */}
+      {type === "image" && resolvedUrl && (
+        <img
+          src={resolvedUrl}
+          alt="Scene thumbnail"
+          style={thumbnailStyle}
+        />
+      )}
+
+      {type !== "image" && <span style={iconStyle}>{ICONS[type]}</span>}
+
+      <span style={readyLabelStyle}>{readyLabel}</span>
+
+      {/* Hidden audio element for inline play */}
+      {type === "audio" && resolvedUrl && (
+        <audio
+          ref={audioRef}
+          src={resolvedUrl}
+          preload="none"
+          onEnded={() => setPlaying(false)}
+          data-testid={`audio-element-${type}`}
+        />
+      )}
+
+      {/* Regenerate button on hover */}
+      {onRegenerate && !disabled && (
+        <button
+          type="button"
+          style={{ ...regenBtnStyle, opacity: hovered ? 1 : 0 }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRegenerate();
+          }}
+          title={`Regenerate ${LABELS[type].toLowerCase()}`}
+          data-testid={`regen-${type}`}
+        >
+          ↻
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/studio-web/src/components/creator/BulkActionBar.tsx
+++ b/apps/studio-web/src/components/creator/BulkActionBar.tsx
@@ -1,0 +1,125 @@
+/**
+ * BulkActionBar — batch operation buttons with remaining counts.
+ *
+ * "Generate All Images (4 remaining)", "Generate All Audio (6 remaining)", etc.
+ * Buttons disabled when all complete or generation in progress.
+ */
+
+import type { StoryboardParagraph } from "../../api/storyboard";
+
+// --------------- props ---------------
+
+export interface BulkActionBarProps {
+  paragraphs: StoryboardParagraph[];
+  /** True when any bulk or per-scene generation is in progress. */
+  generating?: boolean;
+  onGenerateAllImages?: () => void;
+  onGenerateAllAudio?: () => void;
+  onGenerateAllSubtitles?: () => void;
+}
+
+// --------------- styles ---------------
+
+const barStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "8px 12px",
+  background: "#fafafa",
+  borderRadius: 8,
+  border: "1px solid #e5e7eb",
+  flexWrap: "wrap",
+};
+
+const btnBase: React.CSSProperties = {
+  padding: "5px 12px",
+  fontSize: 12,
+  fontWeight: 600,
+  border: "1px solid #d1d5db",
+  borderRadius: 6,
+  background: "#fff",
+  cursor: "pointer",
+  color: "#374151",
+  transition: "all 0.15s",
+  whiteSpace: "nowrap",
+};
+
+const disabledBtn: React.CSSProperties = {
+  ...btnBase,
+  opacity: 0.5,
+  cursor: "not-allowed",
+};
+
+// --------------- component ---------------
+
+export default function BulkActionBar({
+  paragraphs,
+  generating = false,
+  onGenerateAllImages,
+  onGenerateAllAudio,
+  onGenerateAllSubtitles,
+}: BulkActionBarProps) {
+  const total = paragraphs.length;
+  if (total === 0) return null;
+
+  const imagesRemaining = paragraphs.filter((p) => !p.image_url).length;
+  const audioRemaining = paragraphs.filter((p) => !p.audio_url).length;
+  const subtitlesRemaining = paragraphs.filter((p) => !p.subtitles_url).length;
+  const hasAnyGenerating = paragraphs.some((p) => p.status.startsWith("generating_"));
+  const isDisabled = generating || hasAnyGenerating;
+
+  return (
+    <div style={barStyle} data-testid="bulk-action-bar">
+      {/* Generate All Images */}
+      <button
+        type="button"
+        style={{
+          ...(isDisabled || imagesRemaining === 0 ? disabledBtn : btnBase),
+          borderColor: "#e9d5ff",
+          color: isDisabled || imagesRemaining === 0 ? "#9ca3af" : "#6b21a8",
+        }}
+        disabled={isDisabled || imagesRemaining === 0}
+        onClick={onGenerateAllImages}
+        data-testid="bulk-gen-images"
+      >
+        {imagesRemaining > 0
+          ? `Generate All Images (${imagesRemaining})`
+          : `All Images Done ✓`}
+      </button>
+
+      {/* Generate All Audio */}
+      <button
+        type="button"
+        style={{
+          ...(isDisabled || audioRemaining === 0 ? disabledBtn : btnBase),
+          borderColor: "#fde68a",
+          color: isDisabled || audioRemaining === 0 ? "#9ca3af" : "#92400e",
+        }}
+        disabled={isDisabled || audioRemaining === 0}
+        onClick={onGenerateAllAudio}
+        data-testid="bulk-gen-audio"
+      >
+        {audioRemaining > 0
+          ? `Generate All Audio (${audioRemaining})`
+          : `All Audio Done ✓`}
+      </button>
+
+      {/* Generate All Subtitles */}
+      <button
+        type="button"
+        style={{
+          ...(isDisabled || subtitlesRemaining === 0 ? disabledBtn : btnBase),
+          borderColor: "#bae6fd",
+          color: isDisabled || subtitlesRemaining === 0 ? "#9ca3af" : "#075985",
+        }}
+        disabled={isDisabled || subtitlesRemaining === 0}
+        onClick={onGenerateAllSubtitles}
+        data-testid="bulk-gen-subtitles"
+      >
+        {subtitlesRemaining > 0
+          ? `Generate All Subtitles (${subtitlesRemaining})`
+          : `All Subtitles Done ✓`}
+      </button>
+    </div>
+  );
+}

--- a/apps/studio-web/src/components/creator/PipelineOverviewBar.tsx
+++ b/apps/studio-web/src/components/creator/PipelineOverviewBar.tsx
@@ -1,0 +1,134 @@
+/**
+ * PipelineOverviewBar — compact sticky summary of pipeline progress + Render CTA.
+ *
+ * Shows: total scenes, per-type completion counts, progress bar, Render button.
+ */
+
+import type { StoryboardParagraph } from "../../api/storyboard";
+
+// --------------- props ---------------
+
+export interface PipelineOverviewBarProps {
+  paragraphs: StoryboardParagraph[];
+  totalParagraphs: number;
+  readyParagraphs: number;
+  renderReady: boolean;
+  onRender?: () => void;
+  /** True when render is in progress. */
+  rendering?: boolean;
+}
+
+// --------------- styles ---------------
+
+const barStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 16,
+  padding: "10px 16px",
+  background: "#fff",
+  borderRadius: 8,
+  border: "1px solid #e5e7eb",
+  boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+  position: "sticky",
+  top: 0,
+  zIndex: 10,
+};
+
+const statStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 4,
+  fontSize: 12,
+  color: "#6b7280",
+  whiteSpace: "nowrap",
+};
+
+const statValueStyle: React.CSSProperties = {
+  fontWeight: 700,
+  color: "#111827",
+};
+
+const progressOuter: React.CSSProperties = {
+  flex: 1,
+  height: 6,
+  background: "#e5e7eb",
+  borderRadius: 3,
+  overflow: "hidden",
+  minWidth: 60,
+};
+
+const renderBtnStyle: React.CSSProperties = {
+  padding: "6px 16px",
+  fontSize: 13,
+  fontWeight: 700,
+  border: "none",
+  borderRadius: 6,
+  cursor: "pointer",
+  transition: "all 0.15s",
+  whiteSpace: "nowrap",
+};
+
+// --------------- component ---------------
+
+export default function PipelineOverviewBar({
+  paragraphs,
+  totalParagraphs,
+  readyParagraphs,
+  renderReady,
+  onRender,
+  rendering = false,
+}: PipelineOverviewBarProps) {
+  const imagesDone = paragraphs.filter((p) => p.image_url).length;
+  const audioDone = paragraphs.filter((p) => p.audio_url).length;
+  const subsDone = paragraphs.filter((p) => p.subtitles_url).length;
+  const progress = totalParagraphs > 0 ? (readyParagraphs / totalParagraphs) * 100 : 0;
+
+  return (
+    <div style={barStyle} data-testid="pipeline-overview-bar">
+      {/* Per-type stats */}
+      <div style={statStyle} data-testid="stat-images">
+        🖼️ <span style={statValueStyle}>{imagesDone}</span>/{totalParagraphs}
+      </div>
+      <div style={statStyle} data-testid="stat-audio">
+        🔊 <span style={statValueStyle}>{audioDone}</span>/{totalParagraphs}
+      </div>
+      <div style={statStyle} data-testid="stat-subtitles">
+        💬 <span style={statValueStyle}>{subsDone}</span>/{totalParagraphs}
+      </div>
+
+      {/* Progress bar */}
+      <div style={progressOuter} data-testid="progress-bar">
+        <div
+          style={{
+            height: "100%",
+            width: `${progress}%`,
+            background: renderReady ? "#22c55e" : "#4285f4",
+            borderRadius: 3,
+            transition: "width 0.3s ease",
+          }}
+        />
+      </div>
+
+      {/* Ready count */}
+      <span style={{ fontSize: 12, color: "#6b7280", fontWeight: 600, whiteSpace: "nowrap" }}>
+        {readyParagraphs}/{totalParagraphs} ready
+      </span>
+
+      {/* Render CTA */}
+      <button
+        type="button"
+        style={{
+          ...renderBtnStyle,
+          background: renderReady && !rendering ? "#22c55e" : "#e5e7eb",
+          color: renderReady && !rendering ? "#fff" : "#9ca3af",
+          cursor: renderReady && !rendering ? "pointer" : "not-allowed",
+        }}
+        disabled={!renderReady || rendering}
+        onClick={onRender}
+        data-testid="render-btn"
+      >
+        {rendering ? "Rendering…" : "Render Video"}
+      </button>
+    </div>
+  );
+}

--- a/apps/studio-web/src/components/creator/SceneCard.tsx
+++ b/apps/studio-web/src/components/creator/SceneCard.tsx
@@ -1,0 +1,258 @@
+/**
+ * SceneCard — compact card for a single scene (paragraph) in the storyboard.
+ *
+ * Displays: scene number, status badge, script text (truncated),
+ * and 3 AssetSlots (image, audio, subtitle).
+ * Per-scene generate/regenerate actions available.
+ */
+
+import { useState } from "react";
+
+import AssetSlot from "./AssetSlot";
+import type { AssetStatus } from "./AssetSlot";
+import type { StoryboardParagraph } from "../../api/storyboard";
+
+// --------------- helpers ---------------
+
+/** Convert API artifact path → browser URL via Vite proxy. */
+function artifactUrl(path: string): string {
+  const match = path.match(/data\/artifacts\/(.*)/);
+  return match ? `/artifacts/${match[1]}` : `/artifacts/${path}`;
+}
+
+type SceneStatus = "idle" | "partial" | "generating" | "ready";
+
+function deriveSceneStatus(p: StoryboardParagraph): SceneStatus {
+  if (p.status.startsWith("generating_")) return "generating";
+  const slotCount = [p.image_url, p.audio_url, p.subtitles_url].filter(Boolean).length;
+  if (slotCount === 3) return "ready";
+  if (slotCount > 0) return "partial";
+  return "idle";
+}
+
+function assetStatus(url: string | null, isGenerating: boolean): AssetStatus {
+  if (isGenerating) return "loading";
+  if (url) return "ready";
+  return "empty";
+}
+
+const STATUS_BADGE: Record<SceneStatus, { bg: string; border: string; color: string; label: string }> = {
+  idle: { bg: "#f9fafb", border: "#e5e7eb", color: "#6b7280", label: "Idle" },
+  partial: { bg: "#fffbeb", border: "#fde68a", color: "#92400e", label: "Partial" },
+  generating: { bg: "#eff6ff", border: "#bfdbfe", color: "#1e40af", label: "Generating…" },
+  ready: { bg: "#f0fdf4", border: "#bbf7d0", color: "#166534", label: "Ready" },
+};
+
+// --------------- props ---------------
+
+export interface SceneCardProps {
+  paragraph: StoryboardParagraph;
+  /** Called to generate or regenerate the image for this scene. */
+  onGenerateImage?: (sceneId: string) => void;
+  /** Called to generate or regenerate audio for this scene. */
+  onGenerateAudio?: (sectionId: string) => void;
+  /** Called to generate or regenerate subtitles for this scene. */
+  onGenerateSubtitles?: (sectionId: string) => void;
+  /** Disable all actions (e.g. during bulk generation). */
+  disabled?: boolean;
+}
+
+// --------------- styles ---------------
+
+const cardStyle: React.CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  background: "#fff",
+  overflow: "hidden",
+  display: "flex",
+  flexDirection: "column",
+  transition: "box-shadow 0.15s",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "6px 10px",
+  borderBottom: "1px solid #f3f4f6",
+  background: "#fafafa",
+};
+
+const textStyle: React.CSSProperties = {
+  padding: "6px 10px",
+  fontSize: 12,
+  lineHeight: 1.45,
+  color: "#374151",
+  overflow: "hidden",
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+  cursor: "default",
+};
+
+const expandedTextStyle: React.CSSProperties = {
+  ...textStyle,
+  WebkitLineClamp: undefined as unknown as number,
+  overflow: "visible",
+  display: "block",
+};
+
+const slotsStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
+  padding: "6px 10px 8px",
+};
+
+const actionRowStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 4,
+  padding: "0 10px 8px",
+  flexWrap: "wrap",
+};
+
+const actionBtnStyle: React.CSSProperties = {
+  padding: "3px 8px",
+  fontSize: 10,
+  fontWeight: 500,
+  border: "1px solid #d1d5db",
+  borderRadius: 4,
+  background: "#fff",
+  cursor: "pointer",
+  color: "#374151",
+  transition: "all 0.15s",
+};
+
+// --------------- component ---------------
+
+export default function SceneCard({
+  paragraph,
+  onGenerateImage,
+  onGenerateAudio,
+  onGenerateSubtitles,
+  disabled = false,
+}: SceneCardProps) {
+  const p = paragraph;
+  const sceneStatus = deriveSceneStatus(p);
+  const badge = STATUS_BADGE[sceneStatus];
+  const [expanded, setExpanded] = useState(false);
+
+  const isGeneratingImage = p.status === "generating_image";
+  const isGeneratingAudio = p.status === "generating_audio";
+  const isGeneratingSubs = p.status === "generating_subtitles";
+  const isGenerating = p.status.startsWith("generating_");
+
+  return (
+    <div
+      style={cardStyle}
+      data-testid={`scene-card-${p.section_id}`}
+      data-status={sceneStatus}
+    >
+      {/* Header: scene number + status badge */}
+      <div style={headerStyle}>
+        <span style={{ fontSize: 12, fontWeight: 700, color: "#111827" }}>
+          Scene {p.order + 1}
+        </span>
+        <span
+          data-testid={`scene-badge-${p.section_id}`}
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            padding: "1px 6px",
+            borderRadius: 8,
+            background: badge.bg,
+            border: `1px solid ${badge.border}`,
+            color: badge.color,
+          }}
+        >
+          {badge.label}
+        </span>
+      </div>
+
+      {/* Script text (truncated, click to expand) */}
+      <div
+        style={expanded ? expandedTextStyle : textStyle}
+        onClick={() => setExpanded(!expanded)}
+        title={expanded ? "Click to collapse" : "Click to expand"}
+        data-testid={`scene-text-${p.section_id}`}
+      >
+        {p.display_text ?? p.text}
+      </div>
+
+      {/* Asset slots */}
+      <div style={slotsStyle}>
+        <AssetSlot
+          type="image"
+          status={assetStatus(p.image_url, isGeneratingImage)}
+          url={p.image_url}
+          onRegenerate={
+            p.image_url && onGenerateImage && p.scene_id
+              ? () => onGenerateImage(p.scene_id!)
+              : undefined
+          }
+          disabled={disabled || isGenerating}
+        />
+        <AssetSlot
+          type="audio"
+          status={assetStatus(p.audio_url, isGeneratingAudio)}
+          url={p.audio_url}
+          duration={p.audio_duration}
+          onRegenerate={
+            p.audio_url && onGenerateAudio
+              ? () => onGenerateAudio(p.section_id)
+              : undefined
+          }
+          disabled={disabled || isGenerating}
+        />
+        <AssetSlot
+          type="subtitle"
+          status={assetStatus(p.subtitles_url, isGeneratingSubs)}
+          url={p.subtitles_url}
+          subtitleCount={p.subtitle_entries?.length ?? null}
+          onRegenerate={
+            p.subtitles_url && onGenerateSubtitles
+              ? () => onGenerateSubtitles(p.section_id)
+              : undefined
+          }
+          disabled={disabled || isGenerating}
+        />
+      </div>
+
+      {/* Per-scene action buttons (only when not generating) */}
+      {!isGenerating && !disabled && (
+        <div style={actionRowStyle}>
+          {!p.image_url && p.scene_id && onGenerateImage && (
+            <button
+              type="button"
+              style={{ ...actionBtnStyle, borderColor: "#e9d5ff", color: "#6b21a8" }}
+              onClick={() => onGenerateImage(p.scene_id!)}
+              data-testid={`gen-image-${p.section_id}`}
+            >
+              Gen Image
+            </button>
+          )}
+          {!p.audio_url && p.image_url && onGenerateAudio && (
+            <button
+              type="button"
+              style={{ ...actionBtnStyle, borderColor: "#fde68a", color: "#92400e" }}
+              onClick={() => onGenerateAudio(p.section_id)}
+              data-testid={`gen-audio-${p.section_id}`}
+            >
+              Gen Audio
+            </button>
+          )}
+          {!p.subtitles_url && p.audio_url && onGenerateSubtitles && (
+            <button
+              type="button"
+              style={{ ...actionBtnStyle, borderColor: "#bae6fd", color: "#075985" }}
+              onClick={() => onGenerateSubtitles(p.section_id)}
+              data-testid={`gen-subs-${p.section_id}`}
+            >
+              Gen Subtitles
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/studio-web/src/components/creator/SceneCardGrid.tsx
+++ b/apps/studio-web/src/components/creator/SceneCardGrid.tsx
@@ -1,0 +1,71 @@
+/**
+ * SceneCardGrid — displays ALL scene cards in a responsive grid.
+ *
+ * All scenes visible at once — no pagination, no virtual scroll.
+ * Compact cards fit 5-10+ scenes on a typical 1080p screen.
+ */
+
+import SceneCard from "./SceneCard";
+import type { StoryboardParagraph } from "../../api/storyboard";
+
+// --------------- props ---------------
+
+export interface SceneCardGridProps {
+  paragraphs: StoryboardParagraph[];
+  onGenerateImage?: (sceneId: string) => void;
+  onGenerateAudio?: (sectionId: string) => void;
+  onGenerateSubtitles?: (sectionId: string) => void;
+  /** Disable all per-scene actions. */
+  disabled?: boolean;
+}
+
+// --------------- styles ---------------
+
+const gridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
+  gap: 12,
+};
+
+const emptyStyle: React.CSSProperties = {
+  textAlign: "center",
+  padding: 32,
+  color: "#6b7280",
+  fontSize: 13,
+  background: "#f9fafb",
+  borderRadius: 8,
+  border: "1px dashed #d1d5db",
+};
+
+// --------------- component ---------------
+
+export default function SceneCardGrid({
+  paragraphs,
+  onGenerateImage,
+  onGenerateAudio,
+  onGenerateSubtitles,
+  disabled = false,
+}: SceneCardGridProps) {
+  if (paragraphs.length === 0) {
+    return (
+      <div style={emptyStyle} data-testid="scene-card-grid-empty">
+        No scenes in storyboard. Generate a script and visual plan first.
+      </div>
+    );
+  }
+
+  return (
+    <div style={gridStyle} data-testid="scene-card-grid">
+      {paragraphs.map((p) => (
+        <SceneCard
+          key={p.section_id}
+          paragraph={p}
+          onGenerateImage={onGenerateImage}
+          onGenerateAudio={onGenerateAudio}
+          onGenerateSubtitles={onGenerateSubtitles}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/studio-web/src/components/creator/ScriptComposer.tsx
+++ b/apps/studio-web/src/components/creator/ScriptComposer.tsx
@@ -1,0 +1,289 @@
+/**
+ * ScriptComposer — script editing phase before scene generation.
+ *
+ * Wraps MarkdownScriptEditor / StructuredScriptEditor with a
+ * "Confirm Script" button that triggers visual plan generation
+ * and signals the parent to transition to StoryboardWorkspace.
+ */
+
+import { useState, useCallback } from "react";
+
+import MarkdownScriptEditor from "./MarkdownScriptEditor";
+import StructuredScriptEditor from "./StructuredScriptEditor";
+import ModelSelector from "./ModelSelector";
+
+const API_BASE = "/api/creator";
+
+// --------------- types ---------------
+
+type EditorMode = "markdown" | "structured";
+
+export interface ScriptComposerProps {
+  runId: number;
+  /** Current backend stage. */
+  currentStage: string;
+  /** Source type from the project. */
+  sourceType: "idea" | "markdown" | "url";
+  /** Source context text to display. */
+  sourceContext?: string | null;
+  /** Model selection state for script category. */
+  selectedScriptModel?: string;
+  /** Called when model selection changes. */
+  onModelChange?: (category: string, modelKey: string) => void;
+  /** Called when script is approved and visual plan generation should begin. */
+  onConfirm?: () => void;
+  /** Called when script generation should start. */
+  onGenerate?: () => void;
+  /** Called when script should be regenerated. */
+  onRegenerate?: () => void;
+  /** Status message callback. */
+  onStatusMessage?: (msg: string) => void;
+  /** Whether action buttons should be disabled (e.g. during generation). */
+  disabled?: boolean;
+}
+
+// --------------- styles ---------------
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+};
+
+const sourceBoxStyle: React.CSSProperties = {
+  padding: "10px 14px",
+  background: "#f9fafb",
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  fontSize: 13,
+  lineHeight: 1.5,
+  color: "#374151",
+  whiteSpace: "pre-wrap",
+};
+
+const tabListStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 4,
+  borderBottom: "2px solid #ddd",
+};
+
+const tabStyle = (active: boolean): React.CSSProperties => ({
+  padding: "6px 14px",
+  border: "none",
+  borderBottom: active ? "2px solid #4285f4" : "2px solid transparent",
+  background: "transparent",
+  cursor: "pointer",
+  fontWeight: active ? 600 : 400,
+  color: active ? "#4285f4" : "#666",
+  fontSize: 13,
+});
+
+const actionBarStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 8,
+  padding: "10px 0",
+  alignItems: "center",
+};
+
+const primaryBtnStyle: React.CSSProperties = {
+  padding: "8px 20px",
+  fontSize: 13,
+  fontWeight: 700,
+  border: "none",
+  borderRadius: 6,
+  background: "#4285f4",
+  color: "#fff",
+  cursor: "pointer",
+  transition: "all 0.15s",
+};
+
+const secondaryBtnStyle: React.CSSProperties = {
+  padding: "8px 16px",
+  fontSize: 13,
+  fontWeight: 600,
+  border: "1px solid #d1d5db",
+  borderRadius: 6,
+  background: "#fff",
+  color: "#374151",
+  cursor: "pointer",
+  transition: "all 0.15s",
+};
+
+// --------------- component ---------------
+
+export default function ScriptComposer({
+  runId,
+  currentStage,
+  sourceType,
+  sourceContext,
+  selectedScriptModel,
+  onModelChange,
+  onConfirm,
+  onGenerate,
+  onRegenerate,
+  onStatusMessage,
+  disabled = false,
+}: ScriptComposerProps) {
+  const [editorMode, setEditorMode] = useState<EditorMode>("markdown");
+
+  const isIdeaReady = currentStage === "IDEA_READY";
+  const isGenerating = currentStage === "SCRIPT_GENERATING";
+  const isReview = currentStage === "SCRIPT_REVIEW";
+  const isEditable = isReview;
+  const showGenerateBtn = isIdeaReady;
+  const showApproveBtn = isReview;
+  const showRegenerateBtn = isReview;
+
+  return (
+    <div style={containerStyle} data-testid="script-composer">
+      {/* Generating indicator */}
+      {isGenerating && (
+        <div
+          data-testid="script-generating-indicator"
+          style={{
+            padding: "10px 14px",
+            background: "#eff6ff",
+            borderRadius: 8,
+            border: "1px solid #bfdbfe",
+            color: "#1e40af",
+            fontSize: 13,
+          }}
+        >
+          Generating script… Draft will update automatically.
+        </div>
+      )}
+
+      {/* Source context */}
+      {sourceContext && (
+        <div>
+          <div style={{ fontSize: 12, fontWeight: 600, color: "#6b7280", marginBottom: 4 }}>
+            Source ({sourceType})
+          </div>
+          <div style={sourceBoxStyle}>{sourceContext}</div>
+        </div>
+      )}
+
+      {/* Model selector for script */}
+      {(isIdeaReady || isReview) && onModelChange && (
+        <ModelSelector
+          categories={["script"]}
+          selectedModels={selectedScriptModel ? { script: selectedScriptModel } : undefined}
+          apiBase=""
+          onSelectionChange={onModelChange}
+        />
+      )}
+
+      {/* Editor mode tabs */}
+      <div role="tablist" style={tabListStyle}>
+        <button
+          type="button"
+          role="tab"
+          id="tab-md"
+          aria-selected={editorMode === "markdown"}
+          aria-controls="panel-md"
+          onClick={() => setEditorMode("markdown")}
+          style={tabStyle(editorMode === "markdown")}
+        >
+          Markdown
+        </button>
+        <button
+          type="button"
+          role="tab"
+          id="tab-struct"
+          aria-selected={editorMode === "structured"}
+          aria-controls="panel-struct"
+          onClick={() => setEditorMode("structured")}
+          style={tabStyle(editorMode === "structured")}
+        >
+          Structured
+        </button>
+      </div>
+
+      {/* Editor panels */}
+      {editorMode === "markdown" && (
+        <div role="tabpanel" id="panel-md" aria-labelledby="tab-md">
+          <MarkdownScriptEditor
+            runId={runId}
+            readOnly={!isEditable}
+            pollIntervalMs={isIdeaReady || isGenerating ? 3000 : undefined}
+            suppressMissingDraftError={isIdeaReady || isGenerating}
+            pendingMessage={
+              isIdeaReady
+                ? "No script yet. Click Generate Script to start."
+                : "Waiting for generated script…"
+            }
+            onSuccess={() => onStatusMessage?.("Script saved")}
+            onError={(_action, msg) => onStatusMessage?.(msg)}
+          />
+        </div>
+      )}
+      {editorMode === "structured" && (
+        <div role="tabpanel" id="panel-struct" aria-labelledby="tab-struct">
+          <StructuredScriptEditor
+            runId={runId}
+            readOnly={!isEditable}
+            pollIntervalMs={isIdeaReady || isGenerating ? 3000 : undefined}
+            suppressMissingDraftError={isIdeaReady || isGenerating}
+            pendingMessage={
+              isIdeaReady
+                ? "No structured sections yet. Generate a script first."
+                : "Waiting for generated sections…"
+            }
+            onSuccess={() => onStatusMessage?.("Script saved")}
+            onError={(_action, msg) => onStatusMessage?.(msg)}
+          />
+        </div>
+      )}
+
+      {/* Action buttons */}
+      <div style={actionBarStyle} data-testid="script-actions">
+        {showGenerateBtn && (
+          <button
+            type="button"
+            style={{
+              ...primaryBtnStyle,
+              opacity: disabled ? 0.5 : 1,
+              cursor: disabled ? "not-allowed" : "pointer",
+            }}
+            onClick={onGenerate}
+            disabled={disabled}
+            data-testid="btn-generate-script"
+          >
+            Generate Script
+          </button>
+        )}
+        {showApproveBtn && (
+          <button
+            type="button"
+            style={{
+              ...primaryBtnStyle,
+              background: "#22c55e",
+              opacity: disabled ? 0.5 : 1,
+              cursor: disabled ? "not-allowed" : "pointer",
+            }}
+            onClick={onConfirm}
+            disabled={disabled}
+            data-testid="btn-confirm-script"
+          >
+            Confirm & Generate Visual Plan
+          </button>
+        )}
+        {showRegenerateBtn && (
+          <button
+            type="button"
+            style={{
+              ...secondaryBtnStyle,
+              opacity: disabled ? 0.5 : 1,
+              cursor: disabled ? "not-allowed" : "pointer",
+            }}
+            onClick={onRegenerate}
+            disabled={disabled}
+            data-testid="btn-regenerate-script"
+          >
+            Regenerate
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/studio-web/src/components/creator/StoryboardWorkspace.tsx
+++ b/apps/studio-web/src/components/creator/StoryboardWorkspace.tsx
@@ -1,0 +1,357 @@
+/**
+ * StoryboardWorkspace — composes PipelineOverviewBar + BulkActionBar + SceneCardGrid.
+ *
+ * Fetches storyboard data, handles polling during generation,
+ * and wires up per-scene and bulk API calls.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+import PipelineOverviewBar from "./PipelineOverviewBar";
+import BulkActionBar from "./BulkActionBar";
+import SceneCardGrid from "./SceneCardGrid";
+import type {
+  StoryboardResponse,
+  ParagraphAudioParams,
+  ParagraphSubtitlesParams,
+} from "../../api/storyboard";
+import {
+  fetchStoryboard,
+  generateParagraphAudio,
+  generateParagraphSubtitles,
+  generateAllParagraphAudio,
+  generateAllParagraphSubtitles,
+} from "../../api/storyboard";
+
+const API_BASE = "/api/creator";
+
+// --------------- props ---------------
+
+export interface StoryboardWorkspaceProps {
+  runId: number;
+  /** TTS model key from parent model selection. */
+  ttsModel?: string;
+  /** STT model key from parent model selection. */
+  subtitleModel?: string;
+  /** Image model key from parent model selection. */
+  imageModel?: string;
+  /** Polling interval in ms (default 4000). */
+  pollInterval?: number;
+  /** Status message callback. */
+  onStatusMessage?: (msg: string) => void;
+  /** Called when render should be triggered. */
+  onRender?: () => void;
+  /** True when render is in progress. */
+  rendering?: boolean;
+}
+
+// --------------- styles ---------------
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+};
+
+const skeletonStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
+  gap: 12,
+};
+
+const skeletonCardStyle: React.CSSProperties = {
+  height: 160,
+  borderRadius: 8,
+  background: "linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%)",
+  backgroundSize: "200% 100%",
+  animation: "assetSlotShimmer 1.5s ease-in-out infinite",
+};
+
+// --------------- component ---------------
+
+export default function StoryboardWorkspace({
+  runId,
+  ttsModel,
+  subtitleModel,
+  imageModel,
+  pollInterval = 4000,
+  onStatusMessage,
+  onRender,
+  rendering = false,
+}: StoryboardWorkspaceProps) {
+  const [storyboard, setStoryboard] = useState<StoryboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [bulkGenerating, setBulkGenerating] = useState(false);
+
+  const hasGenerating = storyboard?.paragraphs.some(
+    (p) => p.status.startsWith("generating_"),
+  ) ?? false;
+
+  // ---- fetch ----
+
+  const loadStoryboard = useCallback(async () => {
+    try {
+      const data = await fetchStoryboard(runId);
+      setStoryboard(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load storyboard");
+    } finally {
+      setLoading(false);
+    }
+  }, [runId]);
+
+  useEffect(() => {
+    loadStoryboard();
+  }, [loadStoryboard]);
+
+  // ---- polling ----
+
+  useEffect(() => {
+    if (!hasGenerating && !bulkGenerating) return;
+    const timer = setInterval(loadStoryboard, pollInterval);
+    return () => clearInterval(timer);
+  }, [hasGenerating, bulkGenerating, pollInterval, loadStoryboard]);
+
+  // ---- per-scene handlers ----
+
+  const handleGenerateImage = useCallback(
+    async (sceneId: string) => {
+      try {
+        await fetch(
+          `${API_BASE}/runs/${runId}/visual-plan/scenes/${sceneId}/generate-image`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ model_key: imageModel || "sd15" }),
+          },
+        );
+        onStatusMessage?.(`Image generation started for scene ${sceneId}`);
+        setStoryboard((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            paragraphs: prev.paragraphs.map((p) =>
+              p.scene_id === sceneId
+                ? { ...p, status: "generating_image" as const }
+                : p,
+            ),
+          };
+        });
+      } catch (err) {
+        onStatusMessage?.(err instanceof Error ? err.message : "Image generation failed");
+      }
+    },
+    [runId, imageModel, onStatusMessage],
+  );
+
+  const handleGenerateAudio = useCallback(
+    async (sectionId: string, params: ParagraphAudioParams = {}) => {
+      try {
+        await generateParagraphAudio(runId, sectionId, {
+          ...params,
+          tts_model: params.tts_model || ttsModel,
+        });
+        onStatusMessage?.(`Audio generation started for §${sectionId}`);
+        setStoryboard((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            paragraphs: prev.paragraphs.map((p) =>
+              p.section_id === sectionId
+                ? { ...p, status: "generating_audio" as const }
+                : p,
+            ),
+          };
+        });
+      } catch (err) {
+        onStatusMessage?.(err instanceof Error ? err.message : "Audio generation failed");
+      }
+    },
+    [runId, ttsModel, onStatusMessage],
+  );
+
+  const handleGenerateSubtitles = useCallback(
+    async (sectionId: string, params: ParagraphSubtitlesParams = {}) => {
+      try {
+        await generateParagraphSubtitles(runId, sectionId, {
+          ...params,
+          subtitle_model: params.subtitle_model || subtitleModel,
+        });
+        onStatusMessage?.(`Subtitle generation started for §${sectionId}`);
+        setStoryboard((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            paragraphs: prev.paragraphs.map((p) =>
+              p.section_id === sectionId
+                ? { ...p, status: "generating_subtitles" as const }
+                : p,
+            ),
+          };
+        });
+      } catch (err) {
+        onStatusMessage?.(err instanceof Error ? err.message : "Subtitle generation failed");
+      }
+    },
+    [runId, subtitleModel, onStatusMessage],
+  );
+
+  // ---- bulk handlers ----
+
+  const handleBulkImages = useCallback(async () => {
+    setBulkGenerating(true);
+    try {
+      const res = await fetch(`${API_BASE}/runs/${runId}/generate-visual-assets`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model_key: imageModel || "sd15" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail ?? `Bulk image generation failed (${res.status})`);
+      }
+      onStatusMessage?.("Bulk image generation started");
+      setStoryboard((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          paragraphs: prev.paragraphs.map((p) =>
+            !p.image_url ? { ...p, status: "generating_image" as const } : p,
+          ),
+        };
+      });
+    } catch (err) {
+      onStatusMessage?.(err instanceof Error ? err.message : "Bulk image generation failed");
+    } finally {
+      setBulkGenerating(false);
+    }
+  }, [runId, imageModel, onStatusMessage]);
+
+  const handleBulkAudio = useCallback(async () => {
+    setBulkGenerating(true);
+    try {
+      const result = await generateAllParagraphAudio(runId, { tts_model: ttsModel });
+      onStatusMessage?.(`Audio generation started for ${result.dispatched} paragraphs`);
+      setStoryboard((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          paragraphs: prev.paragraphs.map((p) =>
+            !p.audio_url ? { ...p, status: "generating_audio" as const } : p,
+          ),
+        };
+      });
+    } catch (err) {
+      onStatusMessage?.(err instanceof Error ? err.message : "Bulk audio generation failed");
+    } finally {
+      setBulkGenerating(false);
+    }
+  }, [runId, ttsModel, onStatusMessage]);
+
+  const handleBulkSubtitles = useCallback(async () => {
+    setBulkGenerating(true);
+    try {
+      const result = await generateAllParagraphSubtitles(runId, { subtitle_model: subtitleModel });
+      onStatusMessage?.(`Subtitle generation started for ${result.dispatched} paragraphs`);
+      setStoryboard((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          paragraphs: prev.paragraphs.map((p) =>
+            p.audio_url && !p.subtitles_url
+              ? { ...p, status: "generating_subtitles" as const }
+              : p,
+          ),
+        };
+      });
+    } catch (err) {
+      onStatusMessage?.(err instanceof Error ? err.message : "Bulk subtitle generation failed");
+    } finally {
+      setBulkGenerating(false);
+    }
+  }, [runId, subtitleModel, onStatusMessage]);
+
+  // ---- render ----
+
+  if (loading) {
+    return (
+      <div style={containerStyle} data-testid="storyboard-workspace-loading">
+        <div style={skeletonStyle}>
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i} style={skeletonCardStyle} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        role="alert"
+        data-testid="storyboard-workspace-error"
+        style={{
+          padding: "12px 16px",
+          background: "#fef2f2",
+          border: "1px solid #fca5a5",
+          borderRadius: 6,
+          color: "#b91c1c",
+          fontSize: 13,
+        }}
+      >
+        {error}
+        <button
+          type="button"
+          onClick={loadStoryboard}
+          style={{
+            marginLeft: 12,
+            padding: "2px 10px",
+            fontSize: 12,
+            border: "1px solid #fca5a5",
+            borderRadius: 4,
+            background: "#fff",
+            cursor: "pointer",
+            color: "#b91c1c",
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!storyboard) return null;
+
+  const paragraphs = storyboard.paragraphs;
+
+  return (
+    <div style={containerStyle} data-testid="storyboard-workspace">
+      <PipelineOverviewBar
+        paragraphs={paragraphs}
+        totalParagraphs={storyboard.total_paragraphs}
+        readyParagraphs={storyboard.ready_paragraphs}
+        renderReady={storyboard.render_ready}
+        onRender={onRender}
+        rendering={rendering}
+      />
+
+      <BulkActionBar
+        paragraphs={paragraphs}
+        generating={bulkGenerating}
+        onGenerateAllImages={handleBulkImages}
+        onGenerateAllAudio={handleBulkAudio}
+        onGenerateAllSubtitles={handleBulkSubtitles}
+      />
+
+      <SceneCardGrid
+        paragraphs={paragraphs}
+        onGenerateImage={handleGenerateImage}
+        onGenerateAudio={(sectionId) => handleGenerateAudio(sectionId)}
+        onGenerateSubtitles={(sectionId) => handleGenerateSubtitles(sectionId)}
+        disabled={bulkGenerating}
+      />
+    </div>
+  );
+}

--- a/apps/studio-web/src/pages/ProjectPage.tsx
+++ b/apps/studio-web/src/pages/ProjectPage.tsx
@@ -3,27 +3,21 @@
  *
  * Loads the project detail and its latest run, then renders:
  * - PipelineStepper (header progress bar)
- * - Editor area with markdown / structured toggle (during script stages)
- * - VisualPlanEditor (during visual plan stages)
- * - VisualAssetGrid (during visual asset stages)
- * - Audio / subtitle / render generating indicators (automatic stages)
+ * - ScriptComposer (during script stages: IDEA_READY, SCRIPT_GENERATING, SCRIPT_REVIEW)
+ * - VisualPlanEditor section (during visual plan stages)
+ * - StoryboardWorkspace (post visual-plan: scene-centric card grid)
  * - Final review section with preview summary and review-page link
- * - StageActionBar (save / approve / generate / restart)
+ * - ConfirmDialog for stop / resume / delete
  */
 
 import { useState, useEffect, useCallback } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 
 import PipelineStepper from "../components/creator/PipelineStepper";
-import StageActionBar, {
-  type ActionConfig,
-} from "../components/creator/StageActionBar";
-import MarkdownScriptEditor from "../components/creator/MarkdownScriptEditor";
-import StructuredScriptEditor from "../components/creator/StructuredScriptEditor";
+import ScriptComposer from "../components/creator/ScriptComposer";
+import StoryboardWorkspace from "../components/creator/StoryboardWorkspace";
 import VisualPlanEditor from "../components/creator/VisualPlanEditor";
-import VisualAssetGrid from "../components/creator/VisualAssetGrid";
 import ModelSelector from "../components/creator/ModelSelector";
-import StoryboardView from "../components/creator/StoryboardView";
 import ConfirmDialog from "../components/creator/ConfirmDialog";
 
 const API_BASE = "/api/creator";
@@ -64,14 +58,21 @@ interface RunDetail {
 
 type EditorMode = "markdown" | "structured";
 
-// Script stages where the editor area is relevant
+// Script stages where ScriptComposer is shown
 const SCRIPT_STAGES = new Set(["SCRIPT_GENERATING", "SCRIPT_REVIEW"]);
 
 // Visual plan stages where the editor area is relevant
-const VISUAL_PLAN_STAGES = new Set(["VISUAL_PLAN_SETUP", "VISUAL_PLAN_GENERATING", "VISUAL_PLAN_REVIEW"]);
+const VISUAL_PLAN_STAGES = new Set([
+  "VISUAL_PLAN_SETUP",
+  "VISUAL_PLAN_GENERATING",
+  "VISUAL_PLAN_REVIEW",
+]);
 
 // Visual asset stages
-const VISUAL_ASSET_STAGES = new Set(["VISUAL_ASSET_GENERATING", "VISUAL_ASSET_REVIEW"]);
+const VISUAL_ASSET_STAGES = new Set([
+  "VISUAL_ASSET_GENERATING",
+  "VISUAL_ASSET_REVIEW",
+]);
 
 // Audio stage
 const AUDIO_STAGES = new Set(["AUDIO_GENERATING"]);
@@ -85,8 +86,18 @@ const RENDER_STAGES = new Set(["RENDER_GENERATING"]);
 // Final review
 const FINAL_REVIEW_STAGES = new Set(["FINAL_REVIEW"]);
 
-// Storyboard stages — show unified storyboard view instead of separate indicators
-const STORYBOARD_STAGES = new Set(["AUDIO_GENERATING", "SUBTITLE_GENERATING", "RENDER_GENERATING", "FINAL_REVIEW"]);
+// All stages handled by StoryboardWorkspace (scene-centric view)
+const STORYBOARD_WORKSPACE_STAGES = new Set([
+  "VISUAL_ASSET_GENERATING",
+  "VISUAL_ASSET_REVIEW",
+  "AUDIO_GENERATING",
+  "SUBTITLE_GENERATING",
+  "RENDER_GENERATING",
+  "FINAL_REVIEW",
+  "PUBLISHED",
+]);
+
+// Stages where we poll run status
 const RUN_POLL_STAGES = new Set([
   "SCRIPT_GENERATING",
   "VISUAL_PLAN_GENERATING",
@@ -113,15 +124,42 @@ const SD_QUALITY_PRESETS: Record<
   string,
   { steps: number; cfg_scale: number; sampler_name: string; label: string; description: string }
 > = {
-  fast: { steps: 15, cfg_scale: 5, sampler_name: "Euler a", label: "⚡ Fast Preview", description: "Quick preview, lower quality (15 steps)" },
-  balanced: { steps: 25, cfg_scale: 7, sampler_name: "DPM++ 2M Karras", label: "⚖️ Balanced", description: "Good quality/speed balance (25 steps)" },
-  high: { steps: 40, cfg_scale: 8, sampler_name: "DPM++ 2M Karras", label: "✨ High Quality", description: "Best quality, slower (40 steps)" },
+  fast: {
+    steps: 15,
+    cfg_scale: 5,
+    sampler_name: "Euler a",
+    label: "\u26a1 Fast Preview",
+    description: "Quick preview, lower quality (15 steps)",
+  },
+  balanced: {
+    steps: 25,
+    cfg_scale: 7,
+    sampler_name: "DPM++ 2M Karras",
+    label: "\u2696\ufe0f Balanced",
+    description: "Good quality/speed balance (25 steps)",
+  },
+  high: {
+    steps: 40,
+    cfg_scale: 8,
+    sampler_name: "DPM++ 2M Karras",
+    label: "\u2728 High Quality",
+    description: "Best quality, slower (40 steps)",
+  },
 };
 
 const SD_SAMPLERS = [
-  "DPM++ 2M Karras", "DPM++ SDE Karras", "DPM++ 2M SDE Karras",
-  "DPM++ 2M", "DPM++ SDE", "DPM++ 2S a Karras",
-  "Euler a", "Euler", "DDIM", "UniPC", "LMS Karras", "Heun",
+  "DPM++ 2M Karras",
+  "DPM++ SDE Karras",
+  "DPM++ 2M SDE Karras",
+  "DPM++ 2M",
+  "DPM++ SDE",
+  "DPM++ 2S a Karras",
+  "Euler a",
+  "Euler",
+  "DDIM",
+  "UniPC",
+  "LMS Karras",
+  "Heun",
 ];
 
 const RENDER_PROFILE_OPTIONS = [
@@ -129,6 +167,7 @@ const RENDER_PROFILE_OPTIONS = [
   { value: "high_quality", label: "High Quality" },
   { value: "fast_preview", label: "Fast Preview" },
 ];
+
 // --------------- Visual Plan Setup Cards ---------------
 
 interface ScriptSection {
@@ -221,18 +260,29 @@ function VisualPlanSetupCards({ runId }: { runId: number }) {
               flexDirection: "column",
               alignItems: "center",
               justifyContent: "center",
-              background: sec.type === "narration" ? "#eff6ff" : sec.type === "dialogue" ? "#fdf4ff" : "#f0fdf4",
+              background:
+                sec.type === "narration"
+                  ? "#eff6ff"
+                  : sec.type === "dialogue"
+                    ? "#fdf4ff"
+                    : "#f0fdf4",
               borderRight: "1px solid #e5e7eb",
               padding: "12px 0",
               flexShrink: 0,
             }}
           >
-            <span style={{ fontSize: 11, color: "#6b7280", fontWeight: 500 }}>\u00a7{idx + 1}</span>
+            <span style={{ fontSize: 11, color: "#6b7280", fontWeight: 500 }}>
+              \u00a7{idx + 1}
+            </span>
             <span
               style={{
                 fontSize: 10,
                 color:
-                  sec.type === "narration" ? "#2563eb" : sec.type === "dialogue" ? "#7c3aed" : "#16a34a",
+                  sec.type === "narration"
+                    ? "#2563eb"
+                    : sec.type === "dialogue"
+                      ? "#7c3aed"
+                      : "#16a34a",
                 fontWeight: 600,
                 marginTop: 2,
                 textTransform: "uppercase",
@@ -257,7 +307,14 @@ function VisualPlanSetupCards({ runId }: { runId: number }) {
               {sec.display_text || sec.text}
             </p>
             {sec.speaker && (
-              <span style={{ fontSize: 11, color: "#9ca3af", marginTop: 4, display: "inline-block" }}>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: "#9ca3af",
+                  marginTop: 4,
+                  display: "inline-block",
+                }}
+              >
                 Speaker: {sec.speaker}
               </span>
             )}
@@ -277,14 +334,20 @@ function VisualPlanSetupCards({ runId }: { runId: number }) {
               flexShrink: 0,
             }}
           >
-            <span style={{ fontSize: 20 }}>\ud83d\uddbc\ufe0f</span>
-            <span style={{ fontSize: 10, color: "#6b21a8", fontWeight: 600, marginTop: 4 }}>1 Image</span>
+            <span style={{ fontSize: 20 }}>{"\ud83d\uddbc\ufe0f"}</span>
+            <span
+              style={{ fontSize: 10, color: "#6b21a8", fontWeight: 600, marginTop: 4 }}
+            >
+              1 Image
+            </span>
           </div>
         </div>
       ))}
     </div>
   );
 }
+
+// --------------- Main Component ---------------
 
 export default function ProjectPage() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -297,9 +360,6 @@ export default function ProjectPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Editor mode
-  const [editorMode, setEditorMode] = useState<EditorMode>("markdown");
-
   // Action loading states
   const [approving, setApproving] = useState(false);
   const [generating, setGenerating] = useState(false);
@@ -309,33 +369,19 @@ export default function ProjectPage() {
   const [stopping, setStopping] = useState(false);
   const [resuming, setResuming] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [confirmAction, setConfirmAction] = useState<"stop" | "resume" | "delete" | null>(null);
+  const [confirmAction, setConfirmAction] = useState<
+    "stop" | "resume" | "delete" | null
+  >(null);
 
   // Status toast
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
-  // Scene regeneration model override
-  const [regenModelKey, setRegenModelKey] = useState<string | null>(null);
-
-  // SD image tuning parameters
-  const [imageParams, setImageParams] = useState({
-    steps: 25,
-    sampler_name: "DPM++ 2M Karras",
-    negative_prompt:
-      "low quality, worst quality, blurry, out of focus, ugly, deformed, disfigured, watermark, text, signature, poorly drawn, bad anatomy, extra limbs",
-    cfg_scale: 7,
-  });
-  const [activePreset, setActivePreset] = useState<string>("balanced");
-  const [tuningOpen, setTuningOpen] = useState(true);
-  // Asset grid refresh key — increment to force re-fetch
-  const [assetRefreshKey, setAssetRefreshKey] = useState(0);
-
-  // Preview data for FINAL_REVIEW
-  const [preview, setPreview] = useState<Record<string, unknown> | null>(null);
-
   // Per-stage model selection (persisted to backend via model_defaults)
   const [modelSelection, setModelSelection] = useState<ModelDefaults>({});
   const [goingBack, setGoingBack] = useState(false);
+
+  // Preview data for FINAL_REVIEW
+  const [preview, setPreview] = useState<Record<string, unknown> | null>(null);
 
   // ---- data fetching ----
 
@@ -348,21 +394,28 @@ export default function ProjectPage() {
       if (!projRes.ok) {
         if (projRes.status === 404) throw new Error("Project not found");
         const body = await projRes.json().catch(() => null);
-        throw new Error(body?.detail ?? `Failed to load project (${projRes.status})`);
+        throw new Error(
+          body?.detail ?? `Failed to load project (${projRes.status})`,
+        );
       }
       const projData: ProjectDetail = await projRes.json();
       setProject(projData);
 
       // 2. Fetch runs for this project (newest first), take the latest
-      const runsRes = await fetch(`${API_BASE}/projects/${numericProjectId}/runs`);
+      const runsRes = await fetch(
+        `${API_BASE}/projects/${numericProjectId}/runs`,
+      );
       if (runsRes.ok) {
-        const runsData: { runs: RunDetail[]; total: number } = await runsRes.json();
+        const runsData: { runs: RunDetail[]; total: number } =
+          await runsRes.json();
         setRun(runsData.runs.length > 0 ? runsData.runs[0] : null);
       } else {
         setRun(null);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "An unexpected error occurred");
+      setError(
+        err instanceof Error ? err.message : "An unexpected error occurred",
+      );
     } finally {
       setLoading(false);
     }
@@ -410,9 +463,6 @@ export default function ProjectPage() {
     if (!run || !RUN_POLL_STAGES.has(run.current_stage)) return;
     const timer = setInterval(() => {
       void refreshRun(run.id);
-      if (run.current_stage === "VISUAL_ASSET_GENERATING") {
-        setAssetRefreshKey((k) => k + 1);
-      }
     }, 3000);
     return () => clearInterval(timer);
   }, [run, refreshRun]);
@@ -421,7 +471,6 @@ export default function ProjectPage() {
   useEffect(() => {
     if (run?.model_defaults) {
       setModelSelection((prev) => {
-        // Only set if we don't have local selections yet
         const hasLocal = Object.keys(prev).length > 0;
         if (hasLocal) return prev;
         return { ...run.model_defaults } as ModelDefaults;
@@ -430,8 +479,6 @@ export default function ProjectPage() {
   }, [run?.model_defaults]);
 
   // Build a selectedModels map scoped to specific categories.
-  // Returns undefined when none of the requested categories have persisted values,
-  // so ModelSelector stays uncontrolled and can compute its own defaults.
   const buildSelectedModels = useCallback(
     (categories: string[]): Record<string, string> | undefined => {
       const FIELD_TO_CAT: Record<string, string> = {
@@ -443,7 +490,10 @@ export default function ProjectPage() {
       const catSet = new Set(categories);
       const map: Record<string, string> = {};
       for (const [field, cat] of Object.entries(FIELD_TO_CAT)) {
-        if (catSet.has(cat) && modelSelection[field as keyof ModelDefaults]) {
+        if (
+          catSet.has(cat) &&
+          modelSelection[field as keyof ModelDefaults]
+        ) {
           map[cat] = modelSelection[field as keyof ModelDefaults]!;
         }
       }
@@ -455,7 +505,6 @@ export default function ProjectPage() {
   // Persist model selection to backend
   const handleModelChange = useCallback(
     (category: string, modelKey: string) => {
-      // Map ModelSelector category → ModelDefaults field
       const fieldMap: Record<string, keyof ModelDefaults> = {
         script: "script_model",
         image: "image_model",
@@ -466,13 +515,14 @@ export default function ProjectPage() {
       const field = fieldMap[category];
       if (!field) return;
       setModelSelection((prev) => ({ ...prev, [field]: modelKey }));
-      // Fire-and-forget persist to backend
       if (run) {
         fetch(`${API_BASE}/runs/${run.id}/model-defaults`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ [field]: modelKey }),
-        }).catch(() => { /* non-critical */ });
+        }).catch(() => {
+          /* non-critical */
+        });
       }
     },
     [run],
@@ -534,7 +584,9 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/generate-script`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model_key: modelSelection.script_model || "qwen3-4b" }),
+        body: JSON.stringify({
+          model_key: modelSelection.script_model || "qwen3-4b",
+        }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -543,7 +595,9 @@ export default function ProjectPage() {
       setStatusMessage("Script generation started");
       setTimeout(() => refreshRun(run.id), 2000);
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Generate failed");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Generate failed",
+      );
     } finally {
       setGenerating(false);
     }
@@ -563,10 +617,12 @@ export default function ProjectPage() {
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `Restart failed (${res.status})`);
       }
-      setStatusMessage("Restarting script generation…");
+      setStatusMessage("Restarting script generation\u2026");
       await refreshRun(run.id);
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Restart failed");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Restart failed",
+      );
     } finally {
       setRestarting(false);
     }
@@ -579,11 +635,14 @@ export default function ProjectPage() {
     setApproving(true);
     setStatusMessage(null);
     try {
-      const res = await fetch(`${API_BASE}/runs/${run.id}/approve-visual-plan`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ reviewer: "agent" }),
-      });
+      const res = await fetch(
+        `${API_BASE}/runs/${run.id}/approve-visual-plan`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reviewer: "agent" }),
+        },
+      );
       if (!res.ok) {
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `Approve failed (${res.status})`);
@@ -602,11 +661,16 @@ export default function ProjectPage() {
     setGenerating(true);
     setStatusMessage(null);
     try {
-      const res = await fetch(`${API_BASE}/runs/${run.id}/generate-visual-plan`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model_key: modelSelection.script_model || "qwen3-4b" }),
-      });
+      const res = await fetch(
+        `${API_BASE}/runs/${run.id}/generate-visual-plan`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model_key: modelSelection.script_model || "qwen3-4b",
+          }),
+        },
+      );
       if (!res.ok) {
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `Generate failed (${res.status})`);
@@ -614,7 +678,9 @@ export default function ProjectPage() {
       setStatusMessage("Visual plan generation started");
       setTimeout(() => refreshRun(run.id), 2000);
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Generate failed");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Generate failed",
+      );
     } finally {
       setGenerating(false);
     }
@@ -634,112 +700,64 @@ export default function ProjectPage() {
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `Restart failed (${res.status})`);
       }
-      setStatusMessage("Restarting visual plan generation…");
+      setStatusMessage("Restarting visual plan generation\u2026");
       await refreshRun(run.id);
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Restart failed");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Restart failed",
+      );
     } finally {
       setRestarting(false);
     }
   }, [run, refreshRun]);
 
-  // ---- visual asset actions ----
+  // ---- visual asset actions (kept for StoryboardWorkspace internal use) ----
 
   const handleGenerateAllAssets = useCallback(async () => {
     if (!run) return;
     setGenerating(true);
     setStatusMessage(null);
     try {
-      const res = await fetch(`${API_BASE}/runs/${run.id}/generate-visual-assets`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model_key: modelSelection.image_model || "sd15", image_params: imageParams }),
-      });
+      const res = await fetch(
+        `${API_BASE}/runs/${run.id}/generate-visual-assets`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model_key: modelSelection.image_model || "sd15",
+          }),
+        },
+      );
       if (!res.ok) {
         const body = await res.json().catch(() => null);
-        throw new Error(body?.detail ?? `Generate assets failed (${res.status})`);
+        throw new Error(
+          body?.detail ?? `Generate assets failed (${res.status})`,
+        );
       }
       setStatusMessage("Visual asset generation started");
       await refreshRun(run.id);
-      setAssetRefreshKey((k) => k + 1);
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Generate assets failed");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Generate assets failed",
+      );
     } finally {
       setGenerating(false);
     }
-  }, [run, imageParams, modelSelection.image_model]);
-
-  const handleRegenerateScene = useCallback(
-    async (sceneId: string) => {
-      if (!run) return;
-      setStatusMessage(null);
-      try {
-        const payload: Record<string, unknown> = { image_params: imageParams };
-        if (regenModelKey) payload.model_key = regenModelKey;
-        const res = await fetch(
-          `${API_BASE}/runs/${run.id}/visual-plan/scenes/${sceneId}/regenerate-image`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(payload),
-          },
-        );
-        if (!res.ok) {
-          const body = await res.json().catch(() => null);
-          throw new Error(body?.detail ?? `Regenerate failed (${res.status})`);
-        }
-        setStatusMessage(`Regenerating scene ${sceneId}…`);
-        // Refresh asset grid after a short delay for task to complete
-        setTimeout(() => {
-          setAssetRefreshKey((k) => k + 1);
-          if (run) refreshRun(run.id);
-        }, 3000);
-      } catch (err) {
-        setStatusMessage(err instanceof Error ? err.message : "Regenerate failed");
-      }
-    },
-    [run, regenModelKey, imageParams, refreshRun],
-  );
-
-  const handleGenerateScene = useCallback(
-    async (sceneId: string) => {
-      if (!run) return;
-      setStatusMessage(null);
-      try {
-        const res = await fetch(
-          `${API_BASE}/runs/${run.id}/visual-plan/scenes/${sceneId}/generate-image`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ model_key: modelSelection.image_model || "sd15", image_params: imageParams }),
-          },
-        );
-        if (!res.ok) {
-          const body = await res.json().catch(() => null);
-          throw new Error(body?.detail ?? `Generate scene failed (${res.status})`);
-        }
-        setStatusMessage(`Generating image for scene ${sceneId}…`);
-        setTimeout(() => {
-          setAssetRefreshKey((k) => k + 1);
-          if (run) refreshRun(run.id);
-        }, 3000);
-      } catch (err) {
-        setStatusMessage(err instanceof Error ? err.message : "Generate scene failed");
-      }
-    },
-    [run, imageParams, refreshRun, modelSelection.image_model],
-  );
+  }, [run, modelSelection.image_model]);
 
   const handleApproveAssets = useCallback(async () => {
     if (!run) return;
     setApproving(true);
     setStatusMessage(null);
     try {
-      const res = await fetch(`${API_BASE}/runs/${run.id}/approve-visual-assets`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ reviewer: "agent" }),
-      });
+      const res = await fetch(
+        `${API_BASE}/runs/${run.id}/approve-visual-assets`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reviewer: "agent" }),
+        },
+      );
       if (!res.ok) {
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `Approve failed (${res.status})`);
@@ -747,7 +765,9 @@ export default function ProjectPage() {
       setStatusMessage("Visual assets approved");
       await refreshRun(run.id);
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Approve assets failed");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Approve assets failed",
+      );
     } finally {
       setApproving(false);
     }
@@ -767,10 +787,12 @@ export default function ProjectPage() {
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `Restart failed (${res.status})`);
       }
-      setStatusMessage("Restarting visual asset generation…");
+      setStatusMessage("Restarting visual asset generation\u2026");
       await refreshRun(run.id);
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Restart failed");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Restart failed",
+      );
     } finally {
       setRestarting(false);
     }
@@ -786,16 +808,23 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/generate-audio`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tts_model: modelSelection.tts_model || "qwen3-tts", voice: "default" }),
+        body: JSON.stringify({
+          tts_model: modelSelection.tts_model || "qwen3-tts",
+          voice: "default",
+        }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
-        throw new Error(body?.detail ?? `Generate audio failed (${res.status})`);
+        throw new Error(
+          body?.detail ?? `Generate audio failed (${res.status})`,
+        );
       }
       setStatusMessage("Audio generation started");
       await refreshRun(run.id);
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Generate audio failed");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Generate audio failed",
+      );
     } finally {
       setGenerating(false);
     }
@@ -808,19 +837,29 @@ export default function ProjectPage() {
     setGenerating(true);
     setStatusMessage(null);
     try {
-      const res = await fetch(`${API_BASE}/runs/${run.id}/generate-subtitles`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ subtitle_model: modelSelection.subtitle_model || "whisper-small", subtitle_format: "srt" }),
-      });
+      const res = await fetch(
+        `${API_BASE}/runs/${run.id}/generate-subtitles`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            subtitle_model: modelSelection.subtitle_model || "whisper-small",
+            subtitle_format: "srt",
+          }),
+        },
+      );
       if (!res.ok) {
         const body = await res.json().catch(() => null);
-        throw new Error(body?.detail ?? `Generate subtitles failed (${res.status})`);
+        throw new Error(
+          body?.detail ?? `Generate subtitles failed (${res.status})`,
+        );
       }
       setStatusMessage("Subtitle generation started");
       await refreshRun(run.id);
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Generate subtitles failed");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Generate subtitles failed",
+      );
     } finally {
       setGenerating(false);
     }
@@ -836,7 +875,9 @@ export default function ProjectPage() {
       const res = await fetch(`${API_BASE}/runs/${run.id}/render`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ render_profile: modelSelection.render_profile || "shorts_default" }),
+        body: JSON.stringify({
+          render_profile: modelSelection.render_profile || "shorts_default",
+        }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -858,7 +899,9 @@ export default function ProjectPage() {
     setStopping(true);
     setStatusMessage(null);
     try {
-      const res = await fetch(`${API_BASE}/runs/${run.id}/stop`, { method: "POST" });
+      const res = await fetch(`${API_BASE}/runs/${run.id}/stop`, {
+        method: "POST",
+      });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `Stop failed (${res.status})`);
@@ -877,7 +920,9 @@ export default function ProjectPage() {
     setResuming(true);
     setStatusMessage(null);
     try {
-      const res = await fetch(`${API_BASE}/runs/${run.id}/resume`, { method: "POST" });
+      const res = await fetch(`${API_BASE}/runs/${run.id}/resume`, {
+        method: "POST",
+      });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `Resume failed (${res.status})`);
@@ -895,7 +940,9 @@ export default function ProjectPage() {
     setDeleting(true);
     setStatusMessage(null);
     try {
-      const res = await fetch(`${API_BASE}/projects/${numericProjectId}`, { method: "DELETE" });
+      const res = await fetch(`${API_BASE}/projects/${numericProjectId}`, {
+        method: "DELETE",
+      });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
         throw new Error(body?.detail ?? `Delete failed (${res.status})`);
@@ -915,194 +962,24 @@ export default function ProjectPage() {
   const isScriptStage = SCRIPT_STAGES.has(currentStage);
   const isScriptWorkspace = currentStage === "IDEA_READY" || isScriptStage;
   const isVisualPlanStage = VISUAL_PLAN_STAGES.has(currentStage);
-  const isVisualAssetStage = VISUAL_ASSET_STAGES.has(currentStage);
-  const isEditable = EDITABLE_STAGES.has(currentStage);
-  const isGenerating = currentStage === "SCRIPT_GENERATING";
+  const isStoryboardWorkspace = STORYBOARD_WORKSPACE_STAGES.has(currentStage);
   const isVPGenerating = currentStage === "VISUAL_PLAN_GENERATING";
   const isVPSetup = currentStage === "VISUAL_PLAN_SETUP";
-  const isVAGenerating = currentStage === "VISUAL_ASSET_GENERATING";
-  const isAudioStage = AUDIO_STAGES.has(currentStage);
-  const isSubtitleStage = SUBTITLE_STAGES.has(currentStage);
-  const isRenderStage = RENDER_STAGES.has(currentStage);
   const isFinalReview = FINAL_REVIEW_STAGES.has(currentStage);
-  const isStoryboardStage = STORYBOARD_STAGES.has(currentStage);
+  const isRenderStage = RENDER_STAGES.has(currentStage);
   const previewVideo = (preview as Record<string, unknown> | null)?.video;
   const previewVideoPath =
     previewVideo && typeof previewVideo === "object"
       ? (previewVideo as Record<string, unknown>).path
       : null;
 
+  // Determine max width — wider for storyboard scene grid
+  const maxWidth = isStoryboardWorkspace ? 1200 : 960;
 
-  // ---- action bar config ----
-
-  const buildActionBar = (): {
-    save: ActionConfig;
-    approve: ActionConfig;
-    generate: ActionConfig;
-    restart: ActionConfig;
-  } => {
-    // Final review — no actions needed, just view
-    if (isFinalReview) {
-      return {
-        save: { visible: false },
-        approve: { visible: false },
-        generate: { visible: false },
-        restart: {
-          visible: true,
-          disabled: restarting,
-          loading: restarting,
-          onClick: handleRestart,
-          label: "Restart from Script",
-        },
-      };
-    }
-
-    // Storyboard stages — audio/subtitle generation is handled by StoryboardView
-    // Only show render button and restart in the action bar
-    if (isAudioStage) {
-      return {
-        save: { visible: false },
-        approve: { visible: false },
-        generate: { visible: false },
-        restart: {
-          visible: true,
-          disabled: restarting,
-          loading: restarting,
-          onClick: handleRestart,
-          label: "Restart from Script",
-        },
-      };
-    }
-
-    if (isSubtitleStage) {
-      return {
-        save: { visible: false },
-        approve: { visible: false },
-        generate: {
-          visible: true,
-          disabled: generating,
-          loading: generating,
-          onClick: handleRender,
-          label: "Render Video",
-        },
-        restart: {
-          visible: true,
-          disabled: restarting,
-          loading: restarting,
-          onClick: handleRestart,
-          label: "Restart from Script",
-        },
-      };
-    }
-
-    // Render stage — rendering in progress, show restart only
-    if (isRenderStage) {
-      return {
-        save: { visible: false },
-        approve: { visible: false },
-        generate: { visible: false },
-        restart: {
-          visible: true,
-          disabled: restarting,
-          loading: restarting,
-          onClick: handleRestart,
-          label: "Restart from Script",
-        },
-      };
-    }
-
-    // Visual asset stages
-    if (isVisualAssetStage) {
-      return {
-        save: { visible: false },
-        approve: {
-          visible: currentStage === "VISUAL_ASSET_REVIEW",
-          disabled: approving,
-          loading: approving,
-          onClick: handleApproveAssets,
-          label: "Approve Assets",
-        },
-        generate: {
-          visible: currentStage === "VISUAL_ASSET_REVIEW",
-          disabled: generating,
-          loading: generating,
-          onClick: handleGenerateAllAssets,
-          label: "Regenerate All",
-        },
-        restart: {
-          visible: currentStage === "VISUAL_ASSET_REVIEW",
-          disabled: restarting,
-          loading: restarting,
-          onClick: handleRestartAssets,
-          label: "Restart Assets",
-        },
-      };
-    }
-
-    // Visual plan stages
-    // Visual plan setup — show only "Generate Visual Plan" button
-    if (isVPSetup) {
-      return {
-        save: { visible: false },
-        approve: { visible: false },
-        generate: {
-          visible: true,
-          disabled: generating,
-          loading: generating,
-          onClick: handleGenerateVisualPlan,
-          label: "Generate Visual Plan",
-        },
-        restart: { visible: false },
-      };
-    }
-
-    if (isVisualPlanStage) {
-      return {
-        save: { visible: false },
-        approve: {
-          visible: currentStage === "VISUAL_PLAN_REVIEW",
-          disabled: approving,
-          loading: approving,
-          onClick: handleApproveVisualPlan,
-          label: "Approve Visual Plan",
-        },
-        generate: { visible: false },
-        restart: {
-          visible: currentStage === "VISUAL_PLAN_REVIEW",
-          disabled: restarting,
-          loading: restarting,
-          onClick: handleRestartVisualPlan,
-          label: "Regenerate Plan",
-        },
-      };
-    }
-
-    // Script stages and transitions
-    return {
-      save: { visible: false },
-      approve: {
-        visible: currentStage === "SCRIPT_REVIEW",
-        disabled: approving,
-        loading: approving,
-        onClick: handleApprove,
-        label: "Approve Script",
-      },
-      generate: {
-        visible: currentStage === "IDEA_READY",
-        disabled: generating,
-        loading: generating,
-        onClick: handleGenerate,
-        label: "Generate Script",
-      },
-      restart: {
-        visible: currentStage === "SCRIPT_REVIEW",
-        disabled: restarting,
-        loading: restarting,
-        onClick: handleRestart,
-        label: "Regenerate Script",
-      },
-    };
-  };
+  const showGoBack =
+    Boolean(run) &&
+    Boolean(STAGE_BACK_LABELS[currentStage]) &&
+    !(currentStage === "SCRIPT_REVIEW" && project?.source_type !== "idea");
 
   // ---- render ----
 
@@ -1124,9 +1001,15 @@ export default function ProjectPage() {
       <div
         role="status"
         aria-label="Loading project"
-        style={{ maxWidth: 720, margin: "0 auto", padding: 24, textAlign: "center", color: "#6b7280" }}
+        style={{
+          maxWidth: 720,
+          margin: "0 auto",
+          padding: 24,
+          textAlign: "center",
+          color: "#6b7280",
+        }}
       >
-        Loading project…
+        Loading project\u2026
       </div>
     );
   }
@@ -1168,25 +1051,23 @@ export default function ProjectPage() {
     );
   }
 
-  const actions = buildActionBar();
-  const showGoBack =
-    Boolean(run) &&
-    Boolean(STAGE_BACK_LABELS[currentStage]) &&
-    !(currentStage === "SCRIPT_REVIEW" && project.source_type !== "idea");
-
   return (
-    <div style={{ maxWidth: 960, margin: "0 auto", padding: 24 }}>
+    <div style={{ maxWidth, margin: "0 auto", padding: 24 }}>
       {/* Header */}
       <div style={{ marginBottom: 16 }}>
-        <Link to="/runs" style={{ color: "#6b7280", fontSize: 12, textDecoration: "none" }}>
-          ← Projects
+        <Link
+          to="/runs"
+          style={{ color: "#6b7280", fontSize: 12, textDecoration: "none" }}
+        >
+          \u2190 Projects
         </Link>
         <h1 style={{ fontSize: 22, fontWeight: 700, margin: "8px 0 4px" }}>
           {project.title || "Untitled Project"}
         </h1>
         <span style={{ fontSize: 12, color: "#6b7280" }}>
-          Source: {project.source_type} · Status: {run ? run.status : project.status}
-          {run ? ` · Stage: ${currentStage}` : ""}
+          Source: {project.source_type} \u00b7 Status:{" "}
+          {run ? run.status : project.status}
+          {run ? ` \u00b7 Stage: ${currentStage}` : ""}
         </span>
 
         {/* Stop / Resume / Delete actions */}
@@ -1207,28 +1088,31 @@ export default function ProjectPage() {
                 cursor: stopping ? "not-allowed" : "pointer",
               }}
             >
-              {stopping ? "Stopping…" : "⏹ Stop"}
+              {stopping ? "Stopping\u2026" : "\u23f9 Stop"}
             </button>
           )}
-          {run && (run.status === "cancelled" || run.status === "failed" || run.status === "paused") && (
-            <button
-              type="button"
-              onClick={() => setConfirmAction("resume")}
-              disabled={resuming}
-              style={{
-                padding: "6px 14px",
-                border: "1px solid #16a34a",
-                borderRadius: 6,
-                background: "#fff",
-                color: "#16a34a",
-                fontSize: 12,
-                fontWeight: 600,
-                cursor: resuming ? "not-allowed" : "pointer",
-              }}
-            >
-              {resuming ? "Resuming…" : "▶ Resume"}
-            </button>
-          )}
+          {run &&
+            (run.status === "cancelled" ||
+              run.status === "failed" ||
+              run.status === "paused") && (
+              <button
+                type="button"
+                onClick={() => setConfirmAction("resume")}
+                disabled={resuming}
+                style={{
+                  padding: "6px 14px",
+                  border: "1px solid #16a34a",
+                  borderRadius: 6,
+                  background: "#fff",
+                  color: "#16a34a",
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: resuming ? "not-allowed" : "pointer",
+                }}
+              >
+                {resuming ? "Resuming\u2026" : "\u25b6 Resume"}
+              </button>
+            )}
           <button
             type="button"
             onClick={() => setConfirmAction("delete")}
@@ -1244,7 +1128,7 @@ export default function ProjectPage() {
               cursor: deleting ? "not-allowed" : "pointer",
             }}
           >
-            {deleting ? "Deleting…" : "🗑 Delete Project"}
+            {deleting ? "Deleting\u2026" : "\ud83d\uddd1 Delete Project"}
           </button>
         </div>
       </div>
@@ -1281,140 +1165,32 @@ export default function ProjectPage() {
         </div>
       )}
 
-      {/* Script workspace */}
+      {/* ═══════════════ Script Workspace ═══════════════ */}
       {run && isScriptWorkspace && (
         <div style={{ marginBottom: 24 }}>
-          {isGenerating && (
-            <div
-              data-testid="generating-indicator"
-              style={{
-                padding: "10px 14px",
-                background: "#eff6ff",
-                borderRadius: 8,
-                border: "1px solid #bfdbfe",
-                color: "#1e40af",
-                marginBottom: 12,
-                fontSize: 13,
-              }}
-            >
-              Generating Script… Current draft will update automatically.
-            </div>
-          )}
-
-          <div
-            style={{
-              padding: "14px 16px",
-              background: "#f9fafb",
-              border: "1px solid #e5e7eb",
-              borderRadius: 8,
-              marginBottom: 12,
-            }}
-          >
-            <div style={{ fontSize: 12, fontWeight: 600, color: "#6b7280", marginBottom: 6 }}>
-              Source Context
-            </div>
-            <div style={{ fontSize: 13, lineHeight: 1.5, color: "#374151", whiteSpace: "pre-wrap" }}>
-              {project.source_type === "idea"
-                ? (project.idea_brief || "No idea brief")
+          <ScriptComposer
+            runId={run.id}
+            currentStage={currentStage}
+            sourceType={project.source_type as "idea" | "markdown" | "url"}
+            sourceContext={
+              project.source_type === "idea"
+                ? project.idea_brief
                 : project.source_type === "markdown"
-                  ? (project.markdown_source || "No markdown source")
-                  : (project.url_source || "No URL source")}
-            </div>
-          </div>
-
-          {/* Editor mode toggle */}
-          <div
-            role="tablist"
-            style={{
-              display: "flex",
-              gap: 4,
-              marginBottom: 12,
-              borderBottom: "2px solid #ddd",
-            }}
-          >
-            <button
-              type="button"
-              role="tab"
-              id="tab-markdown"
-              aria-selected={editorMode === "markdown"}
-              aria-controls="panel-markdown"
-              onClick={() => setEditorMode("markdown")}
-              style={{
-                padding: "6px 14px",
-                border: "none",
-                borderBottom: editorMode === "markdown" ? "2px solid #4285f4" : "2px solid transparent",
-                background: "transparent",
-                cursor: "pointer",
-                fontWeight: editorMode === "markdown" ? 600 : 400,
-                color: editorMode === "markdown" ? "#4285f4" : "#666",
-                fontSize: 13,
-              }}
-            >
-              Markdown
-            </button>
-            <button
-              type="button"
-              role="tab"
-              id="tab-structured"
-              aria-selected={editorMode === "structured"}
-              aria-controls="panel-structured"
-              onClick={() => setEditorMode("structured")}
-              style={{
-                padding: "6px 14px",
-                border: "none",
-                borderBottom: editorMode === "structured" ? "2px solid #4285f4" : "2px solid transparent",
-                background: "transparent",
-                cursor: "pointer",
-                fontWeight: editorMode === "structured" ? 600 : 400,
-                color: editorMode === "structured" ? "#4285f4" : "#666",
-                fontSize: 13,
-              }}
-            >
-              Structured
-            </button>
-          </div>
-
-          {/* Markdown editor panel */}
-          {editorMode === "markdown" && (
-            <div role="tabpanel" id="panel-markdown" aria-labelledby="tab-markdown">
-              <MarkdownScriptEditor
-                runId={run.id}
-                readOnly={currentStage !== "SCRIPT_REVIEW"}
-                pollIntervalMs={currentStage === "IDEA_READY" || isGenerating ? 3000 : undefined}
-                suppressMissingDraftError={currentStage === "IDEA_READY" || isGenerating}
-                pendingMessage={
-                  currentStage === "IDEA_READY"
-                    ? "No script yet. Click Generate Script to start from this source."
-                    : "Waiting for generated script…"
-                }
-                onSuccess={() => setStatusMessage("Script saved")}
-                onError={(_action, msg) => setStatusMessage(msg)}
-              />
-            </div>
-          )}
-
-          {/* Structured editor panel */}
-          {editorMode === "structured" && (
-            <div role="tabpanel" id="panel-structured" aria-labelledby="tab-structured">
-              <StructuredScriptEditor
-                runId={run.id}
-                readOnly={currentStage !== "SCRIPT_REVIEW"}
-                pollIntervalMs={currentStage === "IDEA_READY" || isGenerating ? 3000 : undefined}
-                suppressMissingDraftError={currentStage === "IDEA_READY" || isGenerating}
-                pendingMessage={
-                  currentStage === "IDEA_READY"
-                    ? "No structured sections yet. Generate a script first."
-                    : "Waiting for generated sections…"
-                }
-                onSuccess={() => setStatusMessage("Script saved")}
-                onError={(_action, msg) => setStatusMessage(msg)}
-              />
-            </div>
-          )}
+                  ? project.markdown_source
+                  : project.url_source
+            }
+            selectedScriptModel={modelSelection.script_model}
+            onModelChange={handleModelChange}
+            onConfirm={handleApprove}
+            onGenerate={handleGenerate}
+            onRegenerate={handleRestart}
+            onStatusMessage={setStatusMessage}
+            disabled={approving || generating || restarting}
+          />
         </div>
       )}
 
-      {/* Visual plan workspace */}
+      {/* ═══════════════ Visual Plan Workspace ═══════════════ */}
       {run && isVisualPlanStage && (
         <div style={{ marginBottom: 24 }}>
           {(isVPSetup || isVPGenerating) && (
@@ -1431,7 +1207,7 @@ export default function ProjectPage() {
               }}
             >
               {isVPGenerating
-                ? "Generating Visual Plan… Scene prompts will appear here automatically."
+                ? "Generating Visual Plan\u2026 Scene prompts will appear here automatically."
                 : "Visual plan not generated yet. Review the source mapping below, then generate it in place."}
             </div>
           )}
@@ -1444,12 +1220,27 @@ export default function ProjectPage() {
               marginBottom: 16,
             }}
           >
-            <h3 style={{ margin: "0 0 6px", fontSize: 16, fontWeight: 700, color: "#1e3a5f" }}>
+            <h3
+              style={{
+                margin: "0 0 6px",
+                fontSize: 16,
+                fontWeight: 700,
+                color: "#1e3a5f",
+              }}
+            >
               Visual Plan Setup
             </h3>
-            <p style={{ margin: 0, fontSize: 13, color: "#4b5563", lineHeight: 1.5 }}>
-              Review the paragraph-to-image mapping below. Each paragraph in your script will
-              generate one image. Select the script model that will draft the visual plan, then click
+            <p
+              style={{
+                margin: 0,
+                fontSize: 13,
+                color: "#4b5563",
+                lineHeight: 1.5,
+              }}
+            >
+              Review the paragraph-to-image mapping below. Each paragraph in
+              your script will generate one image. Select the script model that
+              will draft the visual plan, then click
               <strong> Generate Visual Plan</strong> to proceed.
             </p>
           </div>
@@ -1464,7 +1255,7 @@ export default function ProjectPage() {
             />
           </div>
 
-          {/* Paragraph → Image cards */}
+          {/* Paragraph \u2192 Image cards */}
           <VisualPlanSetupCards runId={run.id} />
           <div style={{ marginTop: 16 }}>
             <VisualPlanEditor
@@ -1475,371 +1266,97 @@ export default function ProjectPage() {
               pendingMessage={
                 isVPSetup
                   ? "No visual plan yet. Generate it from the mapped script sections above."
-                  : "Waiting for generated scenes…"
+                  : "Waiting for generated scenes\u2026"
               }
               onSuccess={() => setStatusMessage("Visual plan saved")}
               onError={(_action, msg) => setStatusMessage(msg)}
             />
           </div>
-        </div>
-      )}
 
-      {/* Visual asset area */}
-      {run && isVisualAssetStage && (
-        <div data-testid="visual-asset-section" style={{ marginBottom: 24 }}>
-          {/* Asset generating indicator */}
-          {isVAGenerating && (
-            <div
-              data-testid="va-generating-indicator"
-              style={{
-                textAlign: "center",
-                padding: 32,
-                background: "#fdf4ff",
-                borderRadius: 8,
-                border: "1px solid #e9d5ff",
-                color: "#6b21a8",
-                marginBottom: 16,
-              }}
-            >
-              <p style={{ margin: "0 0 4px", fontWeight: 600 }}>Generating Visual Assets…</p>
-              <p style={{ margin: 0, fontSize: 13 }}>
-                Image generation is in progress. This may take several minutes.
-              </p>
-            </div>
-          )}
-
-          {/* Asset grid — visible in review or generating (read-only during generation) */}
-          <VisualAssetGrid
-            key={assetRefreshKey}
-            runId={run.id}
-            apiBase={API_BASE}
-            readOnly={isVAGenerating}
-            onSelect={() => setStatusMessage("Active asset updated")}
-            onError={(_action, msg) => setStatusMessage(msg)}
-          />
-
-          {/* Scene-level regeneration controls (review stage only) */}
-          {currentStage === "VISUAL_ASSET_REVIEW" && (
-            <div
-              data-testid="scene-regen-controls"
-              style={{
-                marginTop: 16,
-                padding: 16,
-                border: "1px solid #e5e7eb",
-                borderRadius: 8,
-                background: "#f9fafb",
-              }}
-            >
-              <h4 style={{ margin: "0 0 12px", fontSize: 14, fontWeight: 600 }}>
-                Regenerate Single Scene
-              </h4>
-
-              {/* Model override selector — image category only */}
-              <div style={{ marginBottom: 12 }}>
-                <ModelSelector
-                  categories={["image"]}
-                  apiBase={API_BASE}
-                  onSelectionChange={(_cat, modelKey) => setRegenModelKey(modelKey)}
-                />
-              </div>
-
-              {/* Image quality tuning controls */}
-              <div
-                data-testid="image-tuning-panel"
+          {/* Visual plan action buttons */}
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              marginTop: 16,
+              justifyContent: "flex-end",
+            }}
+          >
+            {isVPSetup && (
+              <button
+                type="button"
+                data-testid="generate-vp-btn"
+                disabled={generating}
+                onClick={handleGenerateVisualPlan}
                 style={{
-                  marginBottom: 16,
-                  border: "1px solid #e5e7eb",
-                  borderRadius: 8,
-                  background: "#fff",
-                  overflow: "hidden",
+                  padding: "8px 20px",
+                  border: "none",
+                  borderRadius: 6,
+                  background: generating ? "#9ca3af" : "#4285f4",
+                  color: "#fff",
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: generating ? "not-allowed" : "pointer",
                 }}
               >
-                {/* Panel header — toggle */}
+                {generating ? "Generating\u2026" : "Generate Visual Plan"}
+              </button>
+            )}
+            {currentStage === "VISUAL_PLAN_REVIEW" && (
+              <>
                 <button
                   type="button"
-                  data-testid="tuning-toggle"
-                  onClick={() => setTuningOpen((v) => !v)}
+                  data-testid="restart-vp-btn"
+                  disabled={restarting}
+                  onClick={handleRestartVisualPlan}
                   style={{
-                    width: "100%",
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                    padding: "10px 14px",
-                    background: "#faf5ff",
+                    padding: "8px 20px",
+                    border: "1px solid #d1d5db",
+                    borderRadius: 6,
+                    background: "#fff",
+                    color: "#374151",
+                    fontSize: 13,
+                    fontWeight: 500,
+                    cursor: restarting ? "not-allowed" : "pointer",
+                  }}
+                >
+                  {restarting ? "Restarting\u2026" : "Regenerate Plan"}
+                </button>
+                <button
+                  type="button"
+                  data-testid="approve-vp-btn"
+                  disabled={approving}
+                  onClick={handleApproveVisualPlan}
+                  style={{
+                    padding: "8px 20px",
                     border: "none",
-                    borderBottom: tuningOpen ? "1px solid #e5e7eb" : "none",
-                    cursor: "pointer",
+                    borderRadius: 6,
+                    background: approving ? "#9ca3af" : "#16a34a",
+                    color: "#fff",
                     fontSize: 13,
                     fontWeight: 600,
-                    color: "#6b21a8",
+                    cursor: approving ? "not-allowed" : "pointer",
                   }}
                 >
-                  <span>🎨 Image Quality Settings</span>
-                  <span style={{ fontSize: 11 }}>{tuningOpen ? "▲" : "▼"}</span>
+                  {approving ? "Approving\u2026" : "Approve Visual Plan"}
                 </button>
-
-                {tuningOpen && (
-                  <div style={{ padding: 14, display: "flex", flexDirection: "column", gap: 14 }}>
-                    {/* Quality presets */}
-                    <div>
-                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "#374151", marginBottom: 6 }}>
-                        Quality Preset
-                      </label>
-                      <div style={{ display: "flex", gap: 6 }}>
-                        {Object.entries(SD_QUALITY_PRESETS).map(([key, preset]) => (
-                          <button
-                            type="button"
-                            key={key}
-                            data-testid={`preset-${key}`}
-                            title={preset.description}
-                            onClick={() => {
-                              setActivePreset(key);
-                              setImageParams((p) => ({
-                                ...p,
-                                steps: preset.steps,
-                                cfg_scale: preset.cfg_scale,
-                                sampler_name: preset.sampler_name,
-                              }));
-                            }}
-                            style={{
-                              flex: 1,
-                              padding: "6px 8px",
-                              fontSize: 12,
-                              fontWeight: activePreset === key ? 600 : 400,
-                              border: activePreset === key ? "2px solid #7c3aed" : "1px solid #d1d5db",
-                              borderRadius: 6,
-                              background: activePreset === key ? "#ede9fe" : "#fff",
-                              color: activePreset === key ? "#6b21a8" : "#374151",
-                              cursor: "pointer",
-                              transition: "all 0.15s",
-                            }}
-                          >
-                            {preset.label}
-                          </button>
-                        ))}
-                      </div>
-                      <p style={{ margin: "4px 0 0", fontSize: 11, color: "#9ca3af" }}>
-                        {SD_QUALITY_PRESETS[activePreset]?.description}
-                      </p>
-                    </div>
-
-                    {/* Steps slider */}
-                    <div>
-                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
-                        <label style={{ fontSize: 12, fontWeight: 600, color: "#374151" }}>
-                          Steps
-                        </label>
-                        <span style={{ fontSize: 12, color: "#6b21a8", fontWeight: 600 }}>{imageParams.steps}</span>
-                      </div>
-                      <input
-                        data-testid="steps-slider"
-                        type="range"
-                        min={15}
-                        max={50}
-                        value={imageParams.steps}
-                        onChange={(e) => {
-                          setActivePreset("");
-                          setImageParams((p) => ({ ...p, steps: Number(e.target.value) }));
-                        }}
-                        style={{ width: "100%", accentColor: "#7c3aed" }}
-                      />
-                      <p style={{ margin: "2px 0 0", fontSize: 11, color: "#9ca3af" }}>
-                        More steps = higher quality but slower. 20-30 is usually optimal.
-                      </p>
-                    </div>
-
-                    {/* CFG Scale slider */}
-                    <div>
-                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
-                        <label style={{ fontSize: 12, fontWeight: 600, color: "#374151" }}>
-                          CFG Scale (Prompt Adherence)
-                        </label>
-                        <span style={{ fontSize: 12, color: "#6b21a8", fontWeight: 600 }}>{imageParams.cfg_scale}</span>
-                      </div>
-                      <input
-                        data-testid="cfg-slider"
-                        type="range"
-                        min={1}
-                        max={20}
-                        value={imageParams.cfg_scale}
-                        onChange={(e) => {
-                          setActivePreset("");
-                          setImageParams((p) => ({ ...p, cfg_scale: Number(e.target.value) }));
-                        }}
-                        style={{ width: "100%", accentColor: "#7c3aed" }}
-                      />
-                      <p style={{ margin: "2px 0 0", fontSize: 11, color: "#9ca3af" }}>
-                        How closely to follow the prompt. 5-9 works well; too high can look harsh.
-                      </p>
-                    </div>
-
-                    {/* Sampler dropdown */}
-                    <div>
-                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "#374151", marginBottom: 4 }}>
-                        Sampler
-                      </label>
-                      <select
-                        data-testid="sampler-select"
-                        value={imageParams.sampler_name}
-                        onChange={(e) => {
-                          setActivePreset("");
-                          setImageParams((p) => ({ ...p, sampler_name: e.target.value }));
-                        }}
-                        style={{
-                          width: "100%",
-                          padding: "6px 10px",
-                          border: "1px solid #d1d5db",
-                          borderRadius: 4,
-                          fontSize: 13,
-                          background: "#fff",
-                          color: "#374151",
-                        }}
-                      >
-                        {SD_SAMPLERS.map((s) => (
-                          <option key={s} value={s}>{s}</option>
-                        ))}
-                      </select>
-                      <p style={{ margin: "2px 0 0", fontSize: 11, color: "#9ca3af" }}>
-                        DPM++ 2M Karras gives best quality for SD 1.5. Euler a is fastest.
-                      </p>
-                    </div>
-
-                    {/* Negative prompt */}
-                    <div>
-                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "#374151", marginBottom: 4 }}>
-                        Negative Prompt
-                      </label>
-                      <textarea
-                        data-testid="negative-prompt"
-                        rows={3}
-                        value={imageParams.negative_prompt}
-                        onChange={(e) => {
-                          setActivePreset("");
-                          setImageParams((p) => ({ ...p, negative_prompt: e.target.value }));
-                        }}
-                        style={{
-                          width: "100%",
-                          padding: "6px 10px",
-                          border: "1px solid #d1d5db",
-                          borderRadius: 4,
-                          fontSize: 12,
-                          fontFamily: "inherit",
-                          resize: "vertical",
-                          color: "#374151",
-                          boxSizing: "border-box",
-                        }}
-                      />
-                      <p style={{ margin: "2px 0 0", fontSize: 11, color: "#9ca3af" }}>
-                        Describe what you do NOT want in the image. Helps avoid common SD artifacts.
-                      </p>
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {/* Scene action buttons — rendered per-scene from the asset grid data is impractical
-                  without lifting scene IDs up. Instead, provide a text input for scene ID. */}
-              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                <input
-                  data-testid="scene-id-input"
-                  type="text"
-                  placeholder="Scene ID (e.g. scene-0)"
-                  style={{
-                    flex: 1,
-                    padding: "6px 10px",
-                    border: "1px solid #d1d5db",
-                    borderRadius: 4,
-                    fontSize: 13,
-                  }}
-                  id="regen-scene-id"
-                />
-                <button
-                  type="button"
-                  data-testid="regen-scene-btn"
-                  onClick={() => {
-                    const input = document.getElementById("regen-scene-id") as HTMLInputElement;
-                    const sceneId = input?.value?.trim();
-                    if (sceneId) handleRegenerateScene(sceneId);
-                  }}
-                  style={{
-                    padding: "6px 16px",
-                    border: "1px solid #d1d5db",
-                    borderRadius: 4,
-                    background: "#fff",
-                    cursor: "pointer",
-                    fontSize: 13,
-                  }}
-                >
-                  Regenerate
-                </button>
-                <button
-                  type="button"
-                  data-testid="generate-scene-btn"
-                  onClick={() => {
-                    const input = document.getElementById("regen-scene-id") as HTMLInputElement;
-                    const sceneId = input?.value?.trim();
-                    if (sceneId) handleGenerateScene(sceneId);
-                  }}
-                  style={{
-                    padding: "6px 16px",
-                    border: "1px solid #d1d5db",
-                    borderRadius: 4,
-                    background: "#fff",
-                    cursor: "pointer",
-                    fontSize: 13,
-                  }}
-                >
-                  Generate New
-                </button>
-              </div>
-            </div>
-          )}
+              </>
+            )}
+          </div>
         </div>
       )}
 
-      {/* Unified Storyboard view — replaces separate audio/subtitle/render indicators */}
-      {run && isStoryboardStage && (
+      {/* ═══════════════ Storyboard Workspace (Scene-Centric) ═══════════════ */}
+      {run && isStoryboardWorkspace && (
         <div style={{ marginBottom: 24 }}>
-          {!isRenderStage && (
-            <div style={{ marginBottom: 12 }}>
-              <ModelSelector
-                categories={["tts", "stt"]}
-                selectedModels={buildSelectedModels(["tts", "stt"])}
-                apiBase=""
-                onSelectionChange={handleModelChange}
-              />
-              <div style={{ marginTop: 12 }}>
-                <label
-                  htmlFor="project-render-profile"
-                  style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}
-                >
-                  Render Profile
-                </label>
-                <select
-                  id="project-render-profile"
-                  value={modelSelection.render_profile || "shorts_default"}
-                  onChange={(e) => handleModelChange("render", e.target.value)}
-                  style={{ padding: "8px 12px", border: "1px solid #ccc", borderRadius: 4, fontSize: 14 }}
-                >
-                  {RENDER_PROFILE_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-          )}
-          <StoryboardView
+          <StoryboardWorkspace
             runId={run.id}
-            readOnly={isRenderStage}
-            currentStage={currentStage}
-            onStatusMessage={setStatusMessage}
-            onRenderReady={() => {
-              if (run) refreshRun(run.id);
-            }}
             ttsModel={modelSelection.tts_model}
             subtitleModel={modelSelection.subtitle_model}
+            imageModel={modelSelection.image_model}
+            onStatusMessage={setStatusMessage}
+            onRender={handleRender}
+            rendering={generating}
           />
 
           {/* Final review extras — review link + video path */}
@@ -1856,14 +1373,27 @@ export default function ProjectPage() {
                 color: "#166534",
               }}
             >
-              <p style={{ margin: "0 0 8px", fontWeight: 600, fontSize: 16 }}>
+              <p
+                style={{
+                  margin: "0 0 8px",
+                  fontWeight: 600,
+                  fontSize: 16,
+                }}
+              >
                 Pipeline Complete
               </p>
               <p style={{ margin: "0 0 16px", fontSize: 13 }}>
-                All stages are done. Review the final output or restart from any stage.
+                All stages are done. Review the final output or restart from
+                any stage.
               </p>
               {typeof previewVideoPath === "string" && (
-                <p style={{ margin: "0 0 8px", fontSize: 13, color: "#374151" }}>
+                <p
+                  style={{
+                    margin: "0 0 8px",
+                    fontSize: 13,
+                    color: "#374151",
+                  }}
+                >
                   Video: {previewVideoPath}
                 </p>
               )}
@@ -1881,7 +1411,7 @@ export default function ProjectPage() {
                   fontSize: 14,
                 }}
               >
-                Open Review Page →
+                Open Review Page \u2192
               </Link>
             </div>
           )}
@@ -1890,7 +1420,13 @@ export default function ProjectPage() {
 
       {/* Back navigation button */}
       {showGoBack && (
-        <div style={{ display: "flex", justifyContent: "flex-start", padding: "8px 16px" }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-start",
+            padding: "8px 0",
+          }}
+        >
           <button
             type="button"
             data-testid="go-back-btn"
@@ -1908,62 +1444,34 @@ export default function ProjectPage() {
               opacity: goingBack ? 0.6 : 1,
             }}
           >
-            {goingBack ? "Going back\u2026" : STAGE_BACK_LABELS[currentStage]}
+            {goingBack
+              ? "Going back\u2026"
+              : STAGE_BACK_LABELS[currentStage]}
           </button>
         </div>
       )}
 
-      {/* Per-stage model selector */}
-      {run && currentStage === "IDEA_READY" && (
-        <div style={{ padding: "8px 16px" }}>
-          <ModelSelector
-            categories={["script"]}
-            selectedModels={buildSelectedModels(["script"])}
-            apiBase=""
-            onSelectionChange={handleModelChange}
-          />
+      {/* Status toast */}
+      {statusMessage && (
+        <div
+          data-testid="status-toast"
+          style={{
+            position: "fixed",
+            bottom: 24,
+            left: "50%",
+            transform: "translateX(-50%)",
+            padding: "10px 24px",
+            background: "#1f2937",
+            color: "#fff",
+            borderRadius: 8,
+            fontSize: 13,
+            fontWeight: 500,
+            boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+            zIndex: 1000,
+          }}
+        >
+          {statusMessage}
         </div>
-      )}
-      {run && currentStage === "SCRIPT_REVIEW" && (
-        <div style={{ padding: "8px 16px" }}>
-          <ModelSelector
-            categories={["script"]}
-            selectedModels={buildSelectedModels(["script"])}
-            apiBase=""
-            onSelectionChange={handleModelChange}
-          />
-        </div>
-      )}
-      {run && currentStage === "VISUAL_PLAN_REVIEW" && (
-        <div style={{ padding: "8px 16px" }}>
-          <ModelSelector
-            categories={["script"]}
-            selectedModels={buildSelectedModels(["script"])}
-            apiBase=""
-            onSelectionChange={handleModelChange}
-          />
-        </div>
-      )}
-      {run && currentStage === "VISUAL_ASSET_REVIEW" && (
-        <div style={{ padding: "8px 16px" }}>
-          <ModelSelector
-            categories={["image"]}
-            selectedModels={buildSelectedModels(["image"])}
-            apiBase=""
-            onSelectionChange={handleModelChange}
-          />
-        </div>
-      )}
-
-      {/* Stage action bar */}
-      {run && (
-        <StageActionBar
-          save={actions.save}
-          approve={actions.approve}
-          generate={actions.generate}
-          restart={actions.restart}
-          statusMessage={statusMessage ?? undefined}
-        />
       )}
 
       {/* Confirm dialog for stop / resume / delete */}
@@ -1983,8 +1491,20 @@ export default function ProjectPage() {
               ? "This will resume the stopped/failed run from where it left off."
               : "This will permanently delete the project and all its runs, assets, and generated content. This action cannot be undone."
         }
-        variant={confirmAction === "stop" ? "warning" : confirmAction === "resume" ? "info" : "danger"}
-        confirmLabel={confirmAction === "stop" ? "Stop Run" : confirmAction === "resume" ? "Resume" : "Delete Forever"}
+        variant={
+          confirmAction === "stop"
+            ? "warning"
+            : confirmAction === "resume"
+              ? "info"
+              : "danger"
+        }
+        confirmLabel={
+          confirmAction === "stop"
+            ? "Stop Run"
+            : confirmAction === "resume"
+              ? "Resume"
+              : "Delete Forever"
+        }
         loading={stopping || resuming || deleting}
         onConfirm={async () => {
           if (confirmAction === "stop") await handleStop();


### PR DESCRIPTION
## Summary

Redesigns ProjectPage from an inline sequential pipeline to a **scene-centric card architecture** where all scenes are visible simultaneously on screen with per-scene and bulk generation actions.

### Milestone
- **Milestone #14**: Scene-Centric ProjectPage Redesign
- **Epic #271**: Scene-Centric ProjectPage Redesign

### What Changed

**7 new components** + **ProjectPage rewrite** across 8 atomic commits:

| Commit | Component | Issue | Tests |
|--------|----------|-------|-------|
| `be28f8e` | `AssetSlot` — shimmer/loading/complete/error states per asset | #272 | 20 |
| `a492204` | `SceneCard` — per-scene card with 3 asset slots + generate actions | #273 | 15 |
| `cf0d69a` | `SceneCardGrid` — responsive grid showing all scenes simultaneously | #274 | 6 |
| `fe81889` | `BulkActionBar` — batch generate buttons with remaining counts | #275 | 9 |
| `7865352` | `PipelineOverviewBar` — sticky progress summary + render CTA | #276 | 6 |
| `cb7e3df` | `StoryboardWorkspace` — orchestrator: data fetching, polling, API wiring | #277 | 7 |
| `be53078` | `ScriptComposer` — unified script editing with tabs and actions | #278 | 11 |
| `912c699` | `ProjectPage` rewrite — integrates all new components | #279 | 40 |

### Architecture

```
ProjectPage (RunWorkspace)
├── PipelineStepper (kept)
├── ScriptComposer (new) — wraps Markdown/Structured editors + ModelSelector
├── VisualPlan section (kept, inline)
└── StoryboardWorkspace (new)
    ├── PipelineOverviewBar — sticky progress + render CTA
    ├── BulkActionBar — batch generation buttons
    └── SceneCardGrid — responsive grid of SceneCards
        └── SceneCard × N — 3 AssetSlots (image, audio, subtitle)
```

### Three Modes
1. **Script stages** → `ScriptComposer`
2. **Visual plan stages** → `VisualPlanEditor` (kept)
3. **Storyboard stages** → `StoryboardWorkspace` (wider 1200px max-width)

### Test Results
- **347/347 tests passing** across 24 test files
- **0 LSP errors/warnings** on all changed files
- Duration: ~8s

### Closes
Closes #272, closes #273, closes #274, closes #275, closes #276, closes #277, closes #278, closes #279