### PR TITLE
fix: lightweight mode event-loop conflict and failure semantics

### DIFF
--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
 import os
 from collections.abc import Callable, Mapping
@@ -23,6 +24,10 @@ _DISPATCH_TASK_TYPES = {
     "dispatch_paragraph_audio": "generate_paragraph_audio",
     "dispatch_paragraph_subtitles": "generate_paragraph_subtitles",
 }
+
+
+class SynchronousTaskExecutionError(Exception):
+    pass
 
 
 class TaskDispatchService:
@@ -73,13 +78,17 @@ class TaskDispatchService:
         task_id = f"sync-{task_attr}-{run_id}-{uuid4().hex[:12]}"
         sync_self = SimpleNamespace(request=SimpleNamespace(id=task_id, retries=0), max_retries=0)
         try:
-            task.run(sync_self, *(args or []), **(kwargs or {}))
-        except Exception:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(task.run, sync_self, *(args or []), **(kwargs or {}))
+                future.result()
+        except Exception as exc:
             logger.exception(
                 "Synchronous task dispatch failed for %s (run_id=%s)", task_attr, run_id
             )
             self._mark_run_failed(run_id)
-            raise
+            raise SynchronousTaskExecutionError(
+                f"Synchronous task execution failed for {task_attr}"
+            ) from exc
         return task_id
 
     def dispatch_generate_script(
@@ -250,6 +259,15 @@ class TaskDispatchService:
 
         try:
             task_id = dispatcher(**dict(dispatcher_args))
+        except SynchronousTaskExecutionError:
+            if workspace_id_for_reservation is not None and quota_operation_type is not None:
+                from creator_service.usage_service import cancel_workspace_quota_reservation
+
+                await cancel_workspace_quota_reservation(
+                    workspace_id_for_reservation,
+                    quota_operation_type,
+                )
+            raise HTTPException(status_code=500, detail="Task execution failed") from None
         except Exception:
             if workspace_id_for_reservation is not None and quota_operation_type is not None:
                 from creator_service.usage_service import cancel_workspace_quota_reservation

--- a/packages/creator-service/tests/test_lightweight_dispatch.py
+++ b/packages/creator-service/tests/test_lightweight_dispatch.py
@@ -1,0 +1,101 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from creator_service.task_dispatch_service import SynchronousTaskExecutionError, TaskDispatchService
+
+
+def test_lightweight_dispatch_runs_in_thread_without_event_loop_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TaskDispatchService()
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    run_thread_names: list[str] = []
+
+    class _FakeTask:
+        def run(self, *_args: object, **_kwargs: object) -> dict[str, object]:
+            import threading
+
+            run_thread_names.append(threading.current_thread().name)
+            asyncio.run(asyncio.sleep(0))
+            return {"ok": True}
+
+    def fake_import_module(name: str) -> object:
+        if name == "tasks.generate_script":
+            return SimpleNamespace(generate_script=_FakeTask())
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("creator_service.task_dispatch_service.import_module", fake_import_module)
+
+    async def _invoke() -> str:
+        return service.dispatch_generate_script(1, "idea", "model", None)
+
+    task_id = asyncio.run(_invoke())
+
+    assert task_id.startswith("sync-generate_script-1-")
+    assert len(run_thread_names) == 1
+    assert "ThreadPoolExecutor" in run_thread_names[0]
+
+
+def test_lightweight_dispatch_wraps_execution_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TaskDispatchService()
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    mark_failed_calls: list[int] = []
+
+    class _FakeTask:
+        def run(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("boom")
+
+    def fake_import_module(name: str) -> object:
+        if name == "tasks.generate_script":
+            return SimpleNamespace(generate_script=_FakeTask())
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("creator_service.task_dispatch_service.import_module", fake_import_module)
+    monkeypatch.setattr(
+        service, "_mark_run_failed", lambda run_id: mark_failed_calls.append(run_id)
+    )
+
+    with pytest.raises(SynchronousTaskExecutionError):
+        service.dispatch_generate_script(22, "idea", "model", None)
+
+    assert mark_failed_calls == [22]
+
+
+def test_dispatch_uses_celery_path_when_redis_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = TaskDispatchService()
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+
+    apply_async_calls: list[tuple[list[object], dict[str, object], dict[str, str]]] = []
+
+    class _FakeTask:
+        def apply_async(
+            self,
+            *,
+            args: list[object],
+            kwargs: dict[str, object],
+            headers: dict[str, str],
+        ) -> object:
+            apply_async_calls.append((args, kwargs, headers))
+            return SimpleNamespace(id="celery-456")
+
+    def fake_import_module(name: str) -> object:
+        if name == "tasks.generate_script":
+            return SimpleNamespace(generate_script=_FakeTask())
+        if name == "creator_service.telemetry":
+            return SimpleNamespace(get_trace_headers=lambda: {"traceparent": "trace"})
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("creator_service.task_dispatch_service.import_module", fake_import_module)
+
+    task_id = service.dispatch_generate_script(9, "idea", "model", "instructions")
+
+    assert task_id == "celery-456"
+    assert apply_async_calls == [
+        ([9, "idea", "model", "instructions"], {}, {"traceparent": "trace"})
+    ]

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -4,7 +4,10 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from creator_service.task_dispatch_service import TaskDispatchService
+from creator_service.task_dispatch_service import (
+    SynchronousTaskExecutionError,
+    TaskDispatchService,
+)
 
 
 class _FakeRunStorage:
@@ -131,6 +134,34 @@ def test_cas_dispatch_with_rollback_enqueue_failure_rolls_back_stage() -> None:
         "current_stage": "SCRIPT_REVIEW",
         "restart_from": None,
     }
+
+
+def test_cas_dispatch_with_rollback_sync_execution_failure_does_not_rollback() -> None:
+    service = TaskDispatchService()
+    run_service = _FakeRunService()
+
+    def failing_dispatcher(**_: object) -> str:
+        raise SynchronousTaskExecutionError("task failed")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            service.cas_dispatch_with_rollback(
+                run_id=99,
+                expected_stages=frozenset({"SCRIPT_REVIEW"}),
+                target_stage="SCRIPT_GENERATING",
+                dispatcher=failing_dispatcher,
+                dispatcher_args={"run_id": 99},
+                run_service=run_service,
+                rollback_stage="SCRIPT_REVIEW",
+                rollback_restart_from=None,
+                enqueue_error_detail="Failed to enqueue script generation task",
+            )
+        )
+
+    assert exc.value.status_code == 500
+    assert exc.value.detail == "Task execution failed"
+    assert len(run_service.storage.calls) == 1
+    assert run_service.storage.calls[0][1] == {"current_stage": "SCRIPT_GENERATING"}
 
 
 def test_cas_dispatch_with_rollback_record_failure_revokes_and_rolls_back(


### PR DESCRIPTION
## Summary
- Fix P0 lightweight mode dispatch crash where `task.run()` eventually calls `asyncio.run()` while FastAPI already has a running event loop.
- Run lightweight dispatch in a dedicated thread via `ThreadPoolExecutor` so worker task `run_task()` can safely call `asyncio.run()` without event-loop conflicts.
- Add `SynchronousTaskExecutionError` handling so execution failures no longer trigger enqueue rollback, and add end-to-end lightweight dispatch tests for thread execution, failure wrapping, and Celery path parity.

## Problem
When `REDIS_URL` is unset, the sync dispatch path called `task.run()` inline. Worker task code uses `asyncio.run()`, which raises at runtime under FastAPI because the API event loop is already running.

## Behavior Change
- Lightweight mode execution now runs in a separate thread.
- Execution failures are surfaced as 500 `Task execution failed` without stage rollback.
- Enqueue failures still rollback and return the existing 503 behavior.