### PR TITLE
fix: make process resource guard opt-in (default off)

### DIFF
--- a/apps/api/src/shorts_api/lifecycle.py
+++ b/apps/api/src/shorts_api/lifecycle.py
@@ -43,6 +43,7 @@ def _parse_int_env(name: str, default: int) -> int:
 MAX_MEMORY_MB = _parse_int_env("MAX_MEMORY_MB", 1024)
 MAX_CPU_PERCENT = _parse_int_env("MAX_CPU_PERCENT", 80)
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+ENABLE_PROCESS_RESOURCE_GUARD = os.getenv("ENABLE_PROCESS_RESOURCE_GUARD", "false").lower() in {"1", "true", "yes", "on"}
 
 
 def _apply_resource_limits() -> None:
@@ -106,16 +107,23 @@ def _mark_shutdown() -> None:
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     shutdown_state.is_shutting_down = False
     shutdown_state.inflight_requests = 0
-    _apply_resource_limits()
-    logger.info(
-        "Resource limits configured: MAX_MEMORY_MB=%d, MAX_CPU_PERCENT=%d",
-        MAX_MEMORY_MB,
-        MAX_CPU_PERCENT,
-    )
-    cpu_monitor_task = asyncio.create_task(_monitor_cpu_limit())
+    if ENABLE_PROCESS_RESOURCE_GUARD:
+        _apply_resource_limits()
+        logger.info(
+            "Resource limits configured: MAX_MEMORY_MB=%d, MAX_CPU_PERCENT=%d",
+            MAX_MEMORY_MB,
+            MAX_CPU_PERCENT,
+        )
+        cpu_monitor_task = asyncio.create_task(_monitor_cpu_limit())
+    else:
+        logger.info(
+            "Process resource guard disabled (set ENABLE_PROCESS_RESOURCE_GUARD=true to enable)"
+        )
+        cpu_monitor_task = None
     yield
     _mark_shutdown()
-    cpu_monitor_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await cpu_monitor_task
+    if cpu_monitor_task is not None:
+        cpu_monitor_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await cpu_monitor_task
     await close_pool()

