### PR TITLE
fix: remove trusted caller params from paragraph tasks and add path validation

### DIFF
--- a/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
@@ -6,7 +6,6 @@ import logging
 from typing import TYPE_CHECKING, Any, Literal
 
 from creator_service.audio_service import audio_service
-from creator_service.run_service import run_service
 from creator_service.script_service import script_service
 from creator_service.subtitle_service import subtitle_service
 from creator_service.task_tracking_service import task_tracking_service
@@ -239,7 +238,6 @@ async def generate_paragraph_audio_endpoint(
         task_id = dispatch_paragraph_audio(
             run_id=run_id,
             section_id=section_id,
-            section_text=section_text,
             tts_model=effective.tts_model,
             voice=effective.voice,
         )
@@ -290,7 +288,6 @@ async def generate_paragraph_subtitles_endpoint(
         task_id = dispatch_paragraph_subtitles(
             run_id=run_id,
             section_id=section_id,
-            audio_path=audio.path,
             subtitle_model=effective.subtitle_model,
             subtitle_format=effective.subtitle_format,
         )
@@ -347,7 +344,6 @@ async def generate_all_paragraph_audio(
             tid = dispatch_paragraph_audio(
                 run_id=run_id,
                 section_id=section.section_id,
-                section_text=section.text,
                 tts_model=effective.tts_model,
                 voice=effective.voice,
             )
@@ -415,7 +411,6 @@ async def generate_all_paragraph_subtitles(
             tid = dispatch_paragraph_subtitles(
                 run_id=run_id,
                 section_id=audio.section_id,
-                audio_path=audio.path,
                 subtitle_model=effective.subtitle_model,
                 subtitle_format=effective.subtitle_format,
             )

--- a/apps/worker-orchestrator/tasks/generate_paragraph_audio.py
+++ b/apps/worker-orchestrator/tasks/generate_paragraph_audio.py
@@ -67,7 +67,6 @@ def generate_paragraph_audio(
     self,
     run_id: int,
     section_id: str,
-    section_text: str,
     tts_model: str = "qwen3-tts",
     voice: str = "default",
 ) -> dict[str, object]:
@@ -83,6 +82,24 @@ def generate_paragraph_audio(
     )
 
     async def execute(ctx: TaskContext) -> TaskResult:
+        run = await _run_service.storage.get_run(run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        script_data = run.get("script_data") or {}
+        sections = script_data.get("sections") if isinstance(script_data, dict) else []
+        section_text: str | None = None
+        if isinstance(sections, list):
+            for section in sections:
+                if not isinstance(section, dict):
+                    continue
+                if section.get("section_id") == section_id:
+                    raw_text = section.get("text")
+                    if isinstance(raw_text, str):
+                        section_text = raw_text
+                    break
+        if section_text is None:
+            raise ValueError(f"Section '{section_id}' not found for run {run_id}")
+
         registry = ProviderRegistry.create_default()
         entry = registry.resolve(tts_model)
         provider = registry.get_provider(tts_model)

--- a/apps/worker-orchestrator/tasks/generate_paragraph_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_paragraph_subtitles.py
@@ -21,13 +21,21 @@ from creator_domain.sanitize import sanitize_path_component
 from creator_provider.exceptions import ProviderError, ProviderTimeoutError, RateLimitError
 from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
 from creator_provider.registry import ProviderRegistry
+from creator_service.audio_service import audio_service as _audio_service
 from creator_service.cost_config import COST_PARAGRAPH_SUBTITLE
 from creator_service.run_service import run_service as _run_service
 from creator_service.subtitle_service import subtitle_service as _subtitle_service
 from creator_service.telemetry import trace_task
 from creator_service.usage_service import record_provider_call
 from tasks import task_runner as _task_runner
-from tasks.task_runner import GpuLockContext, TaskContext, TaskResult, TaskRunnerConfig, run_task
+from tasks.task_runner import (
+    GpuLockContext,
+    TaskContext,
+    TaskResult,
+    TaskRunnerConfig,
+    run_task,
+    validate_artifact_path,
+)
 
 logger = logging.getLogger(__name__)
 _ARTIFACT_ROOT = os.getenv("ARTIFACT_ROOT", "data/artifacts")
@@ -55,7 +63,6 @@ def generate_paragraph_subtitles(
     self,
     run_id: int,
     section_id: str,
-    audio_path: str,
     subtitle_model: str = "whisper-small",
     subtitle_format: str = "srt",
 ) -> dict[str, object]:
@@ -75,6 +82,10 @@ def generate_paragraph_subtitles(
             raise ValueError(
                 f"Invalid subtitle_format: {subtitle_format!r}. Must be 'srt' or 'vtt'."
             )
+        audio_artifact = await _audio_service.get_paragraph_audio(run_id, section_id)
+        if audio_artifact is None:
+            raise RuntimeError(f"Audio file not found for run {run_id} section {section_id}")
+        audio_path = validate_artifact_path(audio_artifact.path, _ARTIFACT_ROOT)
         if not os.path.exists(audio_path):
             raise RuntimeError(f"Audio file not found: {audio_path}")
 

--- a/apps/worker-orchestrator/tasks/task_runner.py
+++ b/apps/worker-orchestrator/tasks/task_runner.py
@@ -106,6 +106,14 @@ def _get_redis_client() -> Any | None:
     return redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
 
 
+def validate_artifact_path(path: str, artifact_root: str) -> str:
+    resolved = os.path.realpath(path)
+    root = os.path.realpath(artifact_root)
+    if not resolved.startswith(root + os.sep) and resolved != root:
+        raise ValueError(f"Path {path!r} is outside artifact root")
+    return resolved
+
+
 async def _run_task_inner(
     run_id: int,
     task_id: str,

--- a/apps/worker-orchestrator/tests/test_generate_paragraph_audio.py
+++ b/apps/worker-orchestrator/tests/test_generate_paragraph_audio.py
@@ -64,6 +64,23 @@ class FakeAudioService:
         return FakeAudioArtifact(id=self.artifact_id, path=path)
 
 
+class FakeRunStorage:
+    def __init__(self, run_row: dict[str, Any] | None) -> None:
+        self.run_row = run_row
+
+    async def get_run(self, run_id: int) -> dict[str, Any] | None:
+        if self.run_row is None:
+            return None
+        row = dict(self.run_row)
+        row["id"] = run_id
+        return row
+
+
+class FakeRunService:
+    def __init__(self, run_row: dict[str, Any] | None) -> None:
+        self.storage = FakeRunStorage(run_row)
+
+
 class FakeRegistry:
     def __init__(self, entry: FakeEntry, provider: FakeProvider) -> None:
         self.entry = entry
@@ -102,12 +119,24 @@ def test_generate_paragraph_audio_success(monkeypatch: pytest.MonkeyPatch) -> No
     _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
 
     audio_service = FakeAudioService(artifact_id=33)
+    monkeypatch.setattr(
+        module,
+        "_run_service",
+        FakeRunService(
+            {
+                "script_data": {
+                    "sections": [
+                        {"section_id": "hook-1", "text": "Hello paragraph"},
+                    ]
+                }
+            }
+        ),
+    )
     monkeypatch.setattr(module, "_audio_service", audio_service)
 
     result = _invoke_task(
         run_id=101,
         section_id="hook-1",
-        section_text="Hello paragraph",
         tts_model="qwen3-tts",
         voice="en_US-lessac-medium",
     )
@@ -162,9 +191,22 @@ def test_generate_paragraph_audio_with_gpu_lock(monkeypatch: pytest.MonkeyPatch)
     )
 
     audio_service = FakeAudioService(artifact_id=61)
+    monkeypatch.setattr(
+        module,
+        "_run_service",
+        FakeRunService(
+            {
+                "script_data": {
+                    "sections": [
+                        {"section_id": "hook-2", "text": "Lock paragraph"},
+                    ]
+                }
+            }
+        ),
+    )
     monkeypatch.setattr(module, "_audio_service", audio_service)
 
-    result = _invoke_task(run_id=105, section_id="hook-2", section_text="Lock paragraph")
+    result = _invoke_task(run_id=105, section_id="hook-2")
 
     assert result["status"] == "success"
     assert result["gpu_lock_acquired_at"] is not None
@@ -189,10 +231,23 @@ def test_generate_paragraph_audio_provider_failure(monkeypatch: pytest.MonkeyPat
     )
 
     audio_service = FakeAudioService()
+    monkeypatch.setattr(
+        module,
+        "_run_service",
+        FakeRunService(
+            {
+                "script_data": {
+                    "sections": [
+                        {"section_id": "hook-3", "text": "Failure paragraph"},
+                    ]
+                }
+            }
+        ),
+    )
     monkeypatch.setattr(module, "_audio_service", audio_service)
 
     with pytest.raises(module.ProviderError, match="Provider failed paragraph audio generation"):
-        _invoke_task(run_id=106, section_id="hook-3", section_text="Failure paragraph")
+        _invoke_task(run_id=106, section_id="hook-3")
 
     assert lock_calls == ["para-106-hook-3"]
     assert release_calls == ["para-106-hook-3"]
@@ -205,10 +260,23 @@ def test_generate_paragraph_audio_sanitizes_section_id(monkeypatch: pytest.Monke
     _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
 
     audio_service = FakeAudioService(artifact_id=78)
+    monkeypatch.setattr(
+        module,
+        "_run_service",
+        FakeRunService(
+            {
+                "script_data": {
+                    "sections": [
+                        {"section_id": "hook:1", "text": "Sanitize me"},
+                    ]
+                }
+            }
+        ),
+    )
     monkeypatch.setattr(module, "_audio_service", audio_service)
     monkeypatch.setattr(module, "sanitize_path_component", lambda value, label: f"san-{value}")
 
-    result = _invoke_task(run_id=107, section_id="hook:1", section_text="Sanitize me")
+    result = _invoke_task(run_id=107, section_id="hook:1")
 
     assert result["status"] == "success"
     assert result["audio_path"] == "data/artifacts/107/audio/san-hook:1.wav"
@@ -216,3 +284,17 @@ def test_generate_paragraph_audio_sanitizes_section_id(monkeypatch: pytest.Monke
     assert params is not None
     assert params["output_path"] == "data/artifacts/107/audio/san-hook:1.wav"
     assert audio_service.calls[0]["path"] == "data/artifacts/107/audio/san-hook:1.wav"
+
+
+def test_generate_paragraph_audio_section_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
+
+    monkeypatch.setattr(module, "_run_service", FakeRunService({"script_data": {"sections": []}}))
+    monkeypatch.setattr(module, "_audio_service", FakeAudioService())
+
+    with pytest.raises(ValueError, match="Section 'missing' not found"):
+        _invoke_task(run_id=108, section_id="missing")
+
+    assert provider.calls == []

--- a/apps/worker-orchestrator/tests/test_generate_paragraph_subtitles.py
+++ b/apps/worker-orchestrator/tests/test_generate_paragraph_subtitles.py
@@ -33,6 +33,11 @@ class FakeSubtitleArtifact:
     path: str
 
 
+@dataclass
+class FakeAudioArtifact:
+    path: str
+
+
 class FakeSubtitleService:
     def __init__(self, artifact_id: int = 1) -> None:
         self.artifact_id = artifact_id
@@ -57,6 +62,16 @@ class FakeSubtitleService:
         }
         self.calls.append(call_data)
         return FakeSubtitleArtifact(id=self.artifact_id, path=path)
+
+
+class FakeAudioService:
+    def __init__(self, artifact: FakeAudioArtifact | None = None) -> None:
+        self.artifact = artifact
+        self.calls: list[tuple[int, str]] = []
+
+    async def get_paragraph_audio(self, run_id: int, section_id: str) -> FakeAudioArtifact | None:
+        self.calls.append((run_id, section_id))
+        return self.artifact
 
 
 class FakeRegistry:
@@ -97,13 +112,17 @@ def test_generate_paragraph_subtitles_success(monkeypatch: pytest.MonkeyPatch) -
     _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
 
     subtitle_service = FakeSubtitleService(artifact_id=33)
+    audio_service = FakeAudioService(
+        artifact=FakeAudioArtifact(path="data/artifacts/101/audio/hook-1.wav")
+    )
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
+    monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(module, "validate_artifact_path", lambda path, _root: path)
     monkeypatch.setattr(module.os.path, "exists", lambda _: True)
 
     result = _invoke_task(
         run_id=101,
         section_id="hook-1",
-        audio_path="data/artifacts/101/audio/hook-1.wav",
         subtitle_model="whisper-small",
         subtitle_format="srt",
     )
@@ -148,11 +167,12 @@ def test_generate_paragraph_subtitles_audio_not_found(monkeypatch: pytest.Monkey
     )
 
     subtitle_service = FakeSubtitleService()
+    audio_service = FakeAudioService(artifact=None)
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
-    monkeypatch.setattr(module.os.path, "exists", lambda _: False)
+    monkeypatch.setattr(module, "_audio_service", audio_service)
 
     with pytest.raises(RuntimeError, match="Audio file not found"):
-        _invoke_task(run_id=102, section_id="hook-2", audio_path="missing.wav")
+        _invoke_task(run_id=102, section_id="hook-2")
 
     assert provider.calls == []
     assert subtitle_service.calls == []
@@ -174,10 +194,13 @@ def test_generate_paragraph_subtitles_with_gpu_lock(monkeypatch: pytest.MonkeyPa
     )
 
     subtitle_service = FakeSubtitleService(artifact_id=61)
+    audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="audio.wav"))
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
+    monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(module, "validate_artifact_path", lambda path, _root: path)
     monkeypatch.setattr(module.os.path, "exists", lambda _: True)
 
-    result = _invoke_task(run_id=103, section_id="hook-3", audio_path="audio.wav")
+    result = _invoke_task(run_id=103, section_id="hook-3")
 
     assert result["status"] == "success"
     assert result["gpu_lock_acquired_at"] is not None
@@ -192,13 +215,35 @@ def test_generate_paragraph_subtitles_provider_failure(monkeypatch: pytest.Monke
     _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
 
     subtitle_service = FakeSubtitleService()
+    audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="audio.wav"))
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
+    monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(module, "validate_artifact_path", lambda path, _root: path)
     monkeypatch.setattr(module.os.path, "exists", lambda _: True)
 
     with pytest.raises(
         module.ProviderError,
         match="Provider failed paragraph subtitle generation",
     ):
-        _invoke_task(run_id=104, section_id="hook-4", audio_path="audio.wav")
+        _invoke_task(run_id=104, section_id="hook-4")
+
+    assert subtitle_service.calls == []
+
+
+def test_generate_paragraph_subtitles_rejects_audio_path_outside_artifact_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = FakeProvider()
+    _patch_registry(
+        monkeypatch, FakeRegistry(entry=FakeEntry(requires_gpu=False), provider=provider)
+    )
+
+    subtitle_service = FakeSubtitleService()
+    audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="/etc/passwd"))
+    monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
+    monkeypatch.setattr(module, "_audio_service", audio_service)
+
+    with pytest.raises(ValueError, match="outside artifact root"):
+        _invoke_task(run_id=105, section_id="hook-5")
 
     assert subtitle_service.calls == []

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -164,7 +164,7 @@ class TaskDispatchService:
         )
 
     def dispatch_paragraph_audio(
-        self, run_id: int, section_id: str, section_text: str, tts_model: str, voice: str
+        self, run_id: int, section_id: str, tts_model: str, voice: str
     ) -> str:
         return self._dispatch_task(
             module_name="tasks.generate_paragraph_audio",
@@ -173,7 +173,6 @@ class TaskDispatchService:
             args=[run_id],
             kwargs={
                 "section_id": section_id,
-                "section_text": section_text,
                 "tts_model": tts_model,
                 "voice": voice,
             },
@@ -183,7 +182,6 @@ class TaskDispatchService:
         self,
         run_id: int,
         section_id: str,
-        audio_path: str,
         subtitle_model: str,
         subtitle_format: str,
     ) -> str:
@@ -194,7 +192,6 @@ class TaskDispatchService:
             args=[run_id],
             kwargs={
                 "section_id": section_id,
-                "audio_path": audio_path,
                 "subtitle_model": subtitle_model,
                 "subtitle_format": subtitle_format,
             },
@@ -372,13 +369,10 @@ def dispatch_generate_scene_image(
     )
 
 
-def dispatch_paragraph_audio(
-    run_id: int, section_id: str, section_text: str, tts_model: str, voice: str
-) -> str:
+def dispatch_paragraph_audio(run_id: int, section_id: str, tts_model: str, voice: str) -> str:
     return task_dispatch_service.dispatch_paragraph_audio(
         run_id,
         section_id,
-        section_text,
         tts_model,
         voice,
     )
@@ -387,14 +381,12 @@ def dispatch_paragraph_audio(
 def dispatch_paragraph_subtitles(
     run_id: int,
     section_id: str,
-    audio_path: str,
     subtitle_model: str,
     subtitle_format: str,
 ) -> str:
     return task_dispatch_service.dispatch_paragraph_subtitles(
         run_id,
         section_id,
-        audio_path,
         subtitle_model,
         subtitle_format,
     )


### PR DESCRIPTION
## Summary
- **#466**: Paragraph subtitle/audio tasks accepted arbitrary file paths and text from queue messages — a trust boundary violation enabling arbitrary file processing

## Changes
- `generate_paragraph_subtitles.py`: Removed `audio_path` param; now resolves audio artifact from DB via `_audio_service.get_paragraph_audio()` and validates path is under artifact root
- `generate_paragraph_audio.py`: Removed `section_text` param; now loads script data from run via `_run_service.storage.get_run()` and extracts section text
- `task_runner.py`: Added `validate_artifact_path()` helper that enforces paths are under `_ARTIFACT_ROOT`
- `task_dispatch_service.py` + `creator_runs_storyboard.py`: Removed the now-unused params from dispatch call sites

## Test Results
- worker-orchestrator: 113 passed ✅
- API: 320 passed ✅

Closes #466