### PR TITLE
fix: close P0 provider key leak and api_key auth subject merge

### DIFF
--- a/packages/creator-provider/creator_provider/image/imagen_provider.py
+++ b/packages/creator-provider/creator_provider/image/imagen_provider.py
@@ -9,6 +9,7 @@ import httpx
 
 from creator_provider.api_keys import resolve_api_key
 from creator_provider.base import ImageProvider, ImageResult
+from creator_provider.exceptions import ProviderError
 
 # Map common width x height to Imagen API aspectRatio values.
 _ASPECT_RATIOS: dict[tuple[int, int], str] = {
@@ -52,10 +53,7 @@ class ImagenProvider(ImageProvider):
         aspect_ratio = merged.get("aspect_ratio", _resolve_aspect_ratio(width, height))
         timeout = float(merged.get("timeout", 120.0))
 
-        url = (
-            f"{self.endpoint}/v1beta/models/{self.model_key}"
-            f":generateImages?key={self.api_key}"
-        )
+        url = f"{self.endpoint}/v1beta/models/{self.model_key}:generateImages"
         payload = {
             "prompt": prompt,
             "config": {
@@ -63,14 +61,19 @@ class ImagenProvider(ImageProvider):
                 "aspectRatio": aspect_ratio,
             },
         }
-        headers = {"Content-Type": "application/json"}
+        if self.api_key is None:
+            raise ProviderError("Imagen API key is not configured")
+        headers = {
+            "Content-Type": "application/json",
+            "x-goog-api-key": self.api_key,
+        }
 
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:
                 response = await client.post(url, json=payload, headers=headers)
                 response.raise_for_status()
         except httpx.HTTPError as exc:
-            raise RuntimeError(f"Imagen API request failed: {exc}") from exc
+            raise ProviderError("Imagen API request failed") from exc
 
         data = response.json()
         images = data.get("generatedImages", [])

--- a/packages/creator-provider/tests/test_external_image_providers.py
+++ b/packages/creator-provider/tests/test_external_image_providers.py
@@ -67,7 +67,10 @@ class TestDalleProvider:
             from creator_provider.image.dalle_provider import DalleProvider
 
             provider = DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3")
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="DALL-E API request failed"):
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(RuntimeError, match="DALL-E API request failed"),
+            ):
                 await provider.generate("test prompt")
 
     @pytest.mark.asyncio
@@ -80,7 +83,10 @@ class TestDalleProvider:
             from creator_provider.image.dalle_provider import DalleProvider
 
             provider = DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3")
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="no images"):
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(RuntimeError, match="no images"),
+            ):
                 await provider.generate("test prompt")
 
 
@@ -154,7 +160,10 @@ class TestStabilityProvider:
                 endpoint="https://api.stability.ai",
                 model_key="sd3-medium",
             )
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="Stability AI API request failed"):
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(RuntimeError, match="Stability AI API request failed"),
+            ):
                 await provider.generate("test prompt")
 
     @pytest.mark.asyncio
@@ -170,7 +179,10 @@ class TestStabilityProvider:
                 endpoint="https://api.stability.ai",
                 model_key="sd3-medium",
             )
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="empty response"):
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(RuntimeError, match="empty response"),
+            ):
                 await provider.generate("test prompt")
 
 
@@ -243,14 +255,53 @@ class TestImagenProvider:
         mock_response.raise_for_status.side_effect = status_error
 
         with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+            from creator_provider.exceptions import ProviderError
             from creator_provider.image.imagen_provider import ImagenProvider
 
             provider = ImagenProvider(
                 endpoint="https://generativelanguage.googleapis.com",
                 model_key="imagen-3",
             )
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="Imagen API request failed"):
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(ProviderError, match="Imagen API request failed"),
+            ):
                 await provider.generate("test prompt")
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error_does_not_leak_api_key_and_uses_header_auth(self):
+        api_key = "gk-sensitive-key"
+        request = httpx.Request(
+            "POST",
+            "https://generativelanguage.googleapis.com/v1beta/models/imagen-3:generateImages",
+        )
+        response = httpx.Response(401, request=request)
+        status_error = httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = status_error
+
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": api_key}):
+            from creator_provider.exceptions import ProviderError
+            from creator_provider.image.imagen_provider import ImagenProvider
+
+            provider = ImagenProvider(
+                endpoint="https://generativelanguage.googleapis.com",
+                model_key="imagen-3",
+            )
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post,
+                pytest.raises(ProviderError, match="Imagen API request failed") as exc_info,
+            ):
+                await provider.generate("test prompt")
+
+        called_url = mock_post.call_args.args[0]
+        called_headers = mock_post.call_args.kwargs["headers"]
+
+        assert "?key=" not in called_url
+        assert api_key not in called_url
+        assert called_headers["x-goog-api-key"] == api_key
+        assert api_key not in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_generate_empty_response_raises(self):
@@ -265,5 +316,8 @@ class TestImagenProvider:
                 endpoint="https://generativelanguage.googleapis.com",
                 model_key="imagen-3",
             )
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="no images"):
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(RuntimeError, match="no images"),
+            ):
                 await provider.generate("test prompt")