--- a/apps/api/tests/test_resource_guard.py
+++ b/apps/api/tests/test_resource_guard.py
@@ -1,0 +1,154 @@
+"""Test resource guard opt-in functionality via env var."""
+
+import pytest
+
+
+@pytest.fixture
+def mock_apply_resource_limits():
+    """Mock _apply_resource_limits function."""
+    from unittest.mock import patch
+
+    with patch("shorts_api.lifecycle._apply_resource_limits") as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+async def test_resource_guard_disabled_by_default(monkeypatch, mock_apply_resource_limits):
+    """Test that resource guard is disabled when env var is not set."""
+    monkeypatch.delenv("ENABLE_PROCESS_RESOURCE_GUARD", raising=False)
+
+    import importlib
+    import shorts_api.lifecycle as lifecycle_module
+
+    importlib.reload(lifecycle_module)
+
+    assert not lifecycle_module.ENABLE_PROCESS_RESOURCE_GUARD
+
+    from fastapi import FastAPI
+
+    app = FastAPI(lifespan=lifecycle_module.lifespan)
+
+    async with lifecycle_module.lifespan(app):
+        pass
+
+    mock_apply_resource_limits.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resource_guard_disabled_explicitly_false(monkeypatch, mock_apply_resource_limits):
+    """Test that resource guard is disabled when env var is 'false'."""
+    monkeypatch.setenv("ENABLE_PROCESS_RESOURCE_GUARD", "false")
+
+    import importlib
+    import shorts_api.lifecycle as lifecycle_module
+
+    importlib.reload(lifecycle_module)
+
+    assert not lifecycle_module.ENABLE_PROCESS_RESOURCE_GUARD
+
+    from fastapi import FastAPI
+
+    app = FastAPI(lifespan=lifecycle_module.lifespan)
+
+    async with lifecycle_module.lifespan(app):
+        pass
+
+    mock_apply_resource_limits.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resource_guard_disabled_zero(monkeypatch, mock_apply_resource_limits):
+    """Test that resource guard is disabled when env var is '0'."""
+    monkeypatch.setenv("ENABLE_PROCESS_RESOURCE_GUARD", "0")
+
+    import importlib
+    import shorts_api.lifecycle as lifecycle_module
+
+    importlib.reload(lifecycle_module)
+
+    assert not lifecycle_module.ENABLE_PROCESS_RESOURCE_GUARD
+
+    from fastapi import FastAPI
+
+    app = FastAPI(lifespan=lifecycle_module.lifespan)
+
+    async with lifecycle_module.lifespan(app):
+        pass
+
+    mock_apply_resource_limits.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resource_guard_enabled_yes(monkeypatch):
+    """Test that resource guard is enabled when env var is 'yes'."""
+    monkeypatch.setenv("ENABLE_PROCESS_RESOURCE_GUARD", "yes")
+
+    import importlib
+    import shorts_api.lifecycle as lifecycle_module
+
+    importlib.reload(lifecycle_module)
+
+    assert lifecycle_module.ENABLE_PROCESS_RESOURCE_GUARD
+
+
+@pytest.mark.asyncio
+async def test_resource_guard_enabled_on(monkeypatch):
+    """Test that resource guard is enabled when env var is 'on'."""
+    monkeypatch.setenv("ENABLE_PROCESS_RESOURCE_GUARD", "on")
+
+    import importlib
+    import shorts_api.lifecycle as lifecycle_module
+
+    importlib.reload(lifecycle_module)
+
+    assert lifecycle_module.ENABLE_PROCESS_RESOURCE_GUARD
+
+
+@pytest.mark.asyncio
+async def test_resource_guard_enabled_1(monkeypatch):
+    """Test that resource guard is enabled when env var is '1'."""
+    monkeypatch.setenv("ENABLE_PROCESS_RESOURCE_GUARD", "1")
+
+    import importlib
+    import shorts_api.lifecycle as lifecycle_module
+
+    importlib.reload(lifecycle_module)
+
+    assert lifecycle_module.ENABLE_PROCESS_RESOURCE_GUARD
+
+
+@pytest.mark.asyncio
+async def test_resource_guard_enabled_true(monkeypatch):
+    """Test that resource guard is enabled when env var is 'true'."""
+    monkeypatch.setenv("ENABLE_PROCESS_RESOURCE_GUARD", "true")
+
+    import importlib
+    import shorts_api.lifecycle as lifecycle_module
+
+    importlib.reload(lifecycle_module)
+
+    assert lifecycle_module.ENABLE_PROCESS_RESOURCE_GUARD
+
+
+@pytest.mark.asyncio
+async def test_cpu_monitor_task_not_created_when_disabled(monkeypatch):
+    """Test that CPU monitor task is NOT created when resource guard is disabled."""
+    from unittest.mock import patch
+
+    monkeypatch.delenv("ENABLE_PROCESS_RESOURCE_GUARD", raising=False)
+
+    import importlib
+    import shorts_api.lifecycle as lifecycle_module
+
+    importlib.reload(lifecycle_module)
+
+    with patch("asyncio.create_task") as mock_create_task:
+        from fastapi import FastAPI
+
+        app = FastAPI(lifespan=lifecycle_module.lifespan)
+
+        async with lifecycle_module.lifespan(app):
+            pass
+
+        # Verify create_task was NOT called
+        mock_create_task.assert_not_called()


### PR DESCRIPTION
## Summary
- Resource guard (memory limits + CPU monitoring) is now opt-in via `ENABLE_PROCESS_RESOURCE_GUARD` env var
- Default is **OFF** — no resource limits unless explicitly enabled
- All tests pass (316 existing + 8 new)

## Implementation Details
- Added `ENABLE_PROCESS_RESOURCE_GUARD` env var with strict parsing (true/yes/1/on = enabled, all else = disabled)
- Wrapped `_apply_resource_limits()` and `_monitor_cpu_limit()` task creation in conditional
- CPU monitor task cancellation is now conditional (only if task exists)
- Appropriate logging for enabled vs disabled states

## Testing
- 8 new tests covering disabled/enabled states and all valid env var values
- Full test suite passes (316 tests)