### PR TITLE
fix: polish admin API (clean imports, audit enrichment, audit_id)

### DIFF
--- a/apps/api/src/shorts_api/routes/admin.py
+++ b/apps/api/src/shorts_api/routes/admin.py
@@ -12,37 +12,21 @@ handled separately from this API surface.
 
 from __future__ import annotations
 
-import hmac
 import hashlib
+import hmac
 import logging
 import os
-import sys
 import time
+import uuid
 from collections import defaultdict
-from importlib import import_module
-from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from redis import Redis
 from redis.exceptions import RedisError
 
-try:
-    admin_service = import_module("creator_service.admin_service").admin_service
-except ModuleNotFoundError:
-    repo_root = Path(__file__).resolve().parents[5]
-    creator_service_pkg = repo_root / "packages" / "creator-service"
-    if str(creator_service_pkg) not in sys.path:
-        sys.path.append(str(creator_service_pkg))
-    try:
-        creator_service_package = import_module("creator_service")
-        local_creator_service = str(creator_service_pkg / "creator_service")
-        if local_creator_service not in creator_service_package.__path__:
-            creator_service_package.__path__.append(local_creator_service)
-    except Exception:
-        pass
-    admin_service = import_module("creator_service.admin_service").admin_service
+from creator_service.admin_service import admin_service
 logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("admin.audit")
 
@@ -212,6 +196,7 @@ class UnstickRunResponse(BaseModel):
     previous_stage: str | None = None
     current_stage: str | None = None
     status: str | None = None
+    audit_id: str | None = None
     error: str | None = None
 
 
@@ -221,6 +206,7 @@ class CacheClearResponse(BaseModel):
     key_pattern: str
     dry_run: bool
     matched_keys: list[str] = Field(default_factory=list)
+    audit_id: str | None = None
     error: str | None = None
 
 
@@ -254,6 +240,7 @@ async def admin_storage_stats() -> dict[str, Any]:
 @router.post("/runs/{run_id}/unstick", response_model=UnstickRunResponse)
 async def admin_unstick_run(
     run_id: str,
+    request: Request,
     admin_key: str = Depends(require_admin),
     _: None = Depends(require_confirmation_and_rate_limit),
 ) -> dict[str, Any]:
@@ -262,13 +249,26 @@ async def admin_unstick_run(
         if isinstance(admin_key, str)
         else "unknown"
     )
+    request_id = request.headers.get("X-Request-Id", "none")
+    source_ip = request.client.host if request.client else "unknown"
     logger.warning("Admin mutation requested: unstick run_id=%s", run_id)
