### PR TITLE
fix: resolve sync task status rollback and API_KEY prod check mismatch

### DIFF
--- a/apps/api/src/shorts_api/auth.py
+++ b/apps/api/src/shorts_api/auth.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import contextvars
 import hashlib
 import logging
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -73,7 +72,6 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
 
     def __init__(self, app, *, api_key: str | None = None) -> None:
         super().__init__(app)
-        self._api_key = os.getenv("API_KEY") if api_key is None else api_key
 
     async def _get_pool(self):
         try:

--- a/packages/creator-service/creator_service/production_checks.py
+++ b/packages/creator-service/creator_service/production_checks.py
@@ -63,13 +63,6 @@ def validate_production_config(*, service_kind: str = "api") -> None:
 
     requires_http_config = service_kind.lower() == "api"
 
-    if requires_http_config:
-        api_key = os.getenv("API_KEY", "")
-        if not api_key.strip():
-            errors.append(
-                "API_KEY is required in production. Set a strong, random key to protect the API."
-            )
-
     # 2. DATABASE_URL must be set with safe credentials
     database_url = os.getenv("DATABASE_URL", "")
     _check_database_url(database_url, errors)

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -285,7 +285,8 @@ class TaskDispatchService:
 
         try:
             task_type = _DISPATCH_TASK_TYPES.get(getattr(dispatcher, "__name__", ""), "unknown")
-            if task_type != "unknown":
+            is_sync = isinstance(task_id, str) and task_id.startswith("sync-")
+            if task_type != "unknown" and not is_sync:
                 tracking_service = import_module(
                     "creator_service.task_tracking_service"
                 ).task_tracking_service

