### PR TITLE
docs: add ADRs for package dependency rules and pipeline design (#378, #381)

### DIFF
--- a/docs/adr/001-package-dependency-rules.md
+++ b/docs/adr/001-package-dependency-rules.md
@@ -1,0 +1,65 @@
+# ADR-001: Package Dependency Rules
+
+**Status**: Accepted  
+**Date**: 2026-05-12  
+**Decision makers**: @yeongseon
+
+## Context
+
+The monorepo has four internal packages and two application layers. As the project grows, unconstrained cross-dependencies would create circular imports, tight coupling, and difficult-to-test code.
+
+## Decision
+
+The dependency graph flows **strictly downward**:
+
+```
+apps/api  ─┬─→ creator-service ──→ creator-domain
+            └─→ creator-provider ──→ creator-domain
+
+apps/worker ─┬─→ creator-service ──→ creator-domain
+             └─→ creator-provider ──→ creator-domain
+```
+
+### Rules
+
+1. **`creator-domain`** is the leaf package. It has **zero** internal dependencies. It defines entities, value objects, enums, and port interfaces.
+
+2. **`creator-service`** depends on `creator-domain` only. It implements use cases, storage adapters, and business logic.
+
+3. **`creator-provider`** depends on `creator-domain` only. It implements LLM, Image, TTS, and STT provider adapters. It does **NOT** depend on `creator-service`.
+
+4. **`apps/api`** and **`apps/worker-orchestrator`** depend on both `creator-service` and `creator-provider`. They are the composition root where dependencies are wired together.
+
+5. **No lateral dependencies**: `creator-service` and `creator-provider` must never import from each other.
+
+6. **No upward dependencies**: packages must never import from apps.
+
+### Why provider does NOT depend on service
+
+Providers are I/O adapters (HTTP calls to external APIs). Services are business logic orchestrators. Keeping them independent allows:
+- Testing providers without mocking business logic
+- Swapping providers without touching service code
+- Deploying provider updates independently
+
+## Verification
+
+Check for violations manually:
+
+```bash
+# Should return empty (no service imports in provider)
+grep -r "from creator_service" packages/creator-provider/ || echo "Clean"
+
+# Should return empty (no provider imports in service)
+grep -r "from creator_provider" packages/creator-service/ || echo "Clean"
+
+# Should return empty (no app imports in packages)
+grep -r "from shorts_api\|from tasks" packages/ || echo "Clean"
+```
+
+A CI lint step can automate this by adding the above checks to the test job.
+
+## Consequences
+
+- New shared types/interfaces must go in `creator-domain`, not copied across packages
+- If a service needs provider functionality, it must go through a port interface defined in domain
+- Apps are the only place where service + provider can be combined

--- a/docs/adr/002-linear-pipeline-no-workflow-engine.md
+++ b/docs/adr/002-linear-pipeline-no-workflow-engine.md
@@ -1,0 +1,65 @@
+# ADR-002: Linear Pipeline, No Workflow Engine
+
+**Status**: Accepted  
+**Date**: 2026-05-12  
+**Decision makers**: @yeongseon
+
+## Context
+
+The video production pipeline has a clear linear stage flow:
+
+```
+IDEA_READY → SCRIPT_GENERATING → SCRIPT_REVIEW
+  → VISUAL_PLAN_SETUP → VISUAL_PLAN_GENERATING → VISUAL_PLAN_REVIEW
+  → VISUAL_ASSET_GENERATING → VISUAL_ASSET_REVIEW
+  → AUDIO_GENERATING → SUBTITLE_GENERATING
+  → RENDER_GENERATING → FINAL_REVIEW → PUBLISHED
+```
+
+Each stage has a dedicated:
+- **Service method** in `creator-service` (business logic)
+- **API route** in `apps/api` (HTTP trigger)
+- **Celery task** in `apps/worker-orchestrator` (async execution)
+- **Stage enum** in `creator-domain` (state machine)
+
+It would be tempting to abstract this into a generic DAG/workflow engine. This ADR explains why we deliberately do not.
+
+## Decision
+
+**Keep the pipeline linear and explicit. Do not introduce a generic workflow engine.**
+
+### Design principles
+
+1. **Explicit over abstract**: Each stage is a named function, not a node in a graph config. This makes the code greppable, debuggable, and obvious.
+
+2. **One path**: There is one production path through the pipeline. Branching (e.g., retry a stage, skip a stage) is handled by explicit state transitions, not graph traversal.
+
+3. **Human-in-the-loop gates**: Review stages (`*_REVIEW`) are intentional pauses. They are not "conditional edges" — they are first-class stages.
+
+4. **Stage = unit of work**: Each stage maps 1:1 to a Celery task via `task_runner.py`. The common runner handles state transitions, error handling, and rollback uniformly.
+
+### When to reconsider
+
+Revisit this decision when **3 or more** of these conditions are met:
+- Multiple distinct pipeline types exist (not just video)
+- Stages need dynamic ordering per pipeline instance
+- Non-linear dependencies between stages (DAG, not chain)
+- External teams need to define custom pipelines
+
+Until then, adding a workflow engine is premature abstraction.
+
+## Current state audit
+
+No generic workflow abstractions exist in the codebase. The pipeline is implemented as:
+- `PipelineStage` enum in `creator-domain` (explicit stage list)
+- `task_runner.py` common runner (uniform execution, not routing)
+- Route handlers that dispatch to specific tasks (not a generic dispatcher)
+
+This is the correct level of abstraction for a single-pipeline product.
+
+## Consequences
+
+- New stages are added by: creating enum value + service method + route + task + tests
+- No YAML/JSON pipeline definitions
+- No dynamic stage ordering
+- The pipeline is "boring" — and that's the point


### PR DESCRIPTION
## Summary
- ADR-001: Package dependency rules — documents allowed dependency directions, why provider ≠ service, verification commands
- ADR-002: Linear pipeline, no workflow engine — documents design philosophy, when to reconsider, current state audit

Closes #378
Closes #381