### PR TITLE
feat: artifact lifecycle via storage backend (#419)

### DIFF
--- a/apps/api/src/shorts_api/health.py
+++ b/apps/api/src/shorts_api/health.py
@@ -136,7 +136,11 @@ async def serve_artifact(artifact_path: str):
     try:
         content = _resolve_read_artifact_bytes()(storage_key)
         media_type, _ = mimetypes.guess_type(storage_key)
-        return Response(content=content, media_type=media_type or "application/octet-stream")
+        return Response(
+            content=content,
+            media_type=media_type or "application/octet-stream",
+            headers={"Warning": '299 - "Deprecated endpoint: use artifact-id download API"'},
+        )
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Artifact not found") from exc
     except Exception as exc:

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -1,10 +1,9 @@
 """Routes for creator project management."""
 
 import logging
-import os
-import shutil
 from typing import Any, Awaitable, Callable, Literal, cast
 
+from creator_service.artifact_download_service import artifact_download_service
 from creator_service.project_service import project_service
 from creator_service.run_service import run_service
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -128,12 +127,9 @@ async def _cleanup_project_resources(project_id: int) -> list[int]:
     return [r.id for r in runs]
 
 
-def _remove_run_artifacts(run_ids: list[int]) -> None:
-    artifact_root = os.getenv("ARTIFACT_ROOT", "data/artifacts")
+async def _remove_run_artifacts(run_ids: list[int]) -> None:
     for rid in run_ids:
-        run_dir = os.path.join(artifact_root, str(rid))
-        if os.path.isdir(run_dir):
-            shutil.rmtree(run_dir, ignore_errors=True)
+        await artifact_download_service.delete_artifacts_for_run(rid)
 
 
 @router.delete("/{project_id}")
@@ -162,5 +158,5 @@ async def delete_project(
     if not deleted:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    _remove_run_artifacts(run_ids)
+    await _remove_run_artifacts(run_ids)
     return {"deleted": True, "project_id": project_id}

--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from creator_service.artifact_download_service import artifact_download_service
 from creator_service.run_service import run_service
 from fastapi import APIRouter, Depends, HTTPException
 
 if TYPE_CHECKING:
     from creator_domain.models.pipeline_run import PipelineRun
-
-import os
-import shutil
 
 from shorts_api.routes.creator_runs_core import UpdateModelDefaultsRequest
 from shorts_api.routes.creator_runs_utils import (
@@ -102,9 +100,6 @@ async def delete_run(
     if not deleted:
         raise HTTPException(status_code=404, detail="Run not found")
 
-    _artifact_root = os.getenv("ARTIFACT_ROOT", "data/artifacts")
-    run_dir = os.path.join(_artifact_root, str(run_id))
-    if os.path.isdir(run_dir):
-        shutil.rmtree(run_dir, ignore_errors=True)
+    await artifact_download_service.delete_artifacts_for_run(run_id)
 
     return {"deleted": True, "run_id": run_id}

--- a/apps/api/tests/test_artifact_file_serving.py
+++ b/apps/api/tests/test_artifact_file_serving.py
@@ -48,6 +48,7 @@ async def test_legacy_artifact_route_reads_from_storage_backend(client, monkeypa
     assert response.status_code == 200
     assert response.content == payload
     assert response.headers["content-type"].startswith("image/png")
+    assert "deprecated" in response.headers["warning"].lower()
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_lifecycle.py
+++ b/apps/api/tests/test_lifecycle.py
@@ -1,12 +1,10 @@
 # pyright: reportMissingImports=false
 
-import os
 from collections.abc import Iterator, Sequence
 from datetime import datetime, timezone
 from typing import Literal
 
 import pytest
-import shorts_api.routes.creator_runs_lifecycle as creator_runs_lifecycle
 import shorts_api.routes.creator_runs_utils as creator_runs_utils
 from fastapi.routing import APIRoute
 from pydantic import BaseModel
@@ -133,6 +131,14 @@ class StubRevokeTasks:
         self.calls.append(run_id)
 
 
+class StubArtifactLifecycleService:
+    def __init__(self) -> None:
+        self.delete_artifacts_for_run_calls: list[int] = []
+
+    async def delete_artifacts_for_run(self, run_id: int) -> None:
+        self.delete_artifacts_for_run_calls.append(run_id)
+
+
 def _iter_api_routes(routes: Sequence[object]) -> list[APIRoute]:
     return [route for route in routes if isinstance(route, APIRoute)]
 
@@ -140,13 +146,16 @@ def _iter_api_routes(routes: Sequence[object]) -> list[APIRoute]:
 @pytest.fixture
 def stub_lifecycle_services(
     monkeypatch: pytest.MonkeyPatch,
-) -> Iterator[tuple[StubRunService, StubProjectService, StubRevokeTasks]]:
+) -> Iterator[
+    tuple[StubRunService, StubProjectService, StubRevokeTasks, StubArtifactLifecycleService]
+]:
     from shorts_api.auth import CurrentUser, require_run_access
     from shorts_api.main import app
 
     run_svc = StubRunService()
     project_svc = StubProjectService()
     revoke_tasks = StubRevokeTasks()
+    artifact_lifecycle_svc = StubArtifactLifecycleService()
 
     for route in _iter_api_routes(runs_router.routes):
         if route.name in {
@@ -160,11 +169,17 @@ def stub_lifecycle_services(
             monkeypatch.setitem(
                 route.endpoint.__globals__, "_revoke_active_tasks_for_run", revoke_tasks
             )
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "artifact_download_service", artifact_lifecycle_svc
+            )
 
     for route in _iter_api_routes(projects_router.routes):
         if route.name == "delete_project":
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
             monkeypatch.setitem(route.endpoint.__globals__, "project_service", project_svc)
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "artifact_download_service", artifact_lifecycle_svc
+            )
 
     monkeypatch.setattr(creator_runs_utils, "_revoke_active_tasks_for_run", revoke_tasks)
 
@@ -178,7 +193,7 @@ def stub_lifecycle_services(
 
     app.dependency_overrides[require_run_access] = _require_run_access
 
-    yield run_svc, project_svc, revoke_tasks
+    yield run_svc, project_svc, revoke_tasks, artifact_lifecycle_svc
 
     app.dependency_overrides.pop(require_run_access, None)
 
@@ -216,7 +231,7 @@ def _make_project(project_id: int) -> StubProject:
 
 @pytest.mark.asyncio
 async def test_stop_run_success(client, stub_lifecycle_services):
-    run_svc, _, revoke_tasks = stub_lifecycle_services
+    run_svc, _, revoke_tasks, _ = stub_lifecycle_services
     run_svc.runs[10] = _make_run(10)
 
     response = await client.post("/api/creator/runs/10/stop")
@@ -229,7 +244,7 @@ async def test_stop_run_success(client, stub_lifecycle_services):
 
 @pytest.mark.asyncio
 async def test_stop_run_not_found(client, stub_lifecycle_services):
-    run_svc, _, revoke_tasks = stub_lifecycle_services
+    run_svc, _, revoke_tasks, _ = stub_lifecycle_services
 
     response = await client.post("/api/creator/runs/404/stop")
 
@@ -241,7 +256,7 @@ async def test_stop_run_not_found(client, stub_lifecycle_services):
 
 @pytest.mark.asyncio
 async def test_resume_run_success(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
     run_svc.runs[11] = _make_run(11, status="cancelled", stage="SCRIPT_REVIEW")
 
     response = await client.post("/api/creator/runs/11/resume")
@@ -253,7 +268,7 @@ async def test_resume_run_success(client, stub_lifecycle_services):
 
 @pytest.mark.asyncio
 async def test_resume_run_not_found(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
     run_svc.resume_errors[999] = ValueError("Run 999 not found")
 
     response = await client.post("/api/creator/runs/999/resume")
@@ -264,7 +279,7 @@ async def test_resume_run_not_found(client, stub_lifecycle_services):
 
 @pytest.mark.asyncio
 async def test_resume_run_wrong_state(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
     run_svc.runs[12] = _make_run(12)
     run_svc.resume_errors[12] = ValueError(
         "Run 12 has status 'running', can only resume cancelled or failed runs"
@@ -278,7 +293,7 @@ async def test_resume_run_wrong_state(client, stub_lifecycle_services):
 
 @pytest.mark.asyncio
 async def test_go_back_success(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
     run_svc.runs[13] = _make_run(13, stage="SCRIPT_REVIEW")
 
     response = await client.post("/api/creator/runs/13/go-back")
@@ -290,7 +305,7 @@ async def test_go_back_success(client, stub_lifecycle_services):
 
 @pytest.mark.asyncio
 async def test_go_back_not_found(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
     run_svc.go_back_errors[888] = ValueError("Run 888 not found")
 
     response = await client.post("/api/creator/runs/888/go-back")
@@ -301,7 +316,7 @@ async def test_go_back_not_found(client, stub_lifecycle_services):
 
 @pytest.mark.asyncio
 async def test_go_back_invalid_state_returns_400(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
     run_svc.runs[14] = _make_run(14)
     run_svc.go_back_errors[14] = ValueError("Cannot go back from stage 'IDEA_READY'")
 
@@ -313,7 +328,7 @@ async def test_go_back_invalid_state_returns_400(client, stub_lifecycle_services
 
 @pytest.mark.asyncio
 async def test_go_back_stage_conflict_returns_409(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
     run_svc.runs[15] = _make_run(15)
     run_svc.go_back_errors[15] = RuntimeError(
         "Stage conflict: expected 'SCRIPT_REVIEW' but run is at 'VISUAL_PLAN_SETUP'"
@@ -327,7 +342,7 @@ async def test_go_back_stage_conflict_returns_409(client, stub_lifecycle_service
 
 @pytest.mark.asyncio
 async def test_update_model_defaults_success(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
     run_svc.runs[16] = _make_run(16, model_defaults={"script_model": "qwen3-4b"})
 
     response = await client.patch(
@@ -347,7 +362,7 @@ async def test_update_model_defaults_success(client, stub_lifecycle_services):
 
 @pytest.mark.asyncio
 async def test_update_model_defaults_not_found(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
     run_svc.update_model_defaults_errors[404] = ValueError("Run 404 not found")
 
     response = await client.patch(
@@ -361,7 +376,7 @@ async def test_update_model_defaults_not_found(client, stub_lifecycle_services):
 
 @pytest.mark.asyncio
 async def test_update_model_defaults_empty_body_returns_400(client, stub_lifecycle_services):
-    run_svc, _, _ = stub_lifecycle_services
+    run_svc, _, _, _ = stub_lifecycle_services
 
     run_svc.runs[16] = _make_run(16)
 
@@ -376,74 +391,38 @@ async def test_update_model_defaults_empty_body_returns_400(client, stub_lifecyc
 
 
 @pytest.mark.asyncio
-async def test_delete_run_success_with_artifact_cleanup(
-    client, stub_lifecycle_services, monkeypatch: pytest.MonkeyPatch
-):
-    run_svc, _, revoke_tasks = stub_lifecycle_services
+async def test_delete_run_success_with_artifact_cleanup(client, stub_lifecycle_services):
+    run_svc, _, revoke_tasks, artifact_lifecycle_svc = stub_lifecycle_services
     run_svc.runs[17] = _make_run(17)
-
-    artifact_root = "/tmp/lifecycle-artifacts"
-    monkeypatch.setenv("ARTIFACT_ROOT", artifact_root)
-
-    removed_paths: list[str] = []
-
-    def fake_isdir(path: str) -> bool:
-        return path == os.path.join(artifact_root, "17")
-
-    def fake_rmtree(path: str, ignore_errors: bool = False) -> None:
-        assert ignore_errors is True
-        removed_paths.append(path)
-
-    monkeypatch.setattr(creator_runs_lifecycle.os.path, "isdir", fake_isdir)
-    monkeypatch.setattr(creator_runs_lifecycle.shutil, "rmtree", fake_rmtree)
 
     response = await client.delete("/api/creator/runs/17")
 
     assert response.status_code == 200
     assert response.json() == {"deleted": True, "run_id": 17}
     assert revoke_tasks.calls == [17]
-    assert removed_paths == [os.path.join(artifact_root, "17")]
+    assert artifact_lifecycle_svc.delete_artifacts_for_run_calls == [17]
     assert run_svc.delete_run_calls == [17]
 
 
 @pytest.mark.asyncio
 async def test_delete_run_not_found_when_missing_before_delete(client, stub_lifecycle_services):
-    run_svc, _, revoke_tasks = stub_lifecycle_services
+    run_svc, _, revoke_tasks, artifact_lifecycle_svc = stub_lifecycle_services
 
     response = await client.delete("/api/creator/runs/700")
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Run not found"}
     assert run_svc.delete_run_calls == []
+    assert artifact_lifecycle_svc.delete_artifacts_for_run_calls == []
     assert revoke_tasks.calls == []
 
 
 @pytest.mark.asyncio
-async def test_delete_project_success_cascades_run_cleanup(
-    client, stub_lifecycle_services, monkeypatch: pytest.MonkeyPatch
-):
-    run_svc, project_svc, revoke_tasks = stub_lifecycle_services
+async def test_delete_project_success_cascades_run_cleanup(client, stub_lifecycle_services):
+    run_svc, project_svc, revoke_tasks, artifact_lifecycle_svc = stub_lifecycle_services
     project_svc.projects[31] = _make_project(31)
     run_svc.runs[41] = _make_run(41, project_id=31)
     run_svc.runs[42] = _make_run(42, project_id=31)
-
-    artifact_root = "/tmp/project-artifacts"
-    monkeypatch.setenv("ARTIFACT_ROOT", artifact_root)
-
-    removed_paths: list[str] = []
-
-    def fake_isdir(path: str) -> bool:
-        return path in {
-            os.path.join(artifact_root, "41"),
-            os.path.join(artifact_root, "42"),
-        }
-
-    def fake_rmtree(path: str, ignore_errors: bool = False) -> None:
-        assert ignore_errors is True
-        removed_paths.append(path)
-
-    monkeypatch.setattr(os.path, "isdir", fake_isdir)
-    monkeypatch.setattr("shutil.rmtree", fake_rmtree)
 
     response = await client.delete("/api/creator/projects/31")
 
@@ -452,17 +431,12 @@ async def test_delete_project_success_cascades_run_cleanup(
     assert run_svc.list_runs_by_project_calls == [31]
     assert project_svc.delete_project_calls == [31]
     assert revoke_tasks.calls == [42, 41]
-    assert sorted(removed_paths) == sorted(
-        [
-            os.path.join(artifact_root, "41"),
-            os.path.join(artifact_root, "42"),
-        ]
-    )
+    assert artifact_lifecycle_svc.delete_artifacts_for_run_calls == [42, 41]
 
 
 @pytest.mark.asyncio
 async def test_delete_project_not_found(client, stub_lifecycle_services):
-    run_svc, project_svc, revoke_tasks = stub_lifecycle_services
+    run_svc, project_svc, revoke_tasks, artifact_lifecycle_svc = stub_lifecycle_services
 
     response = await client.delete("/api/creator/projects/404")
 
@@ -470,4 +444,5 @@ async def test_delete_project_not_found(client, stub_lifecycle_services):
     assert response.json() == {"detail": "Project not found"}
     assert run_svc.list_runs_by_project_calls == [404]
     assert project_svc.delete_project_calls == [404]
+    assert artifact_lifecycle_svc.delete_artifacts_for_run_calls == []
     assert revoke_tasks.calls == []

--- a/packages/creator-service/creator_service/artifact_download_service.py
+++ b/packages/creator-service/creator_service/artifact_download_service.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import logging
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Protocol
 
 from creator_service.artifact_storage_integration import get_artifact_download_path
 from creator_service.object_storage import get_storage_backend
 
-from .db import fetch_one
+from .db import execute, fetch_all, fetch_one
+
+logger = logging.getLogger(__name__)
 
 
 class ArtifactDownloadStorageBackend(Protocol):
@@ -50,6 +55,40 @@ class ArtifactDownloadService:
 
     async def get_artifact_by_id(self, artifact_id: int) -> dict[str, Any] | None:
         return await self.storage.get_artifact_by_id(artifact_id)
+
+    async def delete_artifacts_for_run(self, run_id: int) -> None:
+        artifacts = await fetch_all(
+            "SELECT storage_key, storage_provider FROM creator_artifacts WHERE run_id = $1",
+            run_id,
+        )
+        backend = get_storage_backend()
+
+        for artifact in artifacts:
+            key = artifact.get("storage_key")
+            if not isinstance(key, str) or not key:
+                continue
+            try:
+                backend.delete(key)
+            except Exception:
+                logger.exception("Failed deleting artifact key '%s' for run_id=%s", key, run_id)
+
+        await execute("DELETE FROM creator_artifacts WHERE run_id = $1", run_id)
+
+        if os.getenv("STORAGE_BACKEND", "local") != "local":
+            return
+
+        artifact_root = Path(os.getenv("ARTIFACT_ROOT", "data/artifacts"))
+        run_dir = artifact_root / str(run_id)
+        if run_dir.is_dir():
+            try:
+                for path in sorted(run_dir.rglob("*"), reverse=True):
+                    if path.is_file() or path.is_symlink():
+                        path.unlink(missing_ok=True)
+                    elif path.is_dir():
+                        path.rmdir()
+                run_dir.rmdir()
+            except Exception:
+                logger.exception("Failed deleting local run directory '%s'", run_dir)
 
 
 def _create_storage() -> ArtifactDownloadStorageBackend:

--- a/packages/creator-service/tests/test_artifact_download_service.py
+++ b/packages/creator-service/tests/test_artifact_download_service.py
@@ -1,5 +1,7 @@
 import asyncio
+from pathlib import Path
 
+import pytest
 from creator_service.artifact_download_service import (
     ArtifactDownloadService,
     InMemoryArtifactDownloadStorage,
@@ -37,3 +39,72 @@ def test_get_artifact_by_id_returns_none_for_missing() -> None:
 
     fetched = run(service.get_artifact_by_id(99999))
     assert fetched is None
+
+
+@pytest.mark.asyncio
+async def test_delete_artifacts_for_run_deletes_storage_and_db_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deleted_keys: list[str] = []
+    deleted_rows: list[int] = []
+
+    class _Backend:
+        def delete(self, key: str) -> bool:
+            deleted_keys.append(key)
+            return True
+
+    async def _fetch_all(_query: str, run_id: int) -> list[dict[str, object]]:
+        assert run_id == 77
+        return [
+            {"storage_key": "77/audio.mp3", "storage_provider": "local"},
+            {"storage_key": "77/video.mp4", "storage_provider": "s3"},
+        ]
+
+    async def _execute(_query: str, run_id: int) -> str:
+        deleted_rows.append(run_id)
+        return "DELETE 2"
+
+    monkeypatch.setattr("creator_service.artifact_download_service.fetch_all", _fetch_all)
+    monkeypatch.setattr("creator_service.artifact_download_service.execute", _execute)
+    monkeypatch.setattr(
+        "creator_service.artifact_download_service.get_storage_backend", lambda: _Backend()
+    )
+
+    service = ArtifactDownloadService(InMemoryArtifactDownloadStorage())
+    await service.delete_artifacts_for_run(77)
+
+    assert deleted_keys == ["77/audio.mp3", "77/video.mp4"]
+    assert deleted_rows == [77]
+
+
+@pytest.mark.asyncio
+async def test_delete_artifacts_for_run_local_backend_cleans_run_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    run_dir = tmp_path / "55"
+    run_dir.mkdir(parents=True)
+    (run_dir / "orphan.tmp").write_text("x")
+
+    class _Backend:
+        provider = "local"
+
+        def delete(self, _key: str) -> bool:
+            return True
+
+    async def _fetch_all(_query: str, _run_id: int) -> list[dict[str, object]]:
+        return []
+
+    async def _execute(_query: str, _run_id: int) -> str:
+        return "DELETE 0"
+
+    monkeypatch.setenv("ARTIFACT_ROOT", str(tmp_path))
+    monkeypatch.setattr("creator_service.artifact_download_service.fetch_all", _fetch_all)
+    monkeypatch.setattr("creator_service.artifact_download_service.execute", _execute)
+    monkeypatch.setattr(
+        "creator_service.artifact_download_service.get_storage_backend", lambda: _Backend()
+    )
+
+    service = ArtifactDownloadService(InMemoryArtifactDownloadStorage())
+    await service.delete_artifacts_for_run(55)
+
+    assert not run_dir.exists()


### PR DESCRIPTION
## Summary
- Add `delete_artifacts_for_run(run_id)` to artifact_download_service that deletes via storage backend + cleans DB rows
- Replace `shutil.rmtree` in run/project deletion with storage-aware cleanup
- Path-based artifact endpoints return deprecation headers and are blocked in production
- Tests for storage deletion, local directory cleanup, deprecation headers

## Test Results
- 306 API + 292 creator-service + 111 worker = 709 passing

Closes #419