--- a/packages/creator-service/tests/test_production_checks.py
+++ b/packages/creator-service/tests/test_production_checks.py
@@ -16,7 +16,6 @@ def _prod_env(**overrides: str) -> dict[str, str]:
     """Return a minimal valid production environment, with optional overrides."""
     base = {
         "ENVIRONMENT": "production",
-        "API_KEY": "super-secret-key-12345",
         "DATABASE_URL": "postgresql://user:strong-random-password@db:5432/mydb",
         "CORS_ORIGINS": "https://studio.example.com",
         "REDIS_URL": "redis://redis:6379/0",
@@ -46,11 +45,8 @@ class TestStagingMode:
         with patch.dict(os.environ, env, clear=True):
             validate_production_config()
 
-    def test_staging_rejects_missing_api_key(self) -> None:
-        with (
-            patch.dict(os.environ, _prod_env(ENVIRONMENT="staging", API_KEY=""), clear=True),
-            pytest.raises(ProductionConfigError, match="API_KEY"),
-        ):
+    def test_staging_allows_missing_api_key(self) -> None:
+        with patch.dict(os.environ, _prod_env(ENVIRONMENT="staging"), clear=True):
             validate_production_config()
 
     def test_staging_rejects_weak_database_password(self) -> None:
@@ -75,11 +71,8 @@ class TestProductionMode:
         with patch.dict(os.environ, _prod_env(), clear=True):
             validate_production_config()
 
-    def test_missing_api_key(self) -> None:
-        with (
-            patch.dict(os.environ, _prod_env(API_KEY=""), clear=True),
-            pytest.raises(ProductionConfigError, match="API_KEY"),
-        ):
+    def test_valid_config_passes_without_api_key(self) -> None:
+        with patch.dict(os.environ, _prod_env(), clear=True):
             validate_production_config()
 
     def test_database_url_with_default_password(self) -> None:
@@ -144,14 +137,13 @@ class TestProductionMode:
         with (
             patch.dict(
                 os.environ,
-                _prod_env(API_KEY="", DATABASE_URL=""),
+                _prod_env(DATABASE_URL=""),
                 clear=True,
             ),
             pytest.raises(ProductionConfigError) as exc_info,
         ):
             validate_production_config()
         msg = str(exc_info.value)
-        assert "API_KEY" in msg
         assert "DATABASE_URL" in msg
 
     def test_relative_artifact_root_warns(self) -> None:

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -223,3 +223,81 @@ def test_cas_dispatch_with_rollback_record_failure_revokes_and_rolls_back(
         "current_stage": "AUDIO_GENERATING",
         "restart_from": "AUDIO_GENERATING",
     }
+
+
+def test_cas_dispatch_with_rollback_sync_dispatch_skips_record_task_queued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TaskDispatchService()
+    run_service = _FakeRunService()
+    queued_calls: list[tuple[int, str, str]] = []
+
+    def dispatch_generate_script(**_: object) -> str:
+        return "sync-generate_script-7-abc123"
+
+    class _TrackingService:
+        async def record_task_queued(self, run_id: int, task_type: str, task_id: str) -> None:
+            queued_calls.append((run_id, task_type, task_id))
+
+    def fake_import_module(name: str) -> object:
+        if name == "creator_service.task_tracking_service":
+            return SimpleNamespace(task_tracking_service=_TrackingService())
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("creator_service.task_dispatch_service.import_module", fake_import_module)
+
+    result = asyncio.run(
+        service.cas_dispatch_with_rollback(
+            run_id=7,
+            expected_stages=frozenset({"SCRIPT_REVIEW"}),
+            target_stage="SCRIPT_GENERATING",
+            dispatcher=dispatch_generate_script,
+            dispatcher_args={"run_id": 7},
+            run_service=run_service,
+            rollback_stage="SCRIPT_REVIEW",
+            rollback_restart_from=None,
+            enqueue_error_detail="Failed to enqueue script generation task",
+        )
+    )
+
+    assert result["task_id"] == "sync-generate_script-7-abc123"
+    assert queued_calls == []
+
+
+def test_cas_dispatch_with_rollback_celery_dispatch_records_task_queued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TaskDispatchService()
+    run_service = _FakeRunService()
+    queued_calls: list[tuple[int, str, str]] = []
+
+    def dispatch_generate_script(**_: object) -> str:
+        return "celery-123"
+
+    class _TrackingService:
+        async def record_task_queued(self, run_id: int, task_type: str, task_id: str) -> None:
+            queued_calls.append((run_id, task_type, task_id))
+
+    def fake_import_module(name: str) -> object:
+        if name == "creator_service.task_tracking_service":
+            return SimpleNamespace(task_tracking_service=_TrackingService())
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("creator_service.task_dispatch_service.import_module", fake_import_module)
+
+    result = asyncio.run(
+        service.cas_dispatch_with_rollback(
+            run_id=7,
+            expected_stages=frozenset({"SCRIPT_REVIEW"}),
+            target_stage="SCRIPT_GENERATING",
+            dispatcher=dispatch_generate_script,
+            dispatcher_args={"run_id": 7},
+            run_service=run_service,
+            rollback_stage="SCRIPT_REVIEW",
+            rollback_restart_from=None,
+            enqueue_error_detail="Failed to enqueue script generation task",
+        )
+    )
+
+    assert result["task_id"] == "celery-123"
+    assert queued_calls == [(7, "generate_script", "celery-123")]


### PR DESCRIPTION
## Summary
- Fix sync dispatch tracking regression by skipping `record_task_queued` for `sync-` task IDs in `cas_dispatch_with_rollback`, preventing post-success rollback to `queued`.
- Keep Celery behavior unchanged and add tests proving sync dispatch does not queue-track while Celery dispatch still does.
- Remove obsolete production `API_KEY` env requirement and unused `ApiKeyMiddleware` `self._api_key` assignment, with tests validating production checks pass without `API_KEY`.

## Validation
- `cd packages/creator-service && python3 -m pytest tests/ -q`
- `cd apps/api && python3 -m pytest tests/ --ignore=tests/test_production_safety_limits.py --ignore=tests/test_security_headers.py -q`