### PR TITLE
fix: harden CurrentUser auth handling and usage run access checks

### DIFF
--- a/apps/api/src/shorts_api/auth.py
+++ b/apps/api/src/shorts_api/auth.py
@@ -29,10 +29,10 @@ _current_user_ctx: contextvars.ContextVar["CurrentUser | None"] = contextvars.Co
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class CurrentUser:
-    user_id: int | None = None
-    workspace_id: int | None = None
+    user_id: int
+    workspace_id: int
     workspace_name: str | None = None
 
 
@@ -108,7 +108,7 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
         return workspace_ids
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        request.state.user = CurrentUser()
+        request.state.user = None
 
         if request.method == "OPTIONS" and "origin" in request.headers:
             return await call_next(request)
@@ -176,11 +176,11 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
 
 async def get_current_user(request: Request) -> CurrentUser:
     user = getattr(request.state, "user", None)
-    if isinstance(user, CurrentUser) and user.user_id is not None:
+    if isinstance(user, CurrentUser):
         return user
 
     context_user = _current_user_ctx.get()
-    if isinstance(context_user, CurrentUser) and context_user.user_id is not None:
+    if isinstance(context_user, CurrentUser):
         return context_user
 
     api_key = (
@@ -224,7 +224,7 @@ async def require_current_user(request: Request) -> CurrentUser:
     return await get_current_user(request)
 
 
-async def get_authenticated_workspace_id(request: Request) -> int | None:
+async def get_authenticated_workspace_id(request: Request) -> int:
     user = await get_current_user(request)
     return user.workspace_id
 
@@ -233,9 +233,6 @@ async def require_workspace_access(
     workspace_id: int,
     user: CurrentUser = Depends(get_current_user),
 ) -> CurrentUser:
-    if user.user_id is None:
-        raise HTTPException(status_code=401, detail="Invalid user context")
-
     has_access = await workspace_service.check_access(workspace_id, user.user_id)
     if not has_access:
         raise HTTPException(status_code=404, detail="Not found")
@@ -243,7 +240,7 @@ async def require_workspace_access(
     return user
 
 
-async def get_api_key(request: Request) -> str:
+async def require_api_key_header(request: Request) -> str:
     """Dependency that extracts and validates the API key from the request.
 
     Returns the raw API key string. Raises 401 if missing/invalid.
@@ -269,9 +266,6 @@ async def require_run_access(
     from creator_service.project_service import project_service
     from creator_service.run_service import run_service
 
-    if user.user_id is None:
-        raise HTTPException(status_code=401, detail="Authentication required")
-
     run = await run_service.get_run(run_id)
     if run is None:
         raise HTTPException(status_code=404, detail="Run not found")
@@ -296,9 +290,6 @@ async def require_project_access(
     Raises 404 if project not found or workspace mismatch (prevents IDOR).
     """
     from creator_service.project_service import project_service
-
-    if user.user_id is None:
-        raise HTTPException(status_code=401, detail="Authentication required")
 
     project = await project_service.get_project(project_id)
     if project is None or project.workspace_id is None:

--- a/apps/api/src/shorts_api/routes/creator_artifact_download.py
+++ b/apps/api/src/shorts_api/routes/creator_artifact_download.py
@@ -15,8 +15,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["runs"])
 
 
-
-
 @router.get("/runs/{run_id}/artifacts/{artifact_id}/download")
 async def download_artifact(
     run_id: int,
@@ -40,7 +38,7 @@ async def download_artifact(
 
     if project_workspace_id is None:
         raise HTTPException(status_code=404, detail="Run not found")
-    if user.user_id is None or not await workspace_service.check_access(project_workspace_id, user.user_id):
+    if not await workspace_service.check_access(project_workspace_id, user.user_id):
         raise HTTPException(status_code=404, detail="Run not found")
 
     artifact = await artifact_download_service.get_artifact_by_id(artifact_id)

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -31,8 +31,6 @@ async def create_project(
     user: CurrentUser = Depends(require_current_user),
 ) -> dict[str, object]:
     user_workspace_id = user.workspace_id
-    if user_workspace_id is None:
-        raise HTTPException(status_code=401, detail="Workspace context required")
     create_kwargs = {
         "title": request.title,
         "source_type": request.source_type,
@@ -66,9 +64,7 @@ async def update_project(
     project_workspace_id = getattr(project, "workspace_id", None)
     if project_workspace_id is None:
         raise HTTPException(status_code=404, detail="Project not found")
-    if user.user_id is None or not await workspace_service.check_access(
-        project_workspace_id, user.user_id
-    ):
+    if not await workspace_service.check_access(project_workspace_id, user.user_id):
         raise HTTPException(status_code=404, detail="Project not found")
 
     project = await project_service.update_project(project_id, title=request.title)
@@ -88,9 +84,7 @@ async def get_project_detail(
     project_workspace_id = getattr(project, "workspace_id", None)
     if project_workspace_id is None:
         raise HTTPException(status_code=404, detail="Project not found")
-    if user.user_id is None or not await workspace_service.check_access(
-        project_workspace_id, user.user_id
-    ):
+    if not await workspace_service.check_access(project_workspace_id, user.user_id):
         raise HTTPException(status_code=404, detail="Project not found")
 
     return project.model_dump(mode="json")
@@ -103,8 +97,6 @@ async def list_projects(
     user: CurrentUser = Depends(require_current_user),
 ) -> dict[str, object]:
     user_workspace_id = user.workspace_id
-    if user_workspace_id is None:
-        raise HTTPException(status_code=401, detail="Workspace context required")
 
     list_projects_fn = getattr(project_service, "list_projects")
     count_projects_fn = getattr(project_service, "count_projects")
@@ -148,9 +140,7 @@ async def delete_project(
         project_workspace_id = getattr(project, "workspace_id", None)
         if project_workspace_id is None:
             raise HTTPException(status_code=404, detail="Project not found")
-        if user.user_id is None or not await workspace_service.check_access(
-            project_workspace_id, user.user_id
-        ):
+        if not await workspace_service.check_access(project_workspace_id, user.user_id):
             raise HTTPException(status_code=404, detail="Project not found")
 
     run_ids = await _cleanup_project_resources(project_id)

--- a/apps/api/src/shorts_api/routes/creator_usage.py
+++ b/apps/api/src/shorts_api/routes/creator_usage.py
@@ -1,33 +1,30 @@
 # pyright: reportMissingImports=false
 
 from creator_service.usage_service import usage_service
+from creator_service.workspace_service import workspace_service
+from creator_domain.models.pipeline_run import PipelineRun
 from fastapi import APIRouter, Depends, HTTPException, status
 from starlette.requests import Request
 
-from shorts_api.auth import get_api_key, workspace_service
+from shorts_api.auth import (
+    CurrentUser,
+    require_api_key_header,
+    require_run_access,
+)
 
 router = APIRouter(prefix="/usage", tags=["usage"])
-
-
-
-
-def _get_authenticated_context(request: Request) -> tuple[int, int]:
-    user = getattr(request.state, "user", None)
-    if user is None or not user.user_id:
-        raise HTTPException(status_code=401, detail="Authentication required")
-    if not user.workspace_id:
-        raise HTTPException(status_code=403, detail="Workspace context required")
-    return int(user.user_id), int(user.workspace_id)
 
 
 @router.get("/workspace/{workspace_id}")
 async def get_workspace_usage(
     workspace_id: int,
     request: Request,
-    _api_key: str = Depends(get_api_key),
+    _api_key: str = Depends(require_api_key_header),
 ) -> dict[str, object]:
-    authenticated_user_id, authenticated_workspace_id = _get_authenticated_context(request)
-    if not await workspace_service.check_access(workspace_id, authenticated_user_id):
+    user = getattr(request.state, "user", None)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    if not await workspace_service.check_access(workspace_id, user.user_id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Not found",
@@ -39,14 +36,9 @@ async def get_workspace_usage(
 @router.get("/run/{run_id}")
 async def get_run_usage(
     run_id: int,
-    request: Request,
-    _api_key: str = Depends(get_api_key),
+    access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
+    _api_key: str = Depends(require_api_key_header),
 ) -> list[dict[str, object]]:
-    authenticated_user_id, authenticated_workspace_id = _get_authenticated_context(request)
-    if not await workspace_service.check_access(authenticated_workspace_id, authenticated_user_id):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Not found",
-        )
-    events = await usage_service.list_run_events(run_id, workspace_id=authenticated_workspace_id)
+    user, _run = access
+    events = await usage_service.list_run_events(run_id, workspace_id=user.workspace_id)
     return [event.model_dump(mode="json") for event in events]

--- a/apps/api/src/shorts_api/routes/creator_workspaces.py
+++ b/apps/api/src/shorts_api/routes/creator_workspaces.py
@@ -12,9 +12,6 @@ router = APIRouter(prefix="/workspaces", tags=["workspaces"])
 async def list_workspaces(
     user: CurrentUser = Depends(require_current_user),
 ) -> dict[str, list[dict[str, int | str]]]:
-    if user.user_id is None:
-        raise HTTPException(status_code=401, detail="Authentication required")
-
     user_id = user.user_id
     pool = await get_pool()
     async with pool.acquire() as connection:

--- a/apps/api/tests/test_usage_api.py
+++ b/apps/api/tests/test_usage_api.py
@@ -1,9 +1,11 @@
 # pyright: reportMissingImports=false
 
 from types import SimpleNamespace
+from typing import Generator
 
 import pytest
 from fastapi.routing import APIRoute
+from shorts_api.auth import CurrentUser, require_run_access
 from shorts_api.main import app
 
 
@@ -50,10 +52,6 @@ class StubUsageService:
         return [type("Event", (), {"model_dump": lambda self, mode="json": row})()]
 
 
-def _stub_authenticated_context(_request) -> tuple[int, int]:
-    return 10, 5
-
-
 async def _allow_check_access(workspace_id: int, user_id: int) -> bool:
     return True
 
@@ -63,19 +61,20 @@ async def _deny_check_access(workspace_id: int, user_id: int) -> bool:
 
 
 @pytest.fixture
-def stub_usage_service(monkeypatch: pytest.MonkeyPatch) -> StubUsageService:
+def stub_usage_service(monkeypatch: pytest.MonkeyPatch) -> Generator[StubUsageService, None, None]:
     stub = StubUsageService()
     fake_ws = SimpleNamespace(check_access=_allow_check_access)
+
+    async def _require_run_access(run_id: int):
+        return CurrentUser(user_id=10, workspace_id=5), SimpleNamespace(id=run_id)
+
+    app.dependency_overrides[require_run_access] = _require_run_access
     for route in app.routes:
         if isinstance(route, APIRoute) and route.name in {"get_workspace_usage", "get_run_usage"}:
             monkeypatch.setitem(route.endpoint.__globals__, "usage_service", stub)
             monkeypatch.setitem(route.endpoint.__globals__, "workspace_service", fake_ws)
-            monkeypatch.setitem(
-                route.endpoint.__globals__,
-                "_get_authenticated_context",
-                _stub_authenticated_context,
-            )
-    return stub
+    yield stub
+    app.dependency_overrides.pop(require_run_access, None)
 
 
 @pytest.mark.asyncio
@@ -108,11 +107,6 @@ async def test_workspace_usage_for_non_member_returns_404(client, monkeypatch: p
     for route in app.routes:
         if isinstance(route, APIRoute) and route.name in {"get_workspace_usage", "get_run_usage"}:
             monkeypatch.setitem(route.endpoint.__globals__, "workspace_service", fake_ws)
-            monkeypatch.setitem(
-                route.endpoint.__globals__,
-                "_get_authenticated_context",
-                _stub_authenticated_context,
-            )
 
     response = await client.get("/api/creator/usage/workspace/5")
 

--- a/apps/api/tests/test_usage_api_auth.py
+++ b/apps/api/tests/test_usage_api_auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi.routing import APIRoute
 
-from shorts_api.auth import get_api_key
+from shorts_api.auth import require_api_key_header
 from shorts_api.main import app
 
 
@@ -18,4 +18,4 @@ def test_usage_routes_require_api_key_dependency() -> None:
 
     for route in usage_routes.values():
         dependency_calls = [dependency.call for dependency in route.dependant.dependencies]
-        assert get_api_key in dependency_calls
+        assert require_api_key_header in dependency_calls


### PR DESCRIPTION
## Summary
- make `CurrentUser` immutable with required `user_id`/`workspace_id`, and use `request.state.user = None` for anonymous requests
- rename `get_api_key` to `require_api_key_header` and update usage route/test dependencies
- apply `require_run_access` to `/api/creator/usage/run/{run_id}` and update API tests to override the new access dependency

## Validation
- `cd apps/api && python3 -m pytest tests/ --ignore=tests/test_production_safety_limits.py --ignore=tests/test_security_headers.py -q`
- `cd packages/creator-service && python3 -m pytest tests/ -q`
- `cd apps/worker-orchestrator && python3 -m pytest tests/ -q`