### PR TITLE
refactor: extract task dispatch service (#418)

### DIFF
--- a/apps/api/src/shorts_api/routes/creator_runs_core.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_core.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 from creator_domain.models import TRIGGER_POLICY
+from creator_service.task_dispatch_service import (
+    cas_dispatch_with_rollback,
+    dispatch_generate_script,
+)
 from creator_service.project_service import project_service
 from creator_service.run_service import run_service
 from creator_service.stage_review_service import stage_review_service
@@ -18,8 +22,6 @@ if TYPE_CHECKING:
 
 from shorts_api.routes.creator_runs_utils import (
     _has_active_tasks_for_run,
-    cas_dispatch_with_rollback,
-    dispatch_generate_script,
     validate_model_defaults,
     validate_model_key,
 )

--- a/apps/api/src/shorts_api/routes/creator_runs_scene_assets.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_scene_assets.py
@@ -10,6 +10,13 @@ from creator_service.project_service import project_service
 from creator_service.render_service import render_service
 from creator_service.run_service import run_service
 from creator_service.subtitle_service import subtitle_service
+from creator_service.task_dispatch_service import (
+    cas_dispatch_with_rollback,
+    dispatch_generate_audio,
+    dispatch_generate_scene_image,
+    dispatch_generate_subtitles,
+    dispatch_render_video,
+)
 from creator_service.task_tracking_service import task_tracking_service
 from creator_service.visual_asset_service import visual_asset_service
 from fastapi import APIRouter, Depends, HTTPException
@@ -26,11 +33,6 @@ from shorts_api.routes.creator_runs_core import (
 )
 from shorts_api.routes.creator_runs_utils import (
     _has_active_tasks_for_run,
-    cas_dispatch_with_rollback,
-    dispatch_generate_audio,
-    dispatch_generate_scene_image,
-    dispatch_generate_subtitles,
-    dispatch_render_video,
     validate_model_key,
     validate_render_profile,
 )

--- a/apps/api/src/shorts_api/routes/creator_runs_utils.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_utils.py
@@ -1,29 +1,41 @@
-"""Shared helpers and task dispatch for creator run routes."""
+"""Shared validation and run task helpers for creator routes."""
 
 import logging
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from importlib import import_module
-from typing import Any, cast
 
 from fastapi import HTTPException
 
 logger = logging.getLogger(__name__)
 
-_DISPATCH_TASK_TYPES = {
-    "dispatch_generate_script": "generate_script",
-    "dispatch_generate_visual_plan": "generate_visual_plan",
-    "dispatch_generate_audio": "generate_audio",
-    "dispatch_generate_subtitles": "generate_subtitles",
-    "dispatch_render_video": "render_video",
-    "dispatch_generate_scene_image": "generate_scene_image",
-    "dispatch_paragraph_audio": "generate_paragraph_audio",
-    "dispatch_paragraph_subtitles": "generate_paragraph_subtitles",
-}
+from creator_service.task_dispatch_service import (
+    cas_dispatch_with_rollback,
+    dispatch_generate_audio,
+    dispatch_generate_scene_image,
+    dispatch_generate_script,
+    dispatch_generate_subtitles,
+    dispatch_generate_visual_plan,
+    dispatch_paragraph_audio,
+    dispatch_paragraph_subtitles,
+    dispatch_render_video,
+)
 
-
-def _get_trace_headers() -> dict[str, str]:
-    telemetry = import_module("creator_service.telemetry")
-    return telemetry.get_trace_headers()
+__all__ = [
+    "validate_model_key",
+    "validate_render_profile",
+    "validate_model_defaults",
+    "_revoke_active_tasks_for_run",
+    "_has_active_tasks_for_run",
+    "cas_dispatch_with_rollback",
+    "dispatch_generate_audio",
+    "dispatch_generate_scene_image",
+    "dispatch_generate_script",
+    "dispatch_generate_subtitles",
+    "dispatch_generate_visual_plan",
+    "dispatch_paragraph_audio",
+    "dispatch_paragraph_subtitles",
+    "dispatch_render_video",
+]
 
 
 def validate_model_key(model_key: str) -> None:
@@ -81,159 +93,6 @@ def validate_model_defaults(model_defaults: Mapping[str, str] | None) -> None:
         validator(value)
 
 
-def dispatch_generate_script(
-    run_id: int, idea_brief: str, model_key: str, instructions: str | None
-) -> str:
-    """Dispatch generate_script Celery task. Returns task id.
-
-    Separated into a function so tests can monkeypatch without importing Celery.
-    """
-    from importlib import import_module
-
-    tasks = import_module("tasks.generate_script")
-    result = tasks.generate_script.apply_async(
-        args=[run_id, idea_brief, model_key, instructions],
-        headers=_get_trace_headers(),
-    )
-    return str(result.id)
-
-
-def dispatch_generate_visual_plan(run_id: int, model_key: str, style_preset: str | None) -> str:
-    """Dispatch generate_visual_plan Celery task. Returns task id.
-
-    Separated into a function so tests can monkeypatch without importing Celery.
-    """
-    from importlib import import_module
-
-    tasks = import_module("tasks.generate_visual_plan")
-    result = tasks.generate_visual_plan.apply_async(
-        args=[run_id, model_key, style_preset],
-        headers=_get_trace_headers(),
-    )
-    return str(result.id)
-
-
-def dispatch_generate_audio(run_id: int, tts_model: str, voice: str) -> str:
-    """Dispatch generate_audio Celery task. Returns task id.
-
-    Separated into a function so tests can monkeypatch without importing Celery.
-    """
-    from importlib import import_module
-
-    tasks = import_module("tasks.generate_audio")
-    result = tasks.generate_audio.apply_async(
-        args=[run_id],
-        kwargs={"tts_model": tts_model, "voice": voice},
-        headers=_get_trace_headers(),
-    )
-    return str(result.id)
-
-
-def dispatch_generate_subtitles(run_id: int, subtitle_model: str, subtitle_format: str) -> str:
-    """Dispatch generate_subtitles Celery task. Returns task id.
-
-    Separated into a function so tests can monkeypatch without importing Celery.
-    """
-    from importlib import import_module
-
-    tasks = import_module("tasks.generate_subtitles")
-    result = tasks.generate_subtitles.apply_async(
-        args=[run_id],
-        kwargs={"subtitle_model": subtitle_model, "subtitle_format": subtitle_format},
-        headers=_get_trace_headers(),
-    )
-    return str(result.id)
-
-
-def dispatch_render_video(run_id: int, render_profile: str) -> str:
-    """Dispatch render_video Celery task. Returns task id.
-
-    Separated into a function so tests can monkeypatch without importing Celery.
-    """
-    from importlib import import_module
-
-    tasks = import_module("tasks.render_video")
-    result = tasks.render_video.apply_async(
-        args=[run_id],
-        kwargs={"render_profile": render_profile},
-        headers=_get_trace_headers(),
-    )
-    return str(result.id)
-
-
-def dispatch_generate_scene_image(
-    run_id: int,
-    model_key: str,
-    scene_id: str | None,
-    prompt_override: str | None,
-    is_active: bool,
-    image_params: dict[str, Any] | None = None,
-) -> str:
-    """Dispatch generate_scene_image Celery task. Returns task id.
-
-    Separated into a function so tests can monkeypatch without importing Celery.
-    """
-    from importlib import import_module
-
-    tasks = import_module("tasks.generate_scene_image")
-    result = tasks.generate_scene_image.apply_async(
-        args=[run_id],
-        kwargs={
-            "scene_id": scene_id,
-            "model_key": model_key,
-            "prompt_override": prompt_override,
-            "is_active": is_active,
-            "image_params": image_params,
-        },
-        headers=_get_trace_headers(),
-    )
-    return str(result.id)
-
-
-def dispatch_paragraph_audio(
-    run_id: int, section_id: str, section_text: str, tts_model: str, voice: str
-) -> str:
-    """Dispatch generate_paragraph_audio Celery task. Returns task id."""
-    from importlib import import_module
-
-    tasks = import_module("tasks.generate_paragraph_audio")
-    result = tasks.generate_paragraph_audio.apply_async(
-        args=[run_id],
-        kwargs={
-            "section_id": section_id,
-            "section_text": section_text,
-            "tts_model": tts_model,
-            "voice": voice,
-        },
-        headers=_get_trace_headers(),
-    )
-    return str(result.id)
-
-
-def dispatch_paragraph_subtitles(
-    run_id: int,
-    section_id: str,
-    audio_path: str,
-    subtitle_model: str,
-    subtitle_format: str,
-) -> str:
-    """Dispatch generate_paragraph_subtitles Celery task. Returns task id."""
-    from importlib import import_module
-
-    tasks = import_module("tasks.generate_paragraph_subtitles")
-    result = tasks.generate_paragraph_subtitles.apply_async(
-        args=[run_id],
-        kwargs={
-            "section_id": section_id,
-            "audio_path": audio_path,
-            "subtitle_model": subtitle_model,
-            "subtitle_format": subtitle_format,
-        },
-        headers=_get_trace_headers(),
-    )
-    return str(result.id)
-
-
 async def _revoke_active_tasks_for_run(run_id: int) -> None:
     try:
         celery_app = __import__("celery_app").celery_app
@@ -250,118 +109,6 @@ async def _revoke_active_tasks_for_run(run_id: int) -> None:
 async def _has_active_tasks_for_run(run_id: int) -> bool:
     tracking_service = import_module("creator_service.task_tracking_service").task_tracking_service
     return await tracking_service.has_active_tasks(run_id)
-
-
-async def cas_dispatch_with_rollback(
-    *,
-    run_id: int,
-    expected_stages: frozenset[str],
-    target_stage: str,
-    dispatcher: Callable[..., str],
-    dispatcher_args: Mapping[str, Any],
-    run_service: Any,
-    rollback_stage: str,
-    rollback_restart_from: str | None,
-    enqueue_error_detail: str,
-    restart_from_stage: str | None = None,
-    quota_operation_type: str | None = None,
-) -> dict[str, object]:
-    run_service_obj = cast(Any, run_service)
-    workspace_id_for_reservation: int | None = None
-    if quota_operation_type is not None:
-        from creator_service.project_service import project_service
-        from creator_service.usage_service import check_workspace_quota
-
-        run = await run_service_obj.get_run(run_id)
-        if run is None:
-            raise HTTPException(status_code=404, detail="Run not found")
-        project = await project_service.get_project(run.project_id)
-        if project is None:
-            raise HTTPException(status_code=404, detail="Project not found")
-        workspace_id = cast(int | None, getattr(project, "workspace_id", None))
-        if workspace_id is None:
-            raise HTTPException(status_code=400, detail="Project workspace is not configured")
-        workspace_id_for_reservation = workspace_id
-
-        allowed, reason = await check_workspace_quota(
-            workspace_id,
-            operation_type=quota_operation_type,
-        )
-        if not allowed:
-            raise HTTPException(status_code=429, detail=reason)
-
-    updates: dict[str, object] = {"current_stage": target_stage}
-    restart_stage = restart_from_stage or target_stage
-    if rollback_stage == restart_stage:
-        updates["restart_from"] = target_stage
-
-    ok, row = await run_service_obj.storage.conditional_update_run(
-        run_id,
-        updates,
-        expected_stages=expected_stages,
-    )
-    if not ok:
-        if row is None:
-            raise HTTPException(status_code=404, detail="Run not found")
-        raise HTTPException(
-            status_code=409,
-            detail=f"Stage conflict: run is now in '{row.get('current_stage')}'",
-        )
-
-    try:
-        task_id = dispatcher(**dict(dispatcher_args))
-    except Exception:
-        if workspace_id_for_reservation is not None and quota_operation_type is not None:
-            from creator_service.usage_service import cancel_workspace_quota_reservation
-
-            await cancel_workspace_quota_reservation(
-                workspace_id_for_reservation,
-                quota_operation_type,
-            )
-        await run_service_obj.storage.conditional_update_run(
-            run_id,
-            {"current_stage": rollback_stage, "restart_from": rollback_restart_from},
-            expected_stages=frozenset({target_stage}),
-        )
-        raise HTTPException(status_code=503, detail=enqueue_error_detail) from None
-
-    try:
-        task_type = _DISPATCH_TASK_TYPES.get(getattr(dispatcher, "__name__", ""), "unknown")
-        if task_type != "unknown":
-            tracking_service = import_module(
-                "creator_service.task_tracking_service"
-            ).task_tracking_service
-            await tracking_service.record_task_queued(run_id, task_type, task_id)
-    except Exception:
-        try:
-            __import__("celery_app").celery_app.control.revoke(task_id, terminate=True)
-        except Exception:
-            logger.warning("Failed to revoke task %s during rollback", task_id, exc_info=True)
-        try:
-            tracking_service = import_module(
-                "creator_service.task_tracking_service"
-            ).task_tracking_service
-            await tracking_service.mark_revoked(task_id)
-        except Exception:
-            logger.warning("Failed to mark task %s revoked during rollback", task_id, exc_info=True)
-        if workspace_id_for_reservation is not None and quota_operation_type is not None:
-            from creator_service.usage_service import cancel_workspace_quota_reservation
-
-            await cancel_workspace_quota_reservation(
-                workspace_id_for_reservation,
-                quota_operation_type,
-            )
-        await run_service_obj.storage.conditional_update_run(
-            run_id,
-            {"current_stage": rollback_stage, "restart_from": rollback_restart_from},
-            expected_stages=frozenset({target_stage}),
-        )
-        raise HTTPException(status_code=503, detail=enqueue_error_detail) from None
-    return {
-        "task_id": task_id,
-        "run_id": run_id,
-        "current_stage": target_stage,
-    }
 
 
 _EXPORTED_RUN_HELPERS = (_revoke_active_tasks_for_run, _has_active_tasks_for_run)

--- a/apps/api/src/shorts_api/routes/creator_runs_visuals.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_visuals.py
@@ -6,6 +6,11 @@ from typing import TYPE_CHECKING, Annotated
 
 from creator_domain.models import TRIGGER_POLICY
 from creator_service.run_service import run_service
+from creator_service.task_dispatch_service import (
+    cas_dispatch_with_rollback,
+    dispatch_generate_scene_image,
+    dispatch_generate_visual_plan,
+)
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -16,9 +21,6 @@ if TYPE_CHECKING:
 from shorts_api.routes.creator_runs_core import GenerateVisualPlanRequest
 from shorts_api.routes.creator_runs_utils import (
     _has_active_tasks_for_run,
-    cas_dispatch_with_rollback,
-    dispatch_generate_scene_image,
-    dispatch_generate_visual_plan,
     validate_model_key,
 )
 from shorts_api.auth import CurrentUser, require_run_access

--- a/apps/api/tests/test_telemetry_integration.py
+++ b/apps/api/tests/test_telemetry_integration.py
@@ -144,13 +144,12 @@ def test_api_to_celery_trace_context_propagates_via_task_headers(monkeypatch):
 
     fake_tasks_module = types.SimpleNamespace(generate_script=_FakeTask())
     monkeypatch.setattr(
-        creator_runs_utils,
-        "import_module",
-        lambda name: creator_service_telemetry if name == "creator_service.telemetry" else None,
-    )
-    monkeypatch.setattr(
-        "importlib.import_module",
-        lambda name: fake_tasks_module if name == "tasks.generate_script" else None,
+        "creator_service.task_dispatch_service.import_module",
+        lambda name: creator_service_telemetry
+        if name == "creator_service.telemetry"
+        else fake_tasks_module
+        if name == "tasks.generate_script"
+        else None,
     )
 
     incoming_trace_id = "0af7651916cd43dd8448eb211c80319c"

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from importlib import import_module
+from typing import Any, cast
+
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+_DISPATCH_TASK_TYPES = {
+    "dispatch_generate_script": "generate_script",
+    "dispatch_generate_visual_plan": "generate_visual_plan",
+    "dispatch_generate_audio": "generate_audio",
+    "dispatch_generate_subtitles": "generate_subtitles",
+    "dispatch_render_video": "render_video",
+    "dispatch_generate_scene_image": "generate_scene_image",
+    "dispatch_paragraph_audio": "generate_paragraph_audio",
+    "dispatch_paragraph_subtitles": "generate_paragraph_subtitles",
+}
+
+
+class TaskDispatchService:
+    def _get_trace_headers(self) -> dict[str, str]:
+        telemetry = import_module("creator_service.telemetry")
+        return telemetry.get_trace_headers()
+
+    def dispatch_generate_script(
+        self, run_id: int, idea_brief: str, model_key: str, instructions: str | None
+    ) -> str:
+        tasks = import_module("tasks.generate_script")
+        result = tasks.generate_script.apply_async(
+            args=[run_id, idea_brief, model_key, instructions],
+            headers=self._get_trace_headers(),
+        )
+        return str(result.id)
+
+    def dispatch_generate_visual_plan(
+        self, run_id: int, model_key: str, style_preset: str | None
+    ) -> str:
+        tasks = import_module("tasks.generate_visual_plan")
+        result = tasks.generate_visual_plan.apply_async(
+            args=[run_id, model_key, style_preset],
+            headers=self._get_trace_headers(),
+        )
+        return str(result.id)
+
+    def dispatch_generate_audio(self, run_id: int, tts_model: str, voice: str) -> str:
+        tasks = import_module("tasks.generate_audio")
+        result = tasks.generate_audio.apply_async(
+            args=[run_id],
+            kwargs={"tts_model": tts_model, "voice": voice},
+            headers=self._get_trace_headers(),
+        )
+        return str(result.id)
+
+    def dispatch_generate_subtitles(
+        self, run_id: int, subtitle_model: str, subtitle_format: str
+    ) -> str:
+        tasks = import_module("tasks.generate_subtitles")
+        result = tasks.generate_subtitles.apply_async(
+            args=[run_id],
+            kwargs={"subtitle_model": subtitle_model, "subtitle_format": subtitle_format},
+            headers=self._get_trace_headers(),
+        )
+        return str(result.id)
+
+    def dispatch_render_video(self, run_id: int, render_profile: str) -> str:
+        tasks = import_module("tasks.render_video")
+        result = tasks.render_video.apply_async(
+            args=[run_id],
+            kwargs={"render_profile": render_profile},
+            headers=self._get_trace_headers(),
+        )
+        return str(result.id)
+
+    def dispatch_generate_scene_image(
+        self,
+        run_id: int,
+        model_key: str,
+        scene_id: str | None,
+        prompt_override: str | None,
+        is_active: bool,
+        image_params: dict[str, Any] | None = None,
+    ) -> str:
+        tasks = import_module("tasks.generate_scene_image")
+        result = tasks.generate_scene_image.apply_async(
+            args=[run_id],
+            kwargs={
+                "scene_id": scene_id,
+                "model_key": model_key,
+                "prompt_override": prompt_override,
+                "is_active": is_active,
+                "image_params": image_params,
+            },
+            headers=self._get_trace_headers(),
+        )
+        return str(result.id)
+
+    def dispatch_paragraph_audio(
+        self, run_id: int, section_id: str, section_text: str, tts_model: str, voice: str
+    ) -> str:
+        tasks = import_module("tasks.generate_paragraph_audio")
+        result = tasks.generate_paragraph_audio.apply_async(
+            args=[run_id],
+            kwargs={
+                "section_id": section_id,
+                "section_text": section_text,
+                "tts_model": tts_model,
+                "voice": voice,
+            },
+            headers=self._get_trace_headers(),
+        )
+        return str(result.id)
+
+    def dispatch_paragraph_subtitles(
+        self,
+        run_id: int,
+        section_id: str,
+        audio_path: str,
+        subtitle_model: str,
+        subtitle_format: str,
+    ) -> str:
+        tasks = import_module("tasks.generate_paragraph_subtitles")
+        result = tasks.generate_paragraph_subtitles.apply_async(
+            args=[run_id],
+            kwargs={
+                "section_id": section_id,
+                "audio_path": audio_path,
+                "subtitle_model": subtitle_model,
+                "subtitle_format": subtitle_format,
+            },
+            headers=self._get_trace_headers(),
+        )
+        return str(result.id)
+
+    async def cas_dispatch_with_rollback(
+        self,
+        *,
+        run_id: int,
+        expected_stages: frozenset[str],
+        target_stage: str,
+        dispatcher: Callable[..., str],
+        dispatcher_args: Mapping[str, Any],
+        run_service: Any,
+        rollback_stage: str,
+        rollback_restart_from: str | None,
+        enqueue_error_detail: str,
+        restart_from_stage: str | None = None,
+        quota_operation_type: str | None = None,
+    ) -> dict[str, object]:
+        run_service_obj = cast(Any, run_service)
+        workspace_id_for_reservation: int | None = None
+        if quota_operation_type is not None:
+            from creator_service.project_service import project_service
+            from creator_service.usage_service import check_workspace_quota
+
+            run = await run_service_obj.get_run(run_id)
+            if run is None:
+                raise HTTPException(status_code=404, detail="Run not found")
+            project = await project_service.get_project(run.project_id)
+            if project is None:
+                raise HTTPException(status_code=404, detail="Project not found")
+            workspace_id = cast(int | None, getattr(project, "workspace_id", None))
+            if workspace_id is None:
+                raise HTTPException(status_code=400, detail="Project workspace is not configured")
+            workspace_id_for_reservation = workspace_id
+
+            allowed, reason = await check_workspace_quota(
+                workspace_id,
+                operation_type=quota_operation_type,
+            )
+            if not allowed:
+                raise HTTPException(status_code=429, detail=reason)
+
+        updates: dict[str, object] = {"current_stage": target_stage}
+        restart_stage = restart_from_stage or target_stage
+        if rollback_stage == restart_stage:
+            updates["restart_from"] = target_stage
+
+        ok, row = await run_service_obj.storage.conditional_update_run(
+            run_id,
+            updates,
+            expected_stages=expected_stages,
+        )
+        if not ok:
+            if row is None:
+                raise HTTPException(status_code=404, detail="Run not found")
+            raise HTTPException(
+                status_code=409,
+                detail=f"Stage conflict: run is now in '{row.get('current_stage')}'",
+            )
+
+        try:
+            task_id = dispatcher(**dict(dispatcher_args))
+        except Exception:
+            if workspace_id_for_reservation is not None and quota_operation_type is not None:
+                from creator_service.usage_service import cancel_workspace_quota_reservation
+
+                await cancel_workspace_quota_reservation(
+                    workspace_id_for_reservation,
+                    quota_operation_type,
+                )
+            await run_service_obj.storage.conditional_update_run(
+                run_id,
+                {"current_stage": rollback_stage, "restart_from": rollback_restart_from},
+                expected_stages=frozenset({target_stage}),
+            )
+            raise HTTPException(status_code=503, detail=enqueue_error_detail) from None
+
+        try:
+            task_type = _DISPATCH_TASK_TYPES.get(getattr(dispatcher, "__name__", ""), "unknown")
+            if task_type != "unknown":
+                tracking_service = import_module(
+                    "creator_service.task_tracking_service"
+                ).task_tracking_service
+                await tracking_service.record_task_queued(run_id, task_type, task_id)
+        except Exception:
+            try:
+                __import__("celery_app").celery_app.control.revoke(task_id, terminate=True)
+            except Exception:
+                logger.warning("Failed to revoke task %s during rollback", task_id, exc_info=True)
+            try:
+                tracking_service = import_module(
+                    "creator_service.task_tracking_service"
+                ).task_tracking_service
+                await tracking_service.mark_revoked(task_id)
+            except Exception:
+                logger.warning(
+                    "Failed to mark task %s revoked during rollback", task_id, exc_info=True
+                )
+            if workspace_id_for_reservation is not None and quota_operation_type is not None:
+                from creator_service.usage_service import cancel_workspace_quota_reservation
+
+                await cancel_workspace_quota_reservation(
+                    workspace_id_for_reservation,
+                    quota_operation_type,
+                )
+            await run_service_obj.storage.conditional_update_run(
+                run_id,
+                {"current_stage": rollback_stage, "restart_from": rollback_restart_from},
+                expected_stages=frozenset({target_stage}),
+            )
+            raise HTTPException(status_code=503, detail=enqueue_error_detail) from None
+        return {
+            "task_id": task_id,
+            "run_id": run_id,
+            "current_stage": target_stage,
+        }
+
+
+task_dispatch_service = TaskDispatchService()
+
+
+def dispatch_generate_script(
+    run_id: int, idea_brief: str, model_key: str, instructions: str | None
+) -> str:
+    return task_dispatch_service.dispatch_generate_script(
+        run_id, idea_brief, model_key, instructions
+    )
+
+
+def dispatch_generate_visual_plan(run_id: int, model_key: str, style_preset: str | None) -> str:
+    return task_dispatch_service.dispatch_generate_visual_plan(run_id, model_key, style_preset)
+
+
+def dispatch_generate_audio(run_id: int, tts_model: str, voice: str) -> str:
+    return task_dispatch_service.dispatch_generate_audio(run_id, tts_model, voice)
+
+
+def dispatch_generate_subtitles(run_id: int, subtitle_model: str, subtitle_format: str) -> str:
+    return task_dispatch_service.dispatch_generate_subtitles(
+        run_id, subtitle_model, subtitle_format
+    )
+
+
+def dispatch_render_video(run_id: int, render_profile: str) -> str:
+    return task_dispatch_service.dispatch_render_video(run_id, render_profile)
+
+
+def dispatch_generate_scene_image(
+    run_id: int,
+    model_key: str,
+    scene_id: str | None,
+    prompt_override: str | None,
+    is_active: bool,
+    image_params: dict[str, Any] | None = None,
+) -> str:
+    return task_dispatch_service.dispatch_generate_scene_image(
+        run_id,
+        model_key,
+        scene_id,
+        prompt_override,
+        is_active,
+        image_params,
+    )
+
+
+def dispatch_paragraph_audio(
+    run_id: int, section_id: str, section_text: str, tts_model: str, voice: str
+) -> str:
+    return task_dispatch_service.dispatch_paragraph_audio(
+        run_id,
+        section_id,
+        section_text,
+        tts_model,
+        voice,
+    )
+
+
+def dispatch_paragraph_subtitles(
+    run_id: int,
+    section_id: str,
+    audio_path: str,
+    subtitle_model: str,
+    subtitle_format: str,
+) -> str:
+    return task_dispatch_service.dispatch_paragraph_subtitles(
+        run_id,
+        section_id,
+        audio_path,
+        subtitle_model,
+        subtitle_format,
+    )
+
+
+async def cas_dispatch_with_rollback(
+    *,
+    run_id: int,
+    expected_stages: frozenset[str],
+    target_stage: str,
+    dispatcher: Callable[..., str],
+    dispatcher_args: Mapping[str, Any],
+    run_service: Any,
+    rollback_stage: str,
+    rollback_restart_from: str | None,
+    enqueue_error_detail: str,
+    restart_from_stage: str | None = None,
+    quota_operation_type: str | None = None,
+) -> dict[str, object]:
+    return await task_dispatch_service.cas_dispatch_with_rollback(
+        run_id=run_id,
+        expected_stages=expected_stages,
+        target_stage=target_stage,
+        dispatcher=dispatcher,
+        dispatcher_args=dispatcher_args,
+        run_service=run_service,
+        rollback_stage=rollback_stage,
+        rollback_restart_from=rollback_restart_from,
+        enqueue_error_detail=enqueue_error_detail,
+        restart_from_stage=restart_from_stage,
+        quota_operation_type=quota_operation_type,
+    )

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -1,0 +1,118 @@
+import asyncio
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from creator_service.task_dispatch_service import TaskDispatchService
+
+
+class _FakeRunStorage:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, dict[str, object], frozenset[str]]] = []
+
+    async def conditional_update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        *,
+        expected_stages: frozenset[str],
+    ) -> tuple[bool, dict[str, object] | None]:
+        self.calls.append((run_id, updates, expected_stages))
+        return True, {"current_stage": "SCRIPT_REVIEW"}
+
+
+class _FakeRunService:
+    def __init__(self) -> None:
+        self.storage = _FakeRunStorage()
+
+
+def test_cas_dispatch_with_rollback_enqueue_failure_rolls_back_stage() -> None:
+    service = TaskDispatchService()
+    run_service = _FakeRunService()
+
+    def failing_dispatcher(**_: object) -> str:
+        raise RuntimeError("enqueue failed")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            service.cas_dispatch_with_rollback(
+                run_id=42,
+                expected_stages=frozenset({"SCRIPT_REVIEW"}),
+                target_stage="SCRIPT_GENERATING",
+                dispatcher=failing_dispatcher,
+                dispatcher_args={"run_id": 42},
+                run_service=run_service,
+                rollback_stage="SCRIPT_REVIEW",
+                rollback_restart_from=None,
+                enqueue_error_detail="Failed to enqueue script generation task",
+            )
+        )
+
+    assert exc.value.status_code == 503
+    assert run_service.storage.calls[0][1] == {"current_stage": "SCRIPT_GENERATING"}
+    assert run_service.storage.calls[1][1] == {
+        "current_stage": "SCRIPT_REVIEW",
+        "restart_from": None,
+    }
+
+
+def test_cas_dispatch_with_rollback_record_failure_revokes_and_rolls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TaskDispatchService()
+    run_service = _FakeRunService()
+    revoked: list[tuple[str, bool]] = []
+    marked_revoked: list[str] = []
+
+    def dispatch_generate_subtitles(**_: object) -> str:
+        return "celery-123"
+
+    class _TrackingService:
+        async def record_task_queued(self, _run_id: int, _task_type: str, _task_id: str) -> None:
+            raise RuntimeError("db write failed")
+
+        async def mark_revoked(self, task_id: str) -> None:
+            marked_revoked.append(task_id)
+
+    celery_app_module = ModuleType("celery_app")
+    setattr(
+        celery_app_module,
+        "celery_app",
+        SimpleNamespace(
+            control=SimpleNamespace(
+                revoke=lambda task_id, terminate: revoked.append((task_id, terminate))
+            )
+        ),
+    )
+    monkeypatch.setitem(__import__("sys").modules, "celery_app", celery_app_module)
+
+    def fake_import_module(name: str) -> object:
+        if name == "creator_service.task_tracking_service":
+            return SimpleNamespace(task_tracking_service=_TrackingService())
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("creator_service.task_dispatch_service.import_module", fake_import_module)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            service.cas_dispatch_with_rollback(
+                run_id=7,
+                expected_stages=frozenset({"AUDIO_GENERATING"}),
+                target_stage="SUBTITLE_GENERATING",
+                dispatcher=dispatch_generate_subtitles,
+                dispatcher_args={"run_id": 7},
+                run_service=run_service,
+                rollback_stage="AUDIO_GENERATING",
+                rollback_restart_from="AUDIO_GENERATING",
+                enqueue_error_detail="Failed to enqueue subtitle generation task",
+            )
+        )
+
+    assert exc.value.status_code == 503
+    assert revoked == [("celery-123", True)]
+    assert marked_revoked == ["celery-123"]
+    assert run_service.storage.calls[1][1] == {
+        "current_stage": "AUDIO_GENERATING",
+        "restart_from": "AUDIO_GENERATING",
+    }


### PR DESCRIPTION
## Summary
- Extract `cas_dispatch_with_rollback` and all 8 `dispatch_*` functions from `creator_runs_utils.py` into new `TaskDispatchService` class in `packages/creator-service/creator_service/task_dispatch_service.py`
- Route layer remains thin with backward-compatible re-exports from utils
- Added tests for failure paths: enqueue failure rolls back stage, metadata recording failure revokes task and rolls back

## Test Results
- 306 API tests passing
- 290 creator-service tests passing (+2 new)
- 111 worker tests passing
- Total: 707 passing

Closes #418