--- a/packages/creator-service/creator_service/postgres_user_storage.py
+++ b/packages/creator-service/creator_service/postgres_user_storage.py
@@ -7,6 +7,10 @@ from .db import fetch_all, fetch_one
 
 class PostgresUserStorage:
     async def create_user(self, payload: dict[str, Any]) -> dict[str, Any]:
+        auth_subject = str(payload.get("auth_subject", "")).strip()
+        if not auth_subject:
+            raise ValueError("auth_subject must not be empty")
+
         row = await fetch_one(
             """
             INSERT INTO users (email, name, auth_provider, auth_subject)
@@ -21,7 +25,7 @@ class PostgresUserStorage:
             payload.get("email"),
             payload.get("name"),
             payload.get("auth_provider", "api_key"),
-            payload.get("auth_subject", ""),
+            auth_subject,
         )
         if row is None:
             raise ValueError("Failed to create user")

--- a/packages/creator-service/creator_service/user_service.py
+++ b/packages/creator-service/creator_service/user_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import hashlib
 import re
 import secrets
 from typing import Any, Protocol
@@ -29,6 +30,10 @@ class InMemoryUserStorage:
         self._next_id = 1
 
     async def create_user(self, payload: dict[str, Any]) -> dict[str, Any]:
+        auth_subject = str(payload.get("auth_subject", "")).strip()
+        if not auth_subject:
+            raise ValueError("auth_subject must not be empty")
+
         now = datetime.now(timezone.utc)
         row = {
             "id": self._next_id,
@@ -36,7 +41,7 @@ class InMemoryUserStorage:
             "name": payload.get("name"),
             "workspace_id": payload.get("workspace_id"),
             "auth_provider": payload.get("auth_provider", "api_key"),
-            "auth_subject": payload.get("auth_subject", ""),
+            "auth_subject": auth_subject,
             "created_at": now,
             "updated_at": now,
         }
@@ -78,7 +83,13 @@ class UserService:
         auth_provider: str = "api_key",
         auth_subject: str = "",
     ) -> User:
-        existing = await self.storage.get_user_by_auth(auth_provider, auth_subject)
+        resolved_auth_subject = auth_subject.strip()
+        if not resolved_auth_subject and auth_provider == "api_key":
+            resolved_auth_subject = hashlib.sha256(email.encode()).hexdigest()[:16]
+        if not resolved_auth_subject:
+            raise ValueError("auth_subject must not be empty")
+
+        existing = await self.storage.get_user_by_auth(auth_provider, resolved_auth_subject)
         if existing is not None:
             user = User.model_validate(existing)
             return await self._attach_workspace(user)
@@ -88,7 +99,7 @@ class UserService:
                 "email": email,
                 "name": name,
                 "auth_provider": auth_provider,
-                "auth_subject": auth_subject,
+                "auth_subject": resolved_auth_subject,
             }
         )
         user = User.model_validate(row)

--- a/packages/creator-service/tests/test_user_service.py
+++ b/packages/creator-service/tests/test_user_service.py
@@ -32,3 +32,28 @@ def test_get_user_returns_none_for_missing_user() -> None:
     service = UserService(InMemoryUserStorage())
 
     assert run(service.get_user(999)) is None
+
+
+def test_create_or_get_user_api_key_blank_subject_does_not_merge_accounts() -> None:
+    service = UserService(InMemoryUserStorage())
+
+    first = run(
+        service.create_or_get_user(
+            email="first@example.com",
+            name="First",
+            auth_provider="api_key",
+            auth_subject="",
+        )
+    )
+    second = run(
+        service.create_or_get_user(
+            email="second@example.com",
+            name="Second",
+            auth_provider="api_key",
+            auth_subject="",
+        )
+    )
+
+    assert first.id != second.id
+    assert first.auth_subject != ""
+    assert second.auth_subject != ""


### PR DESCRIPTION
## Summary
- **#465**: Move Imagen API key from URL query param to `x-goog-api-key` header; sanitize error messages to prevent key leakage via exception strings
- **#467**: Generate deterministic `auth_subject` from email hash when blank, preventing account merging for api_key auth users

## Changes
- `imagen_provider.py`: API key sent via header instead of URL; errors raise `ProviderError` without leaking credentials
- `user_service.py`: Empty `auth_subject` resolved to `sha256(email)[:16]` for api_key provider; guard rejects blank subjects
- New tests verifying key is not in URL/error messages, and distinct users with blank subjects get separate records

## Test Results
- creator-provider: 92 passed ✅
- creator-service: 304 passed ✅  
- API: 320 passed ✅

Closes #465, closes #467