-    audit_logger.warning("ADMIN_ACTION: unstick_run | run_id=%s | key=%s", run_id, key_fingerprint)
-    return await admin_service.unstick_run(run_id)
+    audit_id = str(uuid.uuid4())
+    audit_logger.warning(
+        "ADMIN_ACTION: unstick_run | run_id=%s | key=%s | request_id=%s | source_ip=%s | audit_id=%s",
+        run_id,
+        key_fingerprint,
+        request_id,
+        source_ip,
+        audit_id,
+    )
+    result = await admin_service.unstick_run(run_id)
+    result["audit_id"] = audit_id
+    return result
 
 
 @router.post("/cache/clear", response_model=CacheClearResponse)
 async def admin_clear_cache(
+    request: Request,
     key_pattern: str | None = Query(default=None),
     dry_run: bool = Query(default=False),
     admin_key: str = Depends(require_admin),
@@ -280,20 +280,33 @@ async def admin_clear_cache(
         if isinstance(admin_key, str)
         else "unknown"
     )
+    request_id = request.headers.get("X-Request-Id", "none")
+    source_ip = request.client.host if request.client else "unknown"
     logger.warning(
         "Admin mutation requested: clear cache key_pattern=%s dry_run=%s",
         safe_pattern,
         dry_run,
     )
+    audit_id = str(uuid.uuid4())
     if key_pattern is None:
         audit_logger.warning(
-            "ADMIN_ACTION: cache_clear | dry_run=%s | key=%s", dry_run, key_fingerprint
+            "ADMIN_ACTION: cache_clear | dry_run=%s | key=%s | request_id=%s | source_ip=%s | audit_id=%s",
+            dry_run,
+            key_fingerprint,
+            request_id,
+            source_ip,
+            audit_id,
         )
     else:
         audit_logger.warning(
-            "ADMIN_ACTION: cache_clear | key_pattern=%s | dry_run=%s | key=%s",
+            "ADMIN_ACTION: cache_clear | key_pattern=%s | dry_run=%s | key=%s | request_id=%s | source_ip=%s | audit_id=%s",
             safe_pattern,
             dry_run,
             key_fingerprint,
+            request_id,
+            source_ip,
+            audit_id,
         )
-    return await admin_service.clear_cache(key_pattern=key_pattern, dry_run=dry_run)
+    result = await admin_service.clear_cache(key_pattern=key_pattern, dry_run=dry_run)
+    result["audit_id"] = audit_id
+    return result

--- a/apps/api/tests/test_admin_audit.py
+++ b/apps/api/tests/test_admin_audit.py
@@ -1,46 +1,190 @@
-import asyncio
+"""Tests for admin API audit enrichment and audit_id tracking."""
+
 import logging
-from importlib import import_module
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from shorts_api.main import app
+from shorts_api.routes.admin import require_admin, require_confirmation_and_rate_limit
 
 
-admin = import_module("shorts_api.routes.admin")
+@pytest.fixture
+def client():
+    """Fixture for FastAPI test client."""
+    return TestClient(app)
 
 
-def test_admin_unstick_run_emits_audit_log(caplog) -> None:
-    async def _fake_unstick_run(run_id: str):
-        return {"ok": True, "run_id": run_id, "current_stage": "SCRIPT_REVIEW"}
+@pytest.fixture
+def mock_admin_service():
+    """Mock admin_service."""
+    with patch("shorts_api.routes.admin.admin_service") as mock:
+        yield mock
 
+
+@pytest.fixture
+def admin_overrides(mock_admin_service):
+    """Setup dependency overrides for admin endpoints."""
+
+    async def _require_admin(x_admin_key: str | None = None) -> str:
+        return x_admin_key or "test-admin-key"
+
+    async def _require_confirmation(
+        x_confirm_action: str | None = None, x_admin_key: str = "test-key"
+    ):
+        return None
+
+    app.dependency_overrides[require_admin] = _require_admin
+    app.dependency_overrides[require_confirmation_and_rate_limit] = _require_confirmation
+    yield
+    app.dependency_overrides.pop(require_admin, None)
+    app.dependency_overrides.pop(require_confirmation_and_rate_limit, None)
+
+
+def test_admin_unstick_run_includes_audit_id(client, mock_admin_service, admin_overrides, caplog):
+    """Test that unstick_run response includes audit_id."""
     caplog.set_level(logging.WARNING, logger="admin.audit")
 
-    original = admin.admin_service.unstick_run
-    admin.admin_service.unstick_run = _fake_unstick_run
-    try:
-        result = asyncio.run(admin.admin_unstick_run("42"))
-    finally:
-        admin.admin_service.unstick_run = original
+    mock_admin_service.unstick_run = AsyncMock(
+        return_value={"ok": True, "run_id": "42", "current_stage": "SCRIPT_REVIEW"}
+    )
 
-    assert result["ok"] is True
-    assert "ADMIN_ACTION: unstick_run | run_id=42" in caplog.text
+    response = client.post(
+        "/api/admin/runs/42/unstick",
+        headers={"X-Admin-Key": "test-admin-key", "X-Confirm-Action": "yes"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["audit_id"] is not None
+    assert len(data["audit_id"]) == 36  # UUID length
+    assert "audit_id=" in caplog.text
 
 
-def test_admin_clear_cache_emits_audit_log(caplog) -> None:
-    async def _fake_clear_cache(*, key_pattern: str | None = None, dry_run: bool = False):
-        return {
+def test_admin_clear_cache_includes_audit_id(client, mock_admin_service, admin_overrides, caplog):
+    """Test that clear_cache response includes audit_id."""
+    caplog.set_level(logging.WARNING, logger="admin.audit")
+
+    mock_admin_service.clear_cache = AsyncMock(
+        return_value={
             "ok": True,
-            "deleted_keys": 0,
-            "key_pattern": key_pattern or "cache:*",
-            "dry_run": dry_run,
-            "matched_keys": [],
+            "deleted_keys": 5,
+            "key_pattern": "cache:test:*",
+            "dry_run": False,
+            "matched_keys": ["cache:test:1", "cache:test:2"],
         }
+    )
 
+    response = client.post(
+        "/api/admin/cache/clear",
+        params={"key_pattern": "cache:test:*", "dry_run": "false"},
+        headers={"X-Admin-Key": "test-admin-key", "X-Confirm-Action": "yes"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["audit_id"] is not None
+    assert len(data["audit_id"]) == 36  # UUID length
+    assert "audit_id=" in caplog.text
+
+
+def test_audit_log_includes_request_id(client, mock_admin_service, admin_overrides, caplog):
+    """Test that audit logs include X-Request-Id from headers."""
     caplog.set_level(logging.WARNING, logger="admin.audit")
 
-    original = admin.admin_service.clear_cache
-    admin.admin_service.clear_cache = _fake_clear_cache
-    try:
-        result = asyncio.run(admin.admin_clear_cache(key_pattern="cache:test:*", dry_run=True))
-    finally:
-        admin.admin_service.clear_cache = original
+    mock_admin_service.unstick_run = AsyncMock(
+        return_value={"ok": True, "run_id": "99", "current_stage": "SCRIPT_REVIEW"}
+    )
 
-    assert result["ok"] is True
-    assert "ADMIN_ACTION: cache_clear | key_pattern=cache:test:* | dry_run=True" in caplog.text
+    response = client.post(
+        "/api/admin/runs/99/unstick",
+        headers={
+            "X-Admin-Key": "test-admin-key",
+            "X-Confirm-Action": "yes",
+            "X-Request-Id": "req-12345",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "request_id=req-12345" in caplog.text
+
+
+def test_audit_log_includes_source_ip(client, mock_admin_service, admin_overrides, caplog):
+    """Test that audit logs include source_ip from request client."""
+    caplog.set_level(logging.WARNING, logger="admin.audit")
+
+    mock_admin_service.unstick_run = AsyncMock(
+        return_value={"ok": True, "run_id": "100", "current_stage": "SCRIPT_REVIEW"}
+    )
+
+    response = client.post(
+        "/api/admin/runs/100/unstick",
+        headers={"X-Admin-Key": "test-admin-key", "X-Confirm-Action": "yes"},
+    )
+
+    assert response.status_code == 200
+    # Note: TestClient automatically includes client info
+    assert "source_ip=" in caplog.text
+
+
+def test_audit_log_has_correct_format(client, mock_admin_service, admin_overrides, caplog):
+    """Test that audit logs follow the expected format with all enriched fields."""
+    caplog.set_level(logging.WARNING, logger="admin.audit")
+
+    mock_admin_service.unstick_run = AsyncMock(
+        return_value={"ok": True, "run_id": "101", "current_stage": "SCRIPT_REVIEW"}
+    )
+
+    response = client.post(
+        "/api/admin/runs/101/unstick",
+        headers={"X-Admin-Key": "test-admin-key", "X-Confirm-Action": "yes"},
+    )
+
+    assert response.status_code == 200
+    log_output = caplog.text
+    # Verify all expected fields are in the audit log
+    assert "ADMIN_ACTION: unstick_run" in log_output
+    assert "run_id=" in log_output
+    assert "key=" in log_output  # key fingerprint
+    assert "request_id=" in log_output
+    assert "source_ip=" in log_output
+    assert "audit_id=" in log_output
+
+
+def test_audit_log_cache_clear_has_correct_format(
+    client, mock_admin_service, admin_overrides, caplog
+):
+    """Test that cache_clear audit logs follow the expected enriched format."""
+    caplog.set_level(logging.WARNING, logger="admin.audit")
+
+    mock_admin_service.clear_cache = AsyncMock(
+        return_value={
+            "ok": True,
+            "deleted_keys": 3,
+            "key_pattern": "session:*",
+            "dry_run": False,
+        }
+    )
+
+    response = client.post(
+        "/api/admin/cache/clear",
+        params={"key_pattern": "session:*", "dry_run": "false"},
+        headers={
+            "X-Admin-Key": "test-admin-key",
+            "X-Confirm-Action": "yes",
+            "X-Request-Id": "req-999",
+        },
+    )
+
+    assert response.status_code == 200
+    log_output = caplog.text
+    # Verify all expected fields for cache_clear
+    assert "ADMIN_ACTION: cache_clear" in log_output
+    assert "key_pattern=session:*" in log_output
+    assert "key=" in log_output  # key fingerprint
+    assert "request_id=req-999" in log_output
+    assert "source_ip=" in log_output
+    assert "audit_id=" in log_output

--- a/apps/api/tests/test_admin_oracle_fixes.py
+++ b/apps/api/tests/test_admin_oracle_fixes.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
+from unittest.mock import MagicMock
 
 
 admin_routes = import_module("shorts_api.routes.admin")
@@ -105,11 +106,16 @@ def test_admin_clear_cache_logs_sanitized_pattern_without_newlines(caplog) -> No
     malicious_pattern = "cache:test:*\nFORGED_LOG\rLINE"
     caplog.set_level(logging.WARNING)
 
+    # Create a fake request object
+    fake_request = MagicMock()
+    fake_request.headers = {}
+    fake_request.client.host = "127.0.0.1"
+
     original = admin_routes.admin_service.clear_cache
     admin_routes.admin_service.clear_cache = _fake_clear_cache
     try:
         result = asyncio.run(
-            admin_routes.admin_clear_cache(key_pattern=malicious_pattern, dry_run=True)
+            admin_routes.admin_clear_cache(request=fake_request, key_pattern=malicious_pattern, dry_run=True)
         )
     finally:
         admin_routes.admin_service.clear_cache = original


### PR DESCRIPTION
## Summary
Polish the admin API with three key improvements for security and observability:

- **Clean imports**: Remove sys.path fallback mechanism, replace with direct import from creator_service.admin_service
- **Audit enrichment**: Add request_id (from X-Request-Id header) and source_ip (from request.client.host) to all audit logs
- **Audit tracking**: Generate audit_id (UUID) for each destructive operation and include in response for traceability

## Changes
- `apps/api/src/shorts_api/routes/admin.py`: Simplify imports, add Request parameter to endpoints, enrich audit logging, add audit_id to responses
- Updated response models: `UnstickRunResponse` and `CacheClearResponse` now include `audit_id: str | None` field
- `apps/api/tests/test_admin_audit.py`: New comprehensive test suite covering all audit enrichments
- `apps/api/tests/test_admin_oracle_fixes.py`: Updated to support new Request parameter

## Verification
✅ All 320 tests pass (excluding pre-broken tests)
✅ New tests verify audit_id appears in both responses and logs
✅ New tests verify request_id and source_ip are logged correctly
✅ Existing admin tests remain functional