### PR TITLE
feat: add lightweight task dispatch mode without Celery/Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,15 @@ python3 -m pytest apps/api/tests/ -x -v
 cd apps/studio-web && npm test
 ```
 
+## Lightweight Mode
+
+You can run the pipeline without Celery/Redis for local development.
+
+- If `REDIS_URL` is set, dispatch uses Celery (default behavior).
+- If `REDIS_URL` is unset, dispatch runs worker task functions synchronously in the API process.
+
+See [`docs/LIGHTWEIGHT.md`](docs/LIGHTWEIGHT.md) for setup and tradeoffs.
+
 ## Service Ports
 
 | Service | Port | Protocol |
@@ -287,6 +296,7 @@ cd apps/studio-web && npm test
 
 - [Usage Guide](docs/USAGE.md) -- Detailed feature walkthrough
 - [Deployment Guide](docs/CUTOVER.md) -- Production deployment checklist
+- [Lightweight Mode](docs/LIGHTWEIGHT.md) -- Run without Celery/Redis
 
 ## License
 

--- a/docs/LIGHTWEIGHT.md
+++ b/docs/LIGHTWEIGHT.md
@@ -1,0 +1,36 @@
+# Lightweight Mode
+
+Lightweight mode lets you run the API pipeline without Celery and Redis.
+When `REDIS_URL` is not set, task dispatch runs worker task functions synchronously in-process.
+
+## When To Use
+
+- Local development where you only run the API service.
+- Debugging task behavior without queue infrastructure.
+- Small single-user environments where async queueing is not required.
+
+## How It Works
+
+- `REDIS_URL` set: API dispatches tasks with Celery `apply_async(...)` (existing behavior).
+- `REDIS_URL` unset or empty: API calls the same worker task entrypoints directly.
+- Synchronous failures are caught; run status is moved to `FAILED` to avoid silent stuck stages.
+
+## Enable Lightweight Mode
+
+1. Unset `REDIS_URL` in your environment.
+2. Start API normally.
+3. Trigger pipeline stages from the UI or API.
+
+Example:
+
+```bash
+unset REDIS_URL
+cd apps/api
+uvicorn shorts_api.main:app --reload
+```
+
+## Notes
+
+- Tasks execute during the request lifecycle, so requests can take longer.
+- Celery task IDs are replaced with synthetic `sync-...` IDs in lightweight mode.
+- No worker process is required for dispatch execution in this mode.

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 from collections.abc import Callable, Mapping
 from importlib import import_module
+from types import SimpleNamespace
 from typing import Any, cast
+from uuid import uuid4
 
 from fastapi import HTTPException
 
@@ -26,54 +30,106 @@ class TaskDispatchService:
         telemetry = import_module("creator_service.telemetry")
         return telemetry.get_trace_headers()
 
+    def _use_celery_dispatch(self) -> bool:
+        return bool(os.environ.get("REDIS_URL"))
+
+    def _mark_run_failed(self, run_id: int) -> None:
+        async def _update_failed() -> None:
+            try:
+                run_service = import_module("creator_service.run_service").run_service
+                await run_service.storage.update_run(
+                    run_id,
+                    {"current_stage": "FAILED", "status": "failed"},
+                )
+            except Exception:
+                logger.warning("Failed to mark run %s as FAILED", run_id, exc_info=True)
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(_update_failed())
+            return
+        loop.create_task(_update_failed())
+
+    def _dispatch_task(
+        self,
+        *,
+        module_name: str,
+        task_attr: str,
+        run_id: int,
+        args: list[Any] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> str:
+        tasks = import_module(module_name)
+        task = getattr(tasks, task_attr)
+        if self._use_celery_dispatch() or not hasattr(task, "run"):
+            result = task.apply_async(
+                args=args or [],
+                kwargs=kwargs or {},
+                headers=self._get_trace_headers(),
+            )
+            return str(result.id)
+
+        task_id = f"sync-{task_attr}-{run_id}-{uuid4().hex[:12]}"
+        sync_self = SimpleNamespace(request=SimpleNamespace(id=task_id, retries=0), max_retries=0)
+        try:
+            task.run(sync_self, *(args or []), **(kwargs or {}))
+        except Exception:
+            logger.exception(
+                "Synchronous task dispatch failed for %s (run_id=%s)", task_attr, run_id
+            )
+            self._mark_run_failed(run_id)
+            raise
+        return task_id
+
     def dispatch_generate_script(
         self, run_id: int, idea_brief: str, model_key: str, instructions: str | None
     ) -> str:
-        tasks = import_module("tasks.generate_script")
-        result = tasks.generate_script.apply_async(
+        return self._dispatch_task(
+            module_name="tasks.generate_script",
+            task_attr="generate_script",
+            run_id=run_id,
             args=[run_id, idea_brief, model_key, instructions],
-            headers=self._get_trace_headers(),
         )
-        return str(result.id)
 
     def dispatch_generate_visual_plan(
         self, run_id: int, model_key: str, style_preset: str | None
     ) -> str:
-        tasks = import_module("tasks.generate_visual_plan")
-        result = tasks.generate_visual_plan.apply_async(
+        return self._dispatch_task(
+            module_name="tasks.generate_visual_plan",
+            task_attr="generate_visual_plan",
+            run_id=run_id,
             args=[run_id, model_key, style_preset],
-            headers=self._get_trace_headers(),
         )
-        return str(result.id)
 
     def dispatch_generate_audio(self, run_id: int, tts_model: str, voice: str) -> str:
-        tasks = import_module("tasks.generate_audio")
-        result = tasks.generate_audio.apply_async(
+        return self._dispatch_task(
+            module_name="tasks.generate_audio",
+            task_attr="generate_audio",
+            run_id=run_id,
             args=[run_id],
             kwargs={"tts_model": tts_model, "voice": voice},
-            headers=self._get_trace_headers(),
         )
-        return str(result.id)
 
     def dispatch_generate_subtitles(
         self, run_id: int, subtitle_model: str, subtitle_format: str
     ) -> str:
-        tasks = import_module("tasks.generate_subtitles")
-        result = tasks.generate_subtitles.apply_async(
+        return self._dispatch_task(
+            module_name="tasks.generate_subtitles",
+            task_attr="generate_subtitles",
+            run_id=run_id,
             args=[run_id],
             kwargs={"subtitle_model": subtitle_model, "subtitle_format": subtitle_format},
-            headers=self._get_trace_headers(),
         )
-        return str(result.id)
 
     def dispatch_render_video(self, run_id: int, render_profile: str) -> str:
-        tasks = import_module("tasks.render_video")
-        result = tasks.render_video.apply_async(
+        return self._dispatch_task(
+            module_name="tasks.render_video",
+            task_attr="render_video",
+            run_id=run_id,
             args=[run_id],
             kwargs={"render_profile": render_profile},
-            headers=self._get_trace_headers(),
         )
-        return str(result.id)
 
     def dispatch_generate_scene_image(
         self,
@@ -84,8 +140,10 @@ class TaskDispatchService:
         is_active: bool,
         image_params: dict[str, Any] | None = None,
     ) -> str:
-        tasks = import_module("tasks.generate_scene_image")
-        result = tasks.generate_scene_image.apply_async(
+        return self._dispatch_task(
+            module_name="tasks.generate_scene_image",
+            task_attr="generate_scene_image",
+            run_id=run_id,
             args=[run_id],
             kwargs={
                 "scene_id": scene_id,
@@ -94,15 +152,15 @@ class TaskDispatchService:
                 "is_active": is_active,
                 "image_params": image_params,
             },
-            headers=self._get_trace_headers(),
         )
-        return str(result.id)
 
     def dispatch_paragraph_audio(
         self, run_id: int, section_id: str, section_text: str, tts_model: str, voice: str
     ) -> str:
-        tasks = import_module("tasks.generate_paragraph_audio")
-        result = tasks.generate_paragraph_audio.apply_async(
+        return self._dispatch_task(
+            module_name="tasks.generate_paragraph_audio",
+            task_attr="generate_paragraph_audio",
+            run_id=run_id,
             args=[run_id],
             kwargs={
                 "section_id": section_id,
@@ -110,9 +168,7 @@ class TaskDispatchService:
                 "tts_model": tts_model,
                 "voice": voice,
             },
-            headers=self._get_trace_headers(),
         )
-        return str(result.id)
 
     def dispatch_paragraph_subtitles(
         self,
@@ -122,8 +178,10 @@ class TaskDispatchService:
         subtitle_model: str,
         subtitle_format: str,
     ) -> str:
-        tasks = import_module("tasks.generate_paragraph_subtitles")
-        result = tasks.generate_paragraph_subtitles.apply_async(
+        return self._dispatch_task(
+            module_name="tasks.generate_paragraph_subtitles",
+            task_attr="generate_paragraph_subtitles",
+            run_id=run_id,
             args=[run_id],
             kwargs={
                 "section_id": section_id,
@@ -131,9 +189,7 @@ class TaskDispatchService:
                 "subtitle_model": subtitle_model,
                 "subtitle_format": subtitle_format,
             },
-            headers=self._get_trace_headers(),
         )
-        return str(result.id)
 
     async def cas_dispatch_with_rollback(
         self,

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -27,6 +27,82 @@ class _FakeRunService:
         self.storage = _FakeRunStorage()
 
 
+def test_dispatch_generate_script_uses_sync_runner_when_redis_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TaskDispatchService()
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    run_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    class _FakeTask:
+        def run(self, *args: object, **kwargs: object) -> dict[str, object]:
+            run_calls.append((self, args, kwargs))
+            return {"ok": True}
+
+    def fake_import_module(name: str) -> object:
+        if name == "tasks.generate_script":
+            return SimpleNamespace(generate_script=_FakeTask())
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("creator_service.task_dispatch_service.import_module", fake_import_module)
+
+    task_id = service.dispatch_generate_script(
+        run_id=123,
+        idea_brief="idea",
+        model_key="qwen3-4b",
+        instructions="extra",
+    )
+
+    assert task_id.startswith("sync-generate_script-123-")
+    assert len(run_calls) == 1
+    _, args, kwargs = run_calls[0]
+    assert kwargs == {}
+    assert len(args) == 5
+    sync_self = args[0]
+    assert getattr(getattr(sync_self, "request"), "id") == task_id
+    assert args[1:] == (123, "idea", "qwen3-4b", "extra")
+
+
+def test_dispatch_generate_script_uses_celery_when_redis_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TaskDispatchService()
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+
+    apply_async_calls: list[tuple[list[object], dict[str, object], dict[str, str]]] = []
+
+    class _FakeTask:
+        def apply_async(
+            self,
+            *,
+            args: list[object],
+            kwargs: dict[str, object],
+            headers: dict[str, str],
+        ) -> object:
+            apply_async_calls.append((args, kwargs, headers))
+            return SimpleNamespace(id="celery-789")
+
+    def fake_import_module(name: str) -> object:
+        if name == "tasks.generate_script":
+            return SimpleNamespace(generate_script=_FakeTask())
+        if name == "creator_service.telemetry":
+            return SimpleNamespace(get_trace_headers=lambda: {"traceparent": "abc"})
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("creator_service.task_dispatch_service.import_module", fake_import_module)
+
+    task_id = service.dispatch_generate_script(
+        run_id=11,
+        idea_brief="idea",
+        model_key="qwen3-4b",
+        instructions=None,
+    )
+
+    assert task_id == "celery-789"
+    assert apply_async_calls == [([11, "idea", "qwen3-4b", None], {}, {"traceparent": "abc"})]
+
+
 def test_cas_dispatch_with_rollback_enqueue_failure_rolls_back_stage() -> None:
     service = TaskDispatchService()
     run_service = _FakeRunService()


### PR DESCRIPTION
## Summary
- add REDIS_URL-aware dispatch fallback in `task_dispatch_service` so task dispatch runs synchronously when Redis is not configured
- keep existing Celery `apply_async` behavior unchanged when `REDIS_URL` is present
- add dispatch tests for both sync and Celery paths, plus lightweight mode documentation in `docs/LIGHTWEIGHT.md` and README

## Testing
- cd apps/api && python3 -m pytest tests/ --ignore=tests/test_production_safety_limits.py --ignore=tests/test_security_headers.py -q
- cd packages/creator-service && python3 -m pytest tests/ -q
- cd packages/creator-provider && python3 -m pytest tests/ -q
- cd apps/worker-orchestrator && python3 -m pytest tests/ -q

Closes #376