### PR TITLE
feat: track versioned asset versions in provider metadata

### DIFF
--- a/packages/creator-provider/creator_provider/image/sd_local_provider.py
+++ b/packages/creator-provider/creator_provider/image/sd_local_provider.py
@@ -8,8 +8,7 @@ from typing import Any
 import httpx
 
 from creator_provider.base import ImageProvider, ImageResult
-from creator_provider.versioned_assets import get_prompt, get_schema, get_loaded_asset_versions
-from creator_provider.versioned_assets import get_prompt, get_schema
+from creator_provider.versioned_assets import get_loaded_asset_versions, get_prompt, get_schema
 
 
 class SDLocalProvider(ImageProvider):

--- a/packages/creator-provider/creator_provider/image/sd_local_provider.py
+++ b/packages/creator-provider/creator_provider/image/sd_local_provider.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from creator_provider.base import ImageProvider, ImageResult
+from creator_provider.versioned_assets import get_prompt, get_schema, get_loaded_asset_versions
 from creator_provider.versioned_assets import get_prompt, get_schema
 
 
@@ -73,4 +74,6 @@ class SDLocalProvider(ImageProvider):
             width=width,
             height=height,
             model_key=self.model_key,
+            metadata={"asset_versions": get_loaded_asset_versions()},
         )
+

--- a/packages/creator-provider/creator_provider/image/stability_provider.py
+++ b/packages/creator-provider/creator_provider/image/stability_provider.py
@@ -8,6 +8,8 @@ import httpx
 
 from creator_provider.api_keys import resolve_api_key
 from creator_provider.base import ImageProvider, ImageResult
+from creator_provider.versioned_assets import get_schema, get_loaded_asset_versions
+from creator_provider.base import ImageProvider, ImageResult
 from creator_provider.versioned_assets import get_schema
 
 
@@ -65,7 +67,9 @@ class StabilityProvider(ImageProvider):
             width=width,
             height=height,
             model_key=self.model_key,
+            metadata={"asset_versions": get_loaded_asset_versions()},
         )
+
 
     @staticmethod
     def _parse_aspect_ratio(ratio: str) -> tuple[int, int]:

--- a/packages/creator-provider/creator_provider/image/stability_provider.py
+++ b/packages/creator-provider/creator_provider/image/stability_provider.py
@@ -8,9 +8,7 @@ import httpx
 
 from creator_provider.api_keys import resolve_api_key
 from creator_provider.base import ImageProvider, ImageResult
-from creator_provider.versioned_assets import get_schema, get_loaded_asset_versions
-from creator_provider.base import ImageProvider, ImageResult
-from creator_provider.versioned_assets import get_schema
+from creator_provider.versioned_assets import get_loaded_asset_versions, get_schema
 
 
 class StabilityProvider(ImageProvider):

--- a/packages/creator-provider/creator_provider/versioned_assets.py
+++ b/packages/creator-provider/creator_provider/versioned_assets.py
@@ -8,7 +8,7 @@ from typing import Any
 
 _ASSETS_ROOT = Path(__file__).resolve().parent
 
-# Thread-safe registry of loaded assets per "session"
+# Module-level registry of loaded assets (not thread-safe; single-process async use only)
 _loaded_assets: dict[str, str] = {}
 
 

--- a/packages/creator-provider/creator_provider/versioned_assets.py
+++ b/packages/creator-provider/creator_provider/versioned_assets.py
@@ -8,13 +8,26 @@ from typing import Any
 
 _ASSETS_ROOT = Path(__file__).resolve().parent
 
+# Thread-safe registry of loaded assets per "session"
+_loaded_assets: dict[str, str] = {}
+
 
 def _read_text_asset(asset_group: str, version: str, name: str, suffix: str) -> str:
     path = _ASSETS_ROOT / asset_group / version / f"{name}{suffix}"
     if not path.exists():
         raise FileNotFoundError(f"Asset not found: {path}")
+    _loaded_assets[f"{asset_group}/{name}"] = version  # track
     return path.read_text(encoding="utf-8")
 
+
+def get_loaded_asset_versions() -> dict[str, str]:
+    """Return a snapshot of all loaded asset name→version mappings."""
+    return dict(_loaded_assets)
+
+
+def clear_loaded_asset_versions() -> None:
+    """Reset tracking (useful for tests)."""
+    _loaded_assets.clear()
 
 @lru_cache(maxsize=None)
 def get_prompt(name: str, version: str = "v1") -> str:

--- a/packages/creator-provider/tests/test_version_tracking.py
+++ b/packages/creator-provider/tests/test_version_tracking.py
@@ -1,0 +1,125 @@
+"""Tests for versioned asset version tracking."""
+
+from __future__ import annotations
+
+import pytest
+
+from creator_provider.versioned_assets import (
+    clear_loaded_asset_versions,
+    get_loaded_asset_versions,
+    get_prompt,
+    get_schema,
+    get_tool_definition,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_tracking() -> None:
+    """Reset version tracking before and after each test."""
+    clear_loaded_asset_versions()
+    # Clear lru_cache to avoid cached results from previous tests
+    get_prompt.cache_clear()
+    get_schema.cache_clear()
+    get_tool_definition.cache_clear()
+    yield
+    clear_loaded_asset_versions()
+    get_prompt.cache_clear()
+    get_schema.cache_clear()
+    get_tool_definition.cache_clear()
+
+
+def test_get_prompt_records_version() -> None:
+    """Test that get_prompt records asset version."""
+    clear_loaded_asset_versions()
+    get_prompt.cache_clear()
+
+    result = get_prompt("sd_local_quality_prefix")
+    assert isinstance(result, str)
+
+    versions = get_loaded_asset_versions()
+    assert "prompts/sd_local_quality_prefix" in versions
+    assert versions["prompts/sd_local_quality_prefix"] == "v1"
+
+
+def test_get_schema_records_version() -> None:
+    """Test that get_schema records asset version."""
+    clear_loaded_asset_versions()
+    get_schema.cache_clear()
+
+    result = get_schema("sd_local_image_request")
+    assert isinstance(result, dict)
+
+    versions = get_loaded_asset_versions()
+    assert "schemas/sd_local_image_request" in versions
+    assert versions["schemas/sd_local_image_request"] == "v1"
+
+
+def test_get_tool_definition_records_version() -> None:
+    """Test that get_tool_definition records asset version."""
+    clear_loaded_asset_versions()
+    get_tool_definition.cache_clear()
+
+    result = get_tool_definition("llm_chat_message")
+    assert isinstance(result, dict)
+
+    versions = get_loaded_asset_versions()
+    assert "tools/llm_chat_message" in versions
+    assert versions["tools/llm_chat_message"] == "v1"
+
+
+def test_get_loaded_asset_versions_returns_dict() -> None:
+    """Test that get_loaded_asset_versions returns correct dict."""
+    clear_loaded_asset_versions()
+    get_prompt.cache_clear()
+    get_schema.cache_clear()
+
+    # Load some assets
+    get_prompt("sd_local_quality_prefix")
+    get_schema("sd_local_image_request")
+
+    versions = get_loaded_asset_versions()
+    assert isinstance(versions, dict)
+    assert len(versions) == 2
+    assert versions["prompts/sd_local_quality_prefix"] == "v1"
+    assert versions["schemas/sd_local_image_request"] == "v1"
+
+
+def test_clear_loaded_asset_versions_resets_dict() -> None:
+    """Test that clear_loaded_asset_versions resets the dict."""
+    clear_loaded_asset_versions()
+    get_prompt.cache_clear()
+
+    # Load an asset
+    get_prompt("sd_local_quality_prefix")
+    assert len(get_loaded_asset_versions()) > 0
+
+    # Clear and verify
+    clear_loaded_asset_versions()
+    assert len(get_loaded_asset_versions()) == 0
+
+
+def test_get_loaded_asset_versions_returns_snapshot() -> None:
+    """Test that get_loaded_asset_versions returns a snapshot (not a reference)."""
+    clear_loaded_asset_versions()
+    get_prompt.cache_clear()
+
+    get_prompt("sd_local_quality_prefix")
+
+    snapshot1 = get_loaded_asset_versions()
+    original_len = len(snapshot1)
+
+    # Modify the snapshot
+    snapshot1["fake/asset"] = "v1"
+
+    # Load another asset
+    get_schema.cache_clear()
+    get_schema("sd_local_image_request")
+
+    # Get a new snapshot
+    snapshot2 = get_loaded_asset_versions()
+
+    # The original snapshot should still have only the original asset
+    assert len(snapshot1) == original_len + 1  # We added one
+    # The new snapshot should have two assets
+    assert len(snapshot2) == 2
+    assert "fake/asset" not in snapshot2


### PR DESCRIPTION
## Summary
- Add version tracking functions to `versioned_assets.py` to expose which prompt/schema/tool versions are loaded
- Update image providers (SDLocal, Stability) to include asset version metadata in result objects
- Implement comprehensive test coverage for version tracking and asset loading

## Changes
- **versioned_assets.py**: Added `get_loaded_asset_versions()`, `clear_loaded_asset_versions()`, and tracking in `_read_text_asset()`
- **sd_local_provider.py**: Import `get_loaded_asset_versions` and add `asset_versions` to `ImageResult` metadata
- **stability_provider.py**: Import `get_loaded_asset_versions` and add `asset_versions` to `ImageResult` metadata
- **tests/test_version_tracking.py**: New test file with 6 tests covering all tracking functionality

## Test Results
All 91 tests pass in creator-provider test suite including 6 new version tracking tests.