### PR TITLE
fix: close P1 workspace ownership bypass and run mutation race leaks

### DIFF
--- a/apps/api/migrations/versions/020_add_version_to_creator_runs.py
+++ b/apps/api/migrations/versions/020_add_version_to_creator_runs.py
@@ -1,0 +1,27 @@
+"""Add optimistic lock version column to creator_runs.
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-05-14 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "020"
+down_revision: str | None = "019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "creator_runs",
+        sa.Column("version", sa.Integer(), nullable=False, server_default=sa.text("0")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("creator_runs", "version")

--- a/apps/api/src/shorts_api/auth.py
+++ b/apps/api/src/shorts_api/auth.py
@@ -274,11 +274,11 @@ async def require_run_access(
     from creator_service.project_service import project_service
     from creator_service.run_service import run_service
 
-    run = await run_service.get_run(run_id)
+    run = await run_service.get_run(run_id, workspace_id=user.workspace_id)
     if run is None:
         raise HTTPException(status_code=404, detail="Run not found")
 
-    project = await project_service.get_project(run.project_id)
+    project = await project_service.get_project(run.project_id, workspace_id=user.workspace_id)
     if project is None or project.workspace_id is None:
         raise HTTPException(status_code=404, detail="Run not found")
 
@@ -299,7 +299,7 @@ async def require_project_access(
     """
     from creator_service.project_service import project_service
 
-    project = await project_service.get_project(project_id)
+    project = await project_service.get_project(project_id, workspace_id=user.workspace_id)
     if project is None or project.workspace_id is None:
         raise HTTPException(status_code=404, detail="Project not found")
 

--- a/apps/api/src/shorts_api/routes/creator_projects.py
+++ b/apps/api/src/shorts_api/routes/creator_projects.py
@@ -10,7 +10,12 @@ from creator_service.run_service import run_service
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from shorts_api.auth import CurrentUser, require_current_user, require_project_access, workspace_service
+from shorts_api.auth import (
+    CurrentUser,
+    require_current_user,
+    require_project_access,
+    workspace_service,
+)
 from shorts_api.routes import creator_runs_utils
 
 router = APIRouter(prefix="/projects", tags=["projects"])
@@ -60,7 +65,11 @@ async def update_project(
     access: tuple[CurrentUser, Project] = Depends(require_project_access),
 ) -> dict[str, object]:
     user, project = access
-    updated_project = await project_service.update_project(project_id, title=request.title)
+    updated_project = await project_service.update_project(
+        project_id,
+        title=request.title,
+        workspace_id=user.workspace_id,
+    )
     if updated_project is None:
         raise HTTPException(status_code=404, detail="Project not found")
     return updated_project.model_dump(mode="json")
@@ -116,7 +125,7 @@ async def delete_project(
 ) -> dict[str, object]:
     user, project = access
     run_ids = await _cleanup_project_resources(project.id)
-    deleted = await project_service.delete_project(project_id)
+    deleted = await project_service.delete_project(project_id, workspace_id=user.workspace_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Project not found")
 

--- a/apps/api/src/shorts_api/routes/creator_runs_core.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_core.py
@@ -10,7 +10,7 @@ from creator_service.task_dispatch_service import (
     dispatch_generate_script,
 )
 from creator_service.project_service import project_service
-from creator_service.run_service import run_service
+from creator_service.run_service import ConflictError, run_service
 from creator_service.stage_review_service import stage_review_service
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -154,6 +154,8 @@ async def restart_run(
             from_stage=request.stage,
             workspace_id=user.workspace_id,
         )
+    except ConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         detail = str(exc)
         if "not found" in detail.lower():

--- a/apps/api/src/shorts_api/routes/creator_runs_core.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_core.py
@@ -147,8 +147,13 @@ async def restart_run(
     request: RestartRunRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
+    user, _ = access
     try:
-        run = await run_service.restart_run(run_id=run_id, from_stage=request.stage)
+        run = await run_service.restart_run(
+            run_id=run_id,
+            from_stage=request.stage,
+            workspace_id=user.workspace_id,
+        )
     except ValueError as exc:
         detail = str(exc)
         if "not found" in detail.lower():

--- a/apps/api/src/shorts_api/routes/creator_runs_core.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_core.py
@@ -171,6 +171,7 @@ async def approve_script(
     request: ApproveScriptRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
+    user, _ = access
     try:
         updated_run = await stage_review_service.approve_and_advance(
             run_service=run_service,
@@ -179,6 +180,7 @@ async def approve_script(
             target_stage="VISUAL_PLAN_SETUP",
             reviewer=request.reviewer,
             notes=request.notes,
+            workspace_id=user.workspace_id,
         )
     except ValueError as exc:
         detail = str(exc)
@@ -197,6 +199,7 @@ async def approve_visual_plan(
     request: ApproveVisualPlanRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
+    user, _ = access
     try:
         updated_run = await stage_review_service.approve_and_advance(
             run_service=run_service,
@@ -205,6 +208,7 @@ async def approve_visual_plan(
             target_stage="VISUAL_ASSET_GENERATING",
             reviewer=request.reviewer,
             notes=request.notes,
+            workspace_id=user.workspace_id,
         )
     except ValueError as exc:
         detail = str(exc)
@@ -223,6 +227,7 @@ async def approve_visual_assets(
     request: ApproveVisualAssetsRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
+    user, _ = access
     try:
         updated_run = await stage_review_service.approve_and_advance(
             run_service=run_service,
@@ -231,6 +236,7 @@ async def approve_visual_assets(
             target_stage="AUDIO_GENERATING",
             reviewer=request.reviewer,
             notes=request.notes,
+            workspace_id=user.workspace_id,
         )
     except ValueError as exc:
         detail = str(exc)
@@ -249,7 +255,7 @@ async def generate_script_trigger(
     request: GenerateScriptRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
-    _, run = access
+    user, run = access
     if run.current_stage == "SCRIPT_GENERATING" and await _has_active_tasks_for_run(run.id):
         raise HTTPException(status_code=409, detail="Script generation already in progress")
 
@@ -285,4 +291,5 @@ async def generate_script_trigger(
         enqueue_error_detail="Failed to enqueue script generation task",
         restart_from_stage="SCRIPT_REVIEW",
         quota_operation_type="llm",
+        workspace_id=user.workspace_id,
     )

--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -64,16 +64,17 @@ async def resume_run(
 async def go_back(
     run_id: int, access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access)
 ) -> dict[str, object]:
+    user, _ = access
     try:
-        run = await run_service.go_back(run_id)
+        run = await run_service.go_back(run_id, workspace_id=user.workspace_id)
         return run.model_dump(mode="json")
+    except ConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         detail = str(exc)
         if "not found" in detail.lower():
             raise HTTPException(status_code=404, detail=detail) from exc
         raise HTTPException(status_code=400, detail=detail) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.patch("/runs/{run_id}/model-defaults")
@@ -82,12 +83,17 @@ async def update_model_defaults(
     request: UpdateModelDefaultsRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
+    user, _ = access
     updates = {k: v for k, v in request.model_dump().items() if v is not None}
     if not updates:
         raise HTTPException(status_code=400, detail="No model defaults to update")
     validate_model_defaults(updates)
     try:
-        run = await run_service.update_model_defaults(run_id, updates)
+        run = await run_service.update_model_defaults(
+            run_id,
+            updates,
+            workspace_id=user.workspace_id,
+        )
         return run.model_dump(mode="json")
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -97,11 +103,14 @@ async def update_model_defaults(
 async def delete_run(
     run_id: int, access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access)
 ) -> dict[str, object]:
-    _, run = access
+    user, run = access
 
     await _revoke_active_tasks_for_run(run.id)
 
-    deleted = await run_service.delete_run(run_id)
+    try:
+        deleted = await run_service.delete_run(run_id, workspace_id=user.workspace_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     if not deleted:
         raise HTTPException(status_code=404, detail="Run not found")
 

--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from creator_service.artifact_download_service import artifact_download_service
-from creator_service.run_service import run_service
+from creator_service.run_service import ConflictError, run_service
 from fastapi import APIRouter, Depends, HTTPException
 
 if TYPE_CHECKING:
@@ -31,6 +31,8 @@ async def stop_run(
 
     try:
         updated = await run_service.stop_run(run_id, workspace_id=user.workspace_id)
+    except ConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         detail = str(exc)
         if "not found" in detail.lower():
@@ -47,6 +49,8 @@ async def resume_run(
     user, _ = access
     try:
         updated = await run_service.resume_run(run_id, workspace_id=user.workspace_id)
+    except ConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         detail = str(exc)
         if "not found" in detail.lower():

--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -25,12 +25,12 @@ router = APIRouter(tags=["runs"])
 async def stop_run(
     run_id: int, access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access)
 ) -> dict[str, object]:
-    _, run = access
+    user, run = access
 
     await _revoke_active_tasks_for_run(run.id)
 
     try:
-        updated = await run_service.stop_run(run_id)
+        updated = await run_service.stop_run(run_id, workspace_id=user.workspace_id)
     except ValueError as exc:
         detail = str(exc)
         if "not found" in detail.lower():
@@ -44,8 +44,9 @@ async def stop_run(
 async def resume_run(
     run_id: int, access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access)
 ) -> dict[str, object]:
+    user, _ = access
     try:
-        updated = await run_service.resume_run(run_id)
+        updated = await run_service.resume_run(run_id, workspace_id=user.workspace_id)
     except ValueError as exc:
         detail = str(exc)
         if "not found" in detail.lower():

--- a/apps/api/src/shorts_api/routes/creator_runs_scene_assets.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_scene_assets.py
@@ -179,7 +179,7 @@ async def regenerate_scene_image_endpoint(
 async def list_visual_assets_by_run(
     run_id: int, access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access)
 ) -> dict[str, object]:
-    _, run = access
+    _ = access
 
     grouped = await visual_asset_service.list_by_run(run_id)
     return {
@@ -199,7 +199,7 @@ async def list_visual_assets_by_scene(
     scene_id: str,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
-    _, run = access
+    _ = access
 
     assets = await visual_asset_service.list_by_scene(run_id, scene_id)
     return {
@@ -244,7 +244,7 @@ async def generate_audio_trigger(
     request: GenerateAudioRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
-    _, run = access
+    user, run = access
     if run.current_stage == "AUDIO_GENERATING" and await _has_active_tasks_for_run(run.id):
         raise HTTPException(status_code=409, detail="Audio generation already in progress")
 
@@ -272,6 +272,7 @@ async def generate_audio_trigger(
         rollback_restart_from=run.restart_from,
         enqueue_error_detail="Failed to enqueue audio generation task",
         quota_operation_type="tts",
+        workspace_id=user.workspace_id,
     )
 
 
@@ -281,7 +282,7 @@ async def generate_subtitles_trigger(
     request: GenerateSubtitlesRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
-    _, run = access
+    user, run = access
     if run.current_stage == "SUBTITLE_GENERATING" and await _has_active_tasks_for_run(run.id):
         raise HTTPException(status_code=409, detail="Subtitle generation already in progress")
 
@@ -309,6 +310,7 @@ async def generate_subtitles_trigger(
         rollback_restart_from=run.restart_from,
         enqueue_error_detail="Failed to enqueue subtitle generation task",
         quota_operation_type="stt",
+        workspace_id=user.workspace_id,
     )
 
 
@@ -318,7 +320,7 @@ async def render_trigger(
     request: RenderRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
-    _, run = access
+    user, run = access
     if run.current_stage == "RENDER_GENERATING" and await _has_active_tasks_for_run(run.id):
         raise HTTPException(status_code=409, detail="Render already in progress")
 
@@ -345,6 +347,7 @@ async def render_trigger(
         rollback_restart_from=run.restart_from,
         enqueue_error_detail="Failed to enqueue render task",
         quota_operation_type="render",
+        workspace_id=user.workspace_id,
     )
 
 

--- a/apps/api/src/shorts_api/routes/creator_runs_visuals.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_visuals.py
@@ -71,7 +71,7 @@ async def generate_visual_plan_trigger(
     request: GenerateVisualPlanRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
-    _, run = access
+    user, run = access
     if run.current_stage == "VISUAL_PLAN_GENERATING" and await _has_active_tasks_for_run(run.id):
         raise HTTPException(status_code=409, detail="Visual plan generation already in progress")
 
@@ -99,6 +99,7 @@ async def generate_visual_plan_trigger(
         rollback_restart_from=run.restart_from,
         enqueue_error_detail="Failed to enqueue visual plan generation task",
         quota_operation_type="llm",
+        workspace_id=user.workspace_id,
     )
 
 
@@ -108,7 +109,7 @@ async def generate_visual_assets_trigger(
     request: GenerateVisualAssetsRequest,
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
-    _, run = access
+    user, run = access
     if run.current_stage == "VISUAL_ASSET_GENERATING" and await _has_active_tasks_for_run(run.id):
         raise HTTPException(status_code=409, detail="Visual asset generation already in progress")
 
@@ -139,4 +140,5 @@ async def generate_visual_assets_trigger(
         rollback_restart_from=run.restart_from,
         enqueue_error_detail="Failed to enqueue image generation task",
         quota_operation_type="image_gen",
+        workspace_id=user.workspace_id,
     )

--- a/apps/api/tests/test_api_contracts.py
+++ b/apps/api/tests/test_api_contracts.py
@@ -45,10 +45,14 @@ class StubRunService:
         self.runs: dict[int, StubRun] = {}
         self.updated_defaults: list[dict[str, object]] = []
 
-    async def get_run(self, run_id: int) -> StubRun | None:
+    async def get_run(self, run_id: int, workspace_id: int | None = None) -> StubRun | None:
+        _ = workspace_id
         return self.runs.get(run_id)
 
-    async def update_model_defaults(self, run_id: int, updates: dict[str, str]) -> StubRun:
+    async def update_model_defaults(
+        self, run_id: int, updates: dict[str, str], workspace_id: int | None = None
+    ) -> StubRun:
+        _ = workspace_id
         run = self.runs.get(run_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")

--- a/apps/api/tests/test_artifact_download.py
+++ b/apps/api/tests/test_artifact_download.py
@@ -41,7 +41,9 @@ class StubProject:
 
 
 class StubProjectService:
-    async def get_project(self, project_id: int) -> StubProject | None:
+    async def get_project(
+        self, project_id: int, workspace_id: int | None = None
+    ) -> StubProject | None:
         if project_id != 1:
             return None
         return StubProject()
@@ -49,6 +51,7 @@ class StubProjectService:
 
 def _iter_api_routes() -> list[APIRoute]:
     return [route for route in app.routes if isinstance(route, APIRoute)]
+
 
 async def _stub_check_access(workspace_id: int, user_id: int) -> bool:
     return workspace_id == 1 and user_id == 101

--- a/apps/api/tests/test_creator_projects.py
+++ b/apps/api/tests/test_creator_projects.py
@@ -111,7 +111,9 @@ class StubProjectService:
         self._next_id += 1
         return project
 
-    async def get_project(self, project_id: int) -> StubProject | None:
+    async def get_project(
+        self, project_id: int, workspace_id: int | None = None
+    ) -> StubProject | None:
         self.get_project_calls.append(project_id)
         return self._projects.get(project_id)
 
@@ -137,7 +139,7 @@ def _iter_api_routes(routes: Sequence[object]) -> list[APIRoute]:
 def stub_project_service(monkeypatch: pytest.MonkeyPatch) -> StubProjectService:
     from shorts_api.auth import CurrentUser, require_project_access
     from shorts_api.main import app
-    
+
     service = StubProjectService()
 
     async def _stub_check_access(workspace_id: int, user_id: int) -> bool:
@@ -146,7 +148,13 @@ def stub_project_service(monkeypatch: pytest.MonkeyPatch) -> StubProjectService:
     fake_ws = SimpleNamespace(check_access=_stub_check_access)
 
     for route in _iter_api_routes(projects_router.routes):
-        if route.name in {"create_project", "get_project_detail", "list_projects", "update_project", "delete_project"}:
+        if route.name in {
+            "create_project",
+            "get_project_detail",
+            "list_projects",
+            "update_project",
+            "delete_project",
+        }:
             monkeypatch.setitem(route.endpoint.__globals__, "project_service", service)
             monkeypatch.setitem(route.endpoint.__globals__, "workspace_service", fake_ws)
 
@@ -154,12 +162,14 @@ def stub_project_service(monkeypatch: pytest.MonkeyPatch) -> StubProjectService:
         project = await service.get_project(project_id)
         if project is None:
             from fastapi import HTTPException
+
             raise HTTPException(status_code=404, detail="Project not found")
         return CurrentUser(user_id=1, workspace_id=1), project
 
     app.dependency_overrides[require_project_access] = _require_project_access
     yield service
     app.dependency_overrides.pop(require_project_access, None)
+
 
 @pytest.mark.asyncio
 async def test_create_project_idea(client, stub_project_service: StubProjectService):

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -158,7 +158,9 @@ class StubRunStorage:
         run_id: int,
         updates: dict[str, object],
         expected_stages: frozenset[str],
+        workspace_id: int | None = None,
     ) -> tuple[bool, dict[str, object] | None]:
+        _ = workspace_id
         self.conditional_update_calls.append(
             {
                 "run_id": run_id,
@@ -1056,7 +1058,8 @@ async def test_generate_script_cas_conflict(client, stub_generate_services):
     # initial get_run and the CAS call.  Because the route reads once then CAS,
     # we override conditional_update_run to simulate conflict.
 
-    async def cas_conflict(run_id, updates, expected_stages):
+    async def cas_conflict(run_id, updates, expected_stages, workspace_id=None):
+        _ = workspace_id
         # Return conflict: stage changed to SCRIPT_GENERATING
         return False, {"current_stage": "SCRIPT_GENERATING", "id": run_id}
 
@@ -1339,7 +1342,8 @@ async def test_generate_visual_plan_cas_conflict(client, stub_generate_visual_pl
     run_svc, dispatcher = stub_generate_visual_plan_services
     run_svc.runs[35] = _make_run(35, "VISUAL_PLAN_SETUP")
 
-    async def cas_conflict(run_id, updates, expected_stages):
+    async def cas_conflict(run_id, updates, expected_stages, workspace_id=None):
+        _ = workspace_id
         return False, {"current_stage": "VISUAL_PLAN_GENERATING", "id": run_id}
 
     run_svc.storage.conditional_update_run = cas_conflict
@@ -1583,7 +1587,8 @@ async def test_generate_visual_assets_cas_conflict(client, stub_generate_visual_
     run_svc, dispatcher = stub_generate_visual_assets_services
     run_svc.runs[65] = _make_run(65, "VISUAL_PLAN_REVIEW")
 
-    async def cas_conflict(run_id, updates, expected_stages):
+    async def cas_conflict(run_id, updates, expected_stages, workspace_id=None):
+        _ = workspace_id
         return False, {"current_stage": "VISUAL_ASSET_GENERATING", "id": run_id}
 
     run_svc.storage.conditional_update_run = cas_conflict
@@ -2442,7 +2447,8 @@ async def test_generate_audio_cas_conflict(client, stub_generate_audio_services)
     run_svc, dispatcher = stub_generate_audio_services
     run_svc.runs[115] = _make_audio_run(115, "VISUAL_ASSET_REVIEW")
 
-    async def cas_conflict(run_id, updates, expected_stages):
+    async def cas_conflict(run_id, updates, expected_stages, workspace_id=None):
+        _ = workspace_id
         return False, {"current_stage": "AUDIO_GENERATING", "id": run_id}
 
     run_svc.storage.conditional_update_run = cas_conflict
@@ -2687,7 +2693,8 @@ async def test_generate_subtitles_cas_conflict(client, stub_generate_subtitles_s
     run_svc, dispatcher = stub_generate_subtitles_services
     run_svc.runs[125] = _make_subtitle_run(125, "AUDIO_GENERATING")
 
-    async def cas_conflict(run_id, updates, expected_stages):
+    async def cas_conflict(run_id, updates, expected_stages, workspace_id=None):
+        _ = workspace_id
         return False, {"current_stage": "SUBTITLE_GENERATING", "id": run_id}
 
     run_svc.storage.conditional_update_run = cas_conflict
@@ -2911,7 +2918,8 @@ async def test_render_cas_conflict(client, stub_generate_render_services):
     run_svc, dispatcher = stub_generate_render_services
     run_svc.runs[134] = _make_render_run(134, "SUBTITLE_GENERATING")
 
-    async def cas_conflict(run_id, updates, expected_stages):
+    async def cas_conflict(run_id, updates, expected_stages, workspace_id=None):
+        _ = workspace_id
         return False, {"current_stage": "RENDER_GENERATING", "id": run_id}
 
     run_svc.storage.conditional_update_run = cas_conflict

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -90,7 +90,9 @@ class StubRunService:
         self.get_run_calls.append(run_id)
         return self.runs.get(run_id)
 
-    async def restart_run(self, run_id: int, from_stage: str) -> StubPipelineRun:
+    async def restart_run(
+        self, run_id: int, from_stage: str, workspace_id: int | None = None
+    ) -> StubPipelineRun:
         self.restart_run_calls.append({"run_id": run_id, "from_stage": from_stage})
 
         run = self.runs.get(run_id)
@@ -209,7 +211,7 @@ class StubProjectLookupService:
         self.existing_project_ids = existing_project_ids or {7, 8}
         self.get_project_calls: list[int] = []
 
-    async def get_project(self, project_id: int) -> object | None:
+    async def get_project(self, project_id: int, workspace_id: int | None = None) -> object | None:
         self.get_project_calls.append(project_id)
         if project_id in self.existing_project_ids:
             return {"id": project_id}
@@ -779,7 +781,9 @@ class StubProjectService:
     def __init__(self) -> None:
         self.projects: dict[int, StubProject] = {}
 
-    async def get_project(self, project_id: int) -> StubProject | None:
+    async def get_project(
+        self, project_id: int, workspace_id: int | None = None
+    ) -> StubProject | None:
         return self.projects.get(project_id)
 
 

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import Literal, cast
 
 import pytest
+from creator_service.run_service import ConflictError
 from fastapi.routing import APIRoute
 from pydantic import BaseModel, ValidationError
 from shorts_api.auth import CurrentUser, require_project_access, require_run_access
@@ -45,6 +46,7 @@ class StubRunService:
         self.advance_stage_calls: list[dict[str, object]] = []
         self.update_model_defaults_calls: list[dict[str, object]] = []
         self.runs: dict[int, StubPipelineRun] = {}
+        self.restart_errors: dict[int, Exception] = {}
         self.storage = StubRunStorage(self)
         self._next_id = 1
 
@@ -94,6 +96,9 @@ class StubRunService:
         self, run_id: int, from_stage: str, workspace_id: int | None = None
     ) -> StubPipelineRun:
         self.restart_run_calls.append({"run_id": run_id, "from_stage": from_stage})
+        error = self.restart_errors.get(run_id)
+        if error is not None:
+            raise error
 
         run = self.runs.get(run_id)
         if run is None:
@@ -505,6 +510,34 @@ async def test_restart_run_not_found(client, stub_run_service: StubRunService):
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Run not found"}
+
+
+@pytest.mark.asyncio
+async def test_restart_run_conflict_returns_409(client, stub_run_service: StubRunService):
+    now = datetime.now(timezone.utc)
+    stub_run_service.runs[4243] = StubPipelineRun(
+        id=4243,
+        project_id=2,
+        current_stage="IDEA_READY",
+        status="pending",
+        review_stage=None,
+        restart_from=None,
+        model_defaults=None,
+        metadata=None,
+        style_preset="default",
+        started_at=None,
+        finished_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    stub_run_service.restart_errors[4243] = ConflictError("Run 4243 has stale version")
+
+    response = await client.post(
+        "/api/creator/runs/4243/restart", json={"stage": "SCRIPT_GENERATING"}
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Run 4243 has stale version"}
 
 
 @pytest.fixture

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -36,6 +36,7 @@ class StubPipelineRun(BaseModel):
     finished_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
+    workspace_id: int = 1
 
 
 class StubRunService:
@@ -88,7 +89,8 @@ class StubRunService:
         self._next_id += 1
         return run
 
-    async def get_run(self, run_id: int) -> StubPipelineRun | None:
+    async def get_run(self, run_id: int, workspace_id: int | None = None) -> StubPipelineRun | None:
+        _ = workspace_id
         self.get_run_calls.append(run_id)
         return self.runs.get(run_id)
 
@@ -130,7 +132,10 @@ class StubRunService:
             reverse=True,
         )
 
-    async def update_model_defaults(self, run_id: int, updates: dict[str, str]) -> StubPipelineRun:
+    async def update_model_defaults(
+        self, run_id: int, updates: dict[str, str], workspace_id: int | None = None
+    ) -> StubPipelineRun:
+        _ = workspace_id
         self.update_model_defaults_calls.append({"run_id": run_id, "updates": updates})
         run = self.runs.get(run_id)
         if run is None:
@@ -187,6 +192,7 @@ class StubStageReviewService:
         target_stage: str,
         reviewer: str = "agent",
         notes: str | None = None,
+        workspace_id: int | None = None,
     ) -> StubPipelineRun:
         self.approve_calls.append(
             {
@@ -195,11 +201,14 @@ class StubStageReviewService:
                 "target_stage": target_stage,
                 "reviewer": reviewer,
                 "notes": notes,
+                "workspace_id": workspace_id,
             }
         )
 
         run = self._run_svc.runs.get(run_id)
         if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        if workspace_id is not None and run.workspace_id != workspace_id:
             raise ValueError(f"Run {run_id} not found")
         if run.current_stage != stage_name:
             raise ValueError(
@@ -583,6 +592,7 @@ def _make_run(run_id: int, stage: str = "SCRIPT_REVIEW") -> StubPipelineRun:
         finished_at=None,
         created_at=now,
         updated_at=now,
+        workspace_id=1,
     )
 
 
@@ -607,6 +617,7 @@ async def test_approve_script_success(client, stub_approve_services):
             "target_stage": "VISUAL_PLAN_SETUP",
             "reviewer": "human",
             "notes": "Looks good",
+            "workspace_id": 1,
         }
     ]
 
@@ -738,8 +749,20 @@ async def test_approve_visual_plan_success(client, stub_approve_vp_services):
             "target_stage": "VISUAL_ASSET_GENERATING",
             "reviewer": "human",
             "notes": "Visual plan approved",
+            "workspace_id": 1,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_approve_script_returns_404_for_workspace_mismatch(client, stub_approve_services):
+    run_svc, _ = stub_approve_services
+    run_svc.runs[101] = _make_run(101, "SCRIPT_REVIEW").model_copy(update={"workspace_id": 2})
+
+    response = await client.post("/api/creator/runs/101/approve-script", json={})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run 101 not found"}
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_creator_script.py
+++ b/apps/api/tests/test_creator_script.py
@@ -45,7 +45,9 @@ class StubProjectService:
         self.get_project_calls: list[int] = []
         self.projects: dict[int, StubProject] = {}
 
-    async def get_project(self, project_id: int) -> StubProject | None:
+    async def get_project(
+        self, project_id: int, workspace_id: int | None = None
+    ) -> StubProject | None:
         self.get_project_calls.append(project_id)
         return self.projects.get(project_id)
 

--- a/apps/api/tests/test_lifecycle.py
+++ b/apps/api/tests/test_lifecycle.py
@@ -26,6 +26,7 @@ class StubPipelineRun(BaseModel):
     finished_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
+    workspace_id: int = 1
 
 
 class StubProject(BaseModel):
@@ -42,8 +43,11 @@ class StubRunService:
         self.stop_run_calls: list[int] = []
         self.resume_run_calls: list[int] = []
         self.go_back_calls: list[int] = []
+        self.go_back_workspace_ids: list[int | None] = []
         self.update_model_defaults_calls: list[dict[str, object]] = []
+        self.update_model_defaults_workspace_ids: list[int | None] = []
         self.delete_run_calls: list[int] = []
+        self.delete_run_workspace_ids: list[int | None] = []
         self.list_runs_by_project_calls: list[int] = []
         self.resume_errors: dict[int, Exception] = {}
         self.stop_errors: dict[int, Exception] = {}
@@ -78,25 +82,33 @@ class StubRunService:
         self.runs[run_id] = updated
         return updated
 
-    async def go_back(self, run_id: int) -> StubPipelineRun:
+    async def go_back(self, run_id: int, workspace_id: int | None = None) -> StubPipelineRun:
         self.go_back_calls.append(run_id)
+        self.go_back_workspace_ids.append(workspace_id)
         error = self.go_back_errors.get(run_id)
         if error is not None:
             raise error
         run = self.runs.get(run_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")
+        if workspace_id is not None and run.workspace_id != workspace_id:
+            raise ValueError(f"Run {run_id} not found")
         updated = run.model_copy(update={"current_stage": "SCRIPT_GENERATING"})
         self.runs[run_id] = updated
         return updated
 
-    async def update_model_defaults(self, run_id: int, updates: dict[str, str]) -> StubPipelineRun:
+    async def update_model_defaults(
+        self, run_id: int, updates: dict[str, str], workspace_id: int | None = None
+    ) -> StubPipelineRun:
         self.update_model_defaults_calls.append({"run_id": run_id, "updates": updates})
+        self.update_model_defaults_workspace_ids.append(workspace_id)
         error = self.update_model_defaults_errors.get(run_id)
         if error is not None:
             raise error
         run = self.runs.get(run_id)
         if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        if workspace_id is not None and run.workspace_id != workspace_id:
             raise ValueError(f"Run {run_id} not found")
 
         merged = dict(run.model_defaults or {})
@@ -105,8 +117,14 @@ class StubRunService:
         self.runs[run_id] = updated
         return updated
 
-    async def delete_run(self, run_id: int) -> bool:
+    async def delete_run(self, run_id: int, workspace_id: int | None = None) -> bool:
         self.delete_run_calls.append(run_id)
+        self.delete_run_workspace_ids.append(workspace_id)
+        run = self.runs.get(run_id)
+        if run is None:
+            return False
+        if workspace_id is not None and run.workspace_id != workspace_id:
+            return False
         return self.runs.pop(run_id, None) is not None
 
     async def list_runs_by_project(self, project_id: int) -> list[StubPipelineRun]:
@@ -221,6 +239,7 @@ def _make_run(
     status: Literal["pending", "running", "paused", "completed", "failed", "cancelled"] = "running",
     stage: str = "SCRIPT_GENERATING",
     model_defaults: dict[str, str] | None = None,
+    workspace_id: int = 1,
 ) -> StubPipelineRun:
     now = datetime.now(timezone.utc)
     return StubPipelineRun(
@@ -237,6 +256,7 @@ def _make_run(
         finished_at=None,
         created_at=now,
         updated_at=now,
+        workspace_id=workspace_id,
     )
 
 
@@ -341,6 +361,7 @@ async def test_go_back_success(client, stub_lifecycle_services):
     assert response.status_code == 200
     assert response.json()["current_stage"] == "SCRIPT_GENERATING"
     assert run_svc.go_back_calls == [13]
+    assert run_svc.go_back_workspace_ids == [1]
 
 
 @pytest.mark.asyncio
@@ -370,7 +391,7 @@ async def test_go_back_invalid_state_returns_400(client, stub_lifecycle_services
 async def test_go_back_stage_conflict_returns_409(client, stub_lifecycle_services):
     run_svc, _, _, _ = stub_lifecycle_services
     run_svc.runs[15] = _make_run(15)
-    run_svc.go_back_errors[15] = RuntimeError(
+    run_svc.go_back_errors[15] = ConflictError(
         "Stage conflict: expected 'SCRIPT_REVIEW' but run is at 'VISUAL_PLAN_SETUP'"
     )
 
@@ -398,6 +419,7 @@ async def test_update_model_defaults_success(client, stub_lifecycle_services):
     assert run_svc.update_model_defaults_calls == [
         {"run_id": 16, "updates": {"image_model": "sd15"}}
     ]
+    assert run_svc.update_model_defaults_workspace_ids == [1]
 
 
 @pytest.mark.asyncio
@@ -442,6 +464,47 @@ async def test_delete_run_success_with_artifact_cleanup(client, stub_lifecycle_s
     assert revoke_tasks.calls == [17]
     assert artifact_lifecycle_svc.delete_artifacts_for_run_calls == [17]
     assert run_svc.delete_run_calls == [17]
+    assert run_svc.delete_run_workspace_ids == [1]
+
+
+@pytest.mark.asyncio
+async def test_go_back_returns_404_for_workspace_mismatch(client, stub_lifecycle_services):
+    run_svc, _, _, _ = stub_lifecycle_services
+    run_svc.runs[130] = _make_run(130, stage="SCRIPT_REVIEW", workspace_id=2)
+
+    response = await client.post("/api/creator/runs/130/go-back")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run 130 not found"}
+
+
+@pytest.mark.asyncio
+async def test_update_model_defaults_returns_404_for_workspace_mismatch(
+    client, stub_lifecycle_services
+):
+    run_svc, _, _, _ = stub_lifecycle_services
+    run_svc.runs[131] = _make_run(131, workspace_id=2)
+
+    response = await client.patch(
+        "/api/creator/runs/131/model-defaults",
+        json={"script_model": "qwen3-4b"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run 131 not found"}
+
+
+@pytest.mark.asyncio
+async def test_delete_run_returns_404_for_workspace_mismatch(client, stub_lifecycle_services):
+    run_svc, _, revoke_tasks, artifact_lifecycle_svc = stub_lifecycle_services
+    run_svc.runs[132] = _make_run(132, workspace_id=2)
+
+    response = await client.delete("/api/creator/runs/132")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run not found"}
+    assert revoke_tasks.calls == [132]
+    assert artifact_lifecycle_svc.delete_artifacts_for_run_calls == []
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_lifecycle.py
+++ b/apps/api/tests/test_lifecycle.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 import pytest
 import shorts_api.routes.creator_runs_utils as creator_runs_utils
+from creator_service.run_service import ConflictError
 from fastapi.routing import APIRoute
 from pydantic import BaseModel
 from shorts_api.main import projects_router, runs_router
@@ -45,6 +46,7 @@ class StubRunService:
         self.delete_run_calls: list[int] = []
         self.list_runs_by_project_calls: list[int] = []
         self.resume_errors: dict[int, Exception] = {}
+        self.stop_errors: dict[int, Exception] = {}
         self.go_back_errors: dict[int, Exception] = {}
         self.update_model_defaults_errors: dict[int, Exception] = {}
 
@@ -54,6 +56,9 @@ class StubRunService:
 
     async def stop_run(self, run_id: int, workspace_id: int | None = None) -> StubPipelineRun:
         self.stop_run_calls.append(run_id)
+        error = self.stop_errors.get(run_id)
+        if error is not None:
+            raise error
         run = self.runs.get(run_id)
         if run is None:
             raise ValueError("Run not found")
@@ -300,6 +305,30 @@ async def test_resume_run_wrong_state(client, stub_lifecycle_services):
 
     assert response.status_code == 400
     assert "can only resume" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_stop_run_conflict_returns_409(client, stub_lifecycle_services):
+    run_svc, _, _, _ = stub_lifecycle_services
+    run_svc.runs[112] = _make_run(112)
+    run_svc.stop_errors[112] = ConflictError("Run 112 has stale version")
+
+    response = await client.post("/api/creator/runs/112/stop")
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Run 112 has stale version"}
+
+
+@pytest.mark.asyncio
+async def test_resume_run_conflict_returns_409(client, stub_lifecycle_services):
+    run_svc, _, _, _ = stub_lifecycle_services
+    run_svc.runs[113] = _make_run(113, status="cancelled", stage="SCRIPT_REVIEW")
+    run_svc.resume_errors[113] = ConflictError("Run 113 has stale version")
+
+    response = await client.post("/api/creator/runs/113/resume")
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Run 113 has stale version"}
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_lifecycle.py
+++ b/apps/api/tests/test_lifecycle.py
@@ -52,7 +52,7 @@ class StubRunService:
         self.get_run_calls.append(run_id)
         return self.runs.get(run_id)
 
-    async def stop_run(self, run_id: int) -> StubPipelineRun:
+    async def stop_run(self, run_id: int, workspace_id: int | None = None) -> StubPipelineRun:
         self.stop_run_calls.append(run_id)
         run = self.runs.get(run_id)
         if run is None:
@@ -61,7 +61,7 @@ class StubRunService:
         self.runs[run_id] = updated
         return updated
 
-    async def resume_run(self, run_id: int) -> StubPipelineRun:
+    async def resume_run(self, run_id: int, workspace_id: int | None = None) -> StubPipelineRun:
         self.resume_run_calls.append(run_id)
         error = self.resume_errors.get(run_id)
         if error is not None:
@@ -118,7 +118,7 @@ class StubProjectService:
         self.projects: dict[int, StubProject] = {}
         self.delete_project_calls: list[int] = []
 
-    async def delete_project(self, project_id: int) -> bool:
+    async def delete_project(self, project_id: int, workspace_id: int | None = None) -> bool:
         self.delete_project_calls.append(project_id)
         return self.projects.pop(project_id, None) is not None
 
@@ -197,6 +197,7 @@ def stub_lifecycle_services(
         project = project_svc.projects.get(project_id)
         if project is None:
             from fastapi import HTTPException
+
             raise HTTPException(status_code=404, detail="Project not found")
         return CurrentUser(user_id=1, workspace_id=1), project
 

--- a/apps/api/tests/test_script_generation_flow.py
+++ b/apps/api/tests/test_script_generation_flow.py
@@ -83,7 +83,9 @@ class StubProjectService:
         self.next_id += 1
         return project
 
-    async def get_project(self, project_id: int) -> StubProject | None:
+    async def get_project(
+        self, project_id: int, workspace_id: int | None = None
+    ) -> StubProject | None:
         return self.projects.get(project_id)
 
 

--- a/apps/api/tests/test_script_generation_flow.py
+++ b/apps/api/tests/test_script_generation_flow.py
@@ -94,8 +94,13 @@ class StubRunStorage:
         self.run_service = run_service
 
     async def conditional_update_run(
-        self, run_id: int, updates: dict[str, object], expected_stages: frozenset[str]
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+        workspace_id: int | None = None,
     ) -> tuple[bool, dict[str, object] | None]:
+        _ = workspace_id
         run = self.run_service.runs.get(run_id)
         if run is None:
             return False, None

--- a/apps/api/tests/test_script_generation_flow.py
+++ b/apps/api/tests/test_script_generation_flow.py
@@ -134,7 +134,8 @@ class StubRunService:
         self.next_id += 1
         return run
 
-    async def get_run(self, run_id: int) -> StubRun | None:
+    async def get_run(self, run_id: int, workspace_id: int | None = None) -> StubRun | None:
+        _ = workspace_id
         return self.runs.get(run_id)
 
 
@@ -184,8 +185,9 @@ class StubStageReviewService:
         target_stage: str,
         reviewer: str = "agent",
         notes: str | None = None,
+        workspace_id: int | None = None,
     ) -> StubRun:
-        _ = run_service, reviewer, notes
+        _ = run_service, reviewer, notes, workspace_id
         run = self.run_service.runs.get(run_id)
         if run is None:
             raise ValueError("Run not found")

--- a/apps/api/tests/test_security_boundaries.py
+++ b/apps/api/tests/test_security_boundaries.py
@@ -193,13 +193,15 @@ def _patch_for_cross_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
     """Patch services so require_run_access / require_project_access find workspace-2 objects."""
 
     class CrossWsProjectService:
-        async def get_project(self, project_id: int) -> StubProject | None:
+        async def get_project(
+            self, project_id: int, workspace_id: int | None = None
+        ) -> StubProject | None:
             if project_id == 99:
                 return _WS2_PROJECT
             return None
 
     class CrossWsRunService:
-        async def get_run(self, run_id: int) -> StubRun | None:
+        async def get_run(self, run_id: int, workspace_id: int | None = None) -> StubRun | None:
             if run_id == 99:
                 return _WS2_RUN
             return None
@@ -271,7 +273,9 @@ async def test_artifact_download_denies_cross_workspace(
     from shorts_api.routes import creator_artifact_download
 
     class _StorageStub:
-        async def get_run(self, run_id: int) -> dict[str, object] | None:
+        async def get_run(
+            self, run_id: int, workspace_id: int | None = None
+        ) -> dict[str, object] | None:
             if run_id == 99:
                 return {"id": 99, "project_id": 99, "workspace_id": 2}
             return None
@@ -280,7 +284,9 @@ async def test_artifact_download_denies_cross_workspace(
         storage = _StorageStub()
 
     class CrossWsProjSvc:
-        async def get_project(self, project_id: int) -> StubProject | None:
+        async def get_project(
+            self, project_id: int, workspace_id: int | None = None
+        ) -> StubProject | None:
             if project_id == 99:
                 return _WS2_PROJECT
             return None

--- a/apps/api/tests/test_visual_plan_flow.py
+++ b/apps/api/tests/test_visual_plan_flow.py
@@ -82,7 +82,9 @@ class StubProjectService:
         self.next_id += 1
         return project
 
-    async def get_project(self, project_id: int) -> StubProject | None:
+    async def get_project(
+        self, project_id: int, workspace_id: int | None = None
+    ) -> StubProject | None:
         return self.projects.get(project_id)
 
 

--- a/apps/api/tests/test_visual_plan_flow.py
+++ b/apps/api/tests/test_visual_plan_flow.py
@@ -133,7 +133,8 @@ class StubRunService:
         self.next_id += 1
         return run
 
-    async def get_run(self, run_id: int) -> StubRun | None:
+    async def get_run(self, run_id: int, workspace_id: int | None = None) -> StubRun | None:
+        _ = workspace_id
         return self.runs.get(run_id)
 
 
@@ -175,8 +176,9 @@ class StubStageReviewService:
         target_stage: str,
         reviewer: str = "agent",
         notes: str | None = None,
+        workspace_id: int | None = None,
     ) -> StubRun:
-        _ = run_service, reviewer, notes
+        _ = run_service, reviewer, notes, workspace_id
         run = self.run_service.runs.get(run_id)
         if run is None:
             raise ValueError("Run not found")

--- a/apps/api/tests/test_visual_plan_flow.py
+++ b/apps/api/tests/test_visual_plan_flow.py
@@ -93,8 +93,13 @@ class StubRunStorage:
         self.run_service = run_service
 
     async def conditional_update_run(
-        self, run_id: int, updates: dict[str, object], expected_stages: frozenset[str]
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        expected_stages: frozenset[str],
+        workspace_id: int | None = None,
     ) -> tuple[bool, dict[str, object] | None]:
+        _ = workspace_id
         run = self.run_service.runs.get(run_id)
         if run is None:
             return False, None

--- a/packages/creator-domain/creator_domain/models/pipeline_run.py
+++ b/packages/creator-domain/creator_domain/models/pipeline_run.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import BaseModel
 
@@ -17,19 +17,20 @@ class PipelineRun(BaseModel):
     review_stage: str | None = None
     restart_from: str | None = None
     model_defaults: ModelSelection | None = None
-    metadata: dict | None = None
+    metadata: dict[str, object] | None = None
     style_preset: str | None = None
     started_at: datetime | None = None
     finished_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
+    version: int = 0
 
     @classmethod
-    def from_dict(cls, data: dict) -> PipelineRun:
+    def from_dict(cls, data: dict[str, object]) -> PipelineRun:
         return cls.model_validate(data)
 
     @classmethod
-    def from_row(cls, row: dict) -> PipelineRun:
+    def from_row(cls, row: dict[str, object]) -> PipelineRun:
         """Construct from a DB row dict, mapping column names to domain fields.
 
         Handles:
@@ -39,10 +40,10 @@ class PipelineRun(BaseModel):
         mapped = dict(row)
         raw_defaults = mapped.pop("model_defaults_json", None)
         if raw_defaults is not None:
-            mapped["model_defaults"] = json.loads(raw_defaults)
+            mapped["model_defaults"] = cast(dict[str, object], json.loads(cast(str, raw_defaults)))
         raw_meta = mapped.pop("metadata_json", None)
         if raw_meta is not None:
-            mapped["metadata"] = json.loads(raw_meta)
+            mapped["metadata"] = cast(dict[str, object], json.loads(cast(str, raw_meta)))
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-service/creator_service/postgres_project_storage.py
+++ b/packages/creator-service/creator_service/postgres_project_storage.py
@@ -35,8 +35,16 @@ class PostgresProjectStorage:
             raise ValueError("Failed to insert project")
         return row
 
-    async def fetch_project(self, project_id: int) -> dict[str, Any] | None:
-        return await fetch_one("SELECT * FROM creator_projects WHERE id = $1", project_id)
+    async def fetch_project(
+        self, project_id: int, workspace_id: int | None = None
+    ) -> dict[str, Any] | None:
+        if workspace_id is None:
+            return await fetch_one("SELECT * FROM creator_projects WHERE id = $1", project_id)
+        return await fetch_one(
+            "SELECT * FROM creator_projects WHERE id = $1 AND workspace_id = $2",
+            project_id,
+            workspace_id,
+        )
 
     async def list_projects(
         self, limit: int, offset: int, workspace_id: int | None = None
@@ -110,7 +118,11 @@ class PostgresProjectStorage:
     )
 
     async def update_project(
-        self, project_id: int, updates: dict[str, Any]
+        self,
+        project_id: int,
+        updates: dict[str, Any],
+        *,
+        workspace_id: int | None = None,
     ) -> dict[str, Any] | None:
         """Update project fields. Returns updated row or None if not found.
 
@@ -119,7 +131,7 @@ class PostgresProjectStorage:
         """
         safe_updates = {k: v for k, v in updates.items() if k in self._ALLOWED_COLUMNS}
         if not safe_updates:
-            return await self.fetch_project(project_id)
+            return await self.fetch_project(project_id, workspace_id=workspace_id)
         set_clauses = []
         params: list[Any] = []
         idx = 1
@@ -128,10 +140,15 @@ class PostgresProjectStorage:
             params.append(value)
             idx += 1
         params.append(project_id)
+        where_clause = f"id = ${idx}"
+        if workspace_id is not None:
+            idx += 1
+            params.append(workspace_id)
+            where_clause += f" AND workspace_id = ${idx}"
         query = f"""
             UPDATE creator_projects
             SET {", ".join(set_clauses)}, updated_at = NOW()
-            WHERE id = ${idx}
+            WHERE {where_clause}
             RETURNING *
         """
         return await fetch_one(query, *params)

--- a/packages/creator-service/creator_service/postgres_project_storage.py
+++ b/packages/creator-service/creator_service/postgres_project_storage.py
@@ -153,13 +153,20 @@ class PostgresProjectStorage:
         """
         return await fetch_one(query, *params)
 
-    async def delete_project(self, project_id: int) -> bool:
+    async def delete_project(self, project_id: int, *, workspace_id: int | None = None) -> bool:
         """Delete a project by id. Returns True if deleted.
 
         Runs are cascade-deleted by FK constraint.
         """
-        result = await fetch_one(
-            "DELETE FROM creator_projects WHERE id = $1 RETURNING id",
-            project_id,
-        )
+        if workspace_id is None:
+            result = await fetch_one(
+                "DELETE FROM creator_projects WHERE id = $1 RETURNING id",
+                project_id,
+            )
+        else:
+            result = await fetch_one(
+                "DELETE FROM creator_projects WHERE id = $1 AND workspace_id = $2 RETURNING id",
+                project_id,
+                workspace_id,
+            )
         return result is not None

--- a/packages/creator-service/creator_service/postgres_render_storage.py
+++ b/packages/creator-service/creator_service/postgres_render_storage.py
@@ -68,16 +68,40 @@ class PostgresRenderStorage:
             artifact_id,
         )
 
-    async def list_by_run(self, run_id: int) -> list[dict[str, Any]]:
+    async def list_by_run(
+        self, run_id: int, workspace_id: int | None = None
+    ) -> list[dict[str, Any]]:
+        if workspace_id is None:
+            return await fetch_all(
+                """
+                SELECT *
+                FROM creator_artifacts
+                WHERE run_id = $1 AND artifact_type = 'video'
+                ORDER BY created_at DESC
+                """,
+                run_id,
+            )
         return await fetch_all(
             """
-            SELECT *
-            FROM creator_artifacts
-            WHERE run_id = $1 AND artifact_type = 'video'
-            ORDER BY created_at DESC
+            SELECT a.*
+            FROM creator_artifacts a
+            WHERE a.run_id = $1
+              AND a.artifact_type = 'video'
+              AND EXISTS (
+                SELECT 1
+                FROM creator_runs r
+                WHERE r.id = a.run_id AND r.workspace_id = $2
+              )
+            ORDER BY a.created_at DESC
             """,
             run_id,
+            workspace_id,
         )
+
+    async def get_artifacts_for_run(
+        self, run_id: int, workspace_id: int | None = None
+    ) -> list[dict[str, Any]]:
+        return await self.list_by_run(run_id, workspace_id=workspace_id)
 
     async def get_latest_by_run(self, run_id: int) -> dict[str, Any] | None:
         return await fetch_one(

--- a/packages/creator-service/creator_service/postgres_run_storage.py
+++ b/packages/creator-service/creator_service/postgres_run_storage.py
@@ -126,6 +126,7 @@ class PostgresRunStorage:
 
         keys = list(updates.keys())
         assignments = ", ".join(f"{key} = ${idx}" for idx, key in enumerate(keys, start=3))
+        assignments = f"{assignments}, version = version + 1"
         values = [run_id, list(expected_stages), *[updates[key] for key in keys]]
         query = (
             f"UPDATE creator_runs SET {assignments} "

--- a/packages/creator-service/creator_service/postgres_run_storage.py
+++ b/packages/creator-service/creator_service/postgres_run_storage.py
@@ -55,12 +55,25 @@ class PostgresRunStorage:
             raise ValueError("Failed to create run")
         return saved
 
-    async def get_run(self, run_id: int) -> dict[str, Any] | None:
-        return await fetch_one("SELECT * FROM creator_runs WHERE id = $1", run_id)
+    async def get_run(self, run_id: int, workspace_id: int | None = None) -> dict[str, Any] | None:
+        if workspace_id is None:
+            return await fetch_one("SELECT * FROM creator_runs WHERE id = $1", run_id)
+        return await fetch_one(
+            "SELECT * FROM creator_runs WHERE id = $1 AND workspace_id = $2",
+            run_id,
+            workspace_id,
+        )
 
-    async def update_run(self, run_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+    async def update_run(
+        self,
+        run_id: int,
+        updates: dict[str, Any],
+        *,
+        workspace_id: int | None = None,
+        expected_version: int | None = None,
+    ) -> dict[str, Any] | None:
         if not updates:
-            current = await self.get_run(run_id)
+            current = await self.get_run(run_id, workspace_id=workspace_id)
             if current is None:
                 raise ValueError(f"Run {run_id} not found")
             return current
@@ -72,10 +85,21 @@ class PostgresRunStorage:
 
         keys = list(updates.keys())
         assignments = ", ".join(f"{key} = ${idx}" for idx, key in enumerate(keys, start=2))
-        values = [run_id, *[updates[key] for key in keys]]
-        query = f"UPDATE creator_runs SET {assignments} WHERE id = $1 RETURNING *"
+        values: list[Any] = [run_id, *[updates[key] for key in keys]]
+        where_clauses = ["id = $1"]
+        next_index = len(values) + 1
+        if workspace_id is not None:
+            where_clauses.append(f"workspace_id = ${next_index}")
+            values.append(workspace_id)
+            next_index += 1
+        if expected_version is not None:
+            where_clauses.append(f"version = ${next_index}")
+            values.append(expected_version)
+        query = (
+            f"UPDATE creator_runs SET {assignments} WHERE {' AND '.join(where_clauses)} RETURNING *"
+        )
         updated = await fetch_one(query, *values)
-        if updated is None:
+        if updated is None and expected_version is None:
             raise ValueError(f"Run {run_id} not found")
         return updated
 

--- a/packages/creator-service/creator_service/postgres_run_storage.py
+++ b/packages/creator-service/creator_service/postgres_run_storage.py
@@ -110,9 +110,10 @@ class PostgresRunStorage:
         run_id: int,
         updates: dict[str, Any],
         expected_stages: frozenset[str],
+        workspace_id: int | None = None,
     ) -> tuple[bool, dict[str, Any] | None]:
         if not updates:
-            current = await self.get_run(run_id)
+            current = await self.get_run(run_id, workspace_id=workspace_id)
             if current is None:
                 return False, None
             if current.get("current_stage") in expected_stages:
@@ -128,27 +129,45 @@ class PostgresRunStorage:
         assignments = ", ".join(f"{key} = ${idx}" for idx, key in enumerate(keys, start=3))
         assignments = f"{assignments}, version = version + 1"
         values = [run_id, list(expected_stages), *[updates[key] for key in keys]]
+        where_clauses = ["id = $1", "current_stage = ANY($2::text[])"]
+        if workspace_id is not None:
+            where_clauses.append(f"workspace_id = ${len(values) + 1}")
+            values.append(workspace_id)
         query = (
-            f"UPDATE creator_runs SET {assignments} "
-            "WHERE id = $1 AND current_stage = ANY($2::text[]) RETURNING *"
+            f"UPDATE creator_runs SET {assignments} WHERE {' AND '.join(where_clauses)} RETURNING *"
         )
         updated = await fetch_one(query, *values)
         if updated is not None:
             return True, updated
-        current = await self.get_run(run_id)
+        current = await self.get_run(run_id, workspace_id=workspace_id)
         if current is None:
             return False, None
         return False, current
 
-    async def merge_model_defaults(self, run_id: int, updates_json: str) -> dict[str, Any]:
+    async def merge_model_defaults(
+        self,
+        run_id: int,
+        updates_json: str,
+        workspace_id: int | None = None,
+    ) -> dict[str, Any]:
         """Atomically merge JSON updates into model_defaults_json using PostgreSQL jsonb."""
-        row = await fetch_one(
-            "UPDATE creator_runs "
-            "SET model_defaults_json = (COALESCE(model_defaults_json, '{}')::jsonb || $2::jsonb)::text "
-            "WHERE id = $1 RETURNING *",
-            run_id,
-            updates_json,
-        )
+        if workspace_id is None:
+            row = await fetch_one(
+                "UPDATE creator_runs "
+                "SET model_defaults_json = (COALESCE(model_defaults_json, '{}')::jsonb || $2::jsonb)::text "
+                "WHERE id = $1 RETURNING *",
+                run_id,
+                updates_json,
+            )
+        else:
+            row = await fetch_one(
+                "UPDATE creator_runs "
+                "SET model_defaults_json = (COALESCE(model_defaults_json, '{}')::jsonb || $2::jsonb)::text "
+                "WHERE id = $1 AND workspace_id = $3 RETURNING *",
+                run_id,
+                updates_json,
+                workspace_id,
+            )
         if row is None:
             raise ValueError(f"Run {run_id} not found")
         return row
@@ -165,12 +184,19 @@ class PostgresRunStorage:
             workspace_id,
         )
 
-    async def delete_run(self, run_id: int) -> bool:
+    async def delete_run(self, run_id: int, workspace_id: int | None = None) -> bool:
         """Delete a run by id. Returns True if deleted."""
-        result = await fetch_one(
-            "DELETE FROM creator_runs WHERE id = $1 RETURNING id",
-            run_id,
-        )
+        if workspace_id is None:
+            result = await fetch_one(
+                "DELETE FROM creator_runs WHERE id = $1 RETURNING id",
+                run_id,
+            )
+        else:
+            result = await fetch_one(
+                "DELETE FROM creator_runs WHERE id = $1 AND workspace_id = $2 RETURNING id",
+                run_id,
+                workspace_id,
+            )
         return result is not None
 
     async def delete_runs_by_project(self, project_id: int) -> int:

--- a/packages/creator-service/creator_service/postgres_run_storage.py
+++ b/packages/creator-service/creator_service/postgres_run_storage.py
@@ -84,7 +84,7 @@ class PostgresRunStorage:
             raise ValueError(f"Invalid update columns: {invalid_list}")
 
         keys = list(updates.keys())
-        assignments = ", ".join(f"{key} = ${idx}" for idx, key in enumerate(keys, start=2))
+        assignments_parts = [f"{key} = ${idx}" for idx, key in enumerate(keys, start=2)]
         values: list[Any] = [run_id, *[updates[key] for key in keys]]
         where_clauses = ["id = $1"]
         next_index = len(values) + 1
@@ -95,6 +95,8 @@ class PostgresRunStorage:
         if expected_version is not None:
             where_clauses.append(f"version = ${next_index}")
             values.append(expected_version)
+            assignments_parts.append("version = version + 1")
+        assignments = ", ".join(assignments_parts)
         query = (
             f"UPDATE creator_runs SET {assignments} WHERE {' AND '.join(where_clauses)} RETURNING *"
         )

--- a/packages/creator-service/creator_service/project_service.py
+++ b/packages/creator-service/creator_service/project_service.py
@@ -22,7 +22,9 @@ class ProjectStorageBackend(Protocol):
 
     async def insert_project(self, payload: dict[str, Any]) -> dict[str, Any]: ...
 
-    async def fetch_project(self, project_id: int) -> dict[str, Any] | None: ...
+    async def fetch_project(
+        self, project_id: int, workspace_id: int | None = None
+    ) -> dict[str, Any] | None: ...
 
     async def list_projects(
         self, limit: int, offset: int, workspace_id: int | None = None
@@ -33,12 +35,16 @@ class ProjectStorageBackend(Protocol):
     async def count_projects(self, workspace_id: int | None = None) -> int: ...
 
     async def update_project(
-        self, project_id: int, updates: dict[str, Any]
+        self,
+        project_id: int,
+        updates: dict[str, Any],
+        *,
+        workspace_id: int | None = None,
     ) -> dict[str, Any] | None:
         """Update project fields. Returns updated row or None if not found."""
         ...
 
-    async def delete_project(self, project_id: int) -> bool:
+    async def delete_project(self, project_id: int, *, workspace_id: int | None = None) -> bool:
         """Delete a project by id. Returns True if deleted."""
         ...
 
@@ -73,9 +79,13 @@ class InMemoryProjectStorage:
         self._projects[project_id] = row
         return dict(row)
 
-    async def fetch_project(self, project_id: int) -> dict[str, Any] | None:
+    async def fetch_project(
+        self, project_id: int, workspace_id: int | None = None
+    ) -> dict[str, Any] | None:
         row = self._projects.get(project_id)
         if row is None:
+            return None
+        if workspace_id is not None and row.get("workspace_id") != workspace_id:
             return None
         return dict(row)
 
@@ -97,17 +107,28 @@ class InMemoryProjectStorage:
         return sum(1 for row in self._projects.values() if row.get("workspace_id") == workspace_id)
 
     async def update_project(
-        self, project_id: int, updates: dict[str, Any]
+        self,
+        project_id: int,
+        updates: dict[str, Any],
+        *,
+        workspace_id: int | None = None,
     ) -> dict[str, Any] | None:
         row = self._projects.get(project_id)
         if row is None:
+            return None
+        if workspace_id is not None and row.get("workspace_id") != workspace_id:
             return None
         for key, value in updates.items():
             row[key] = value
         row["updated_at"] = datetime.now(timezone.utc)
         return dict(row)
 
-    async def delete_project(self, project_id: int) -> bool:
+    async def delete_project(self, project_id: int, *, workspace_id: int | None = None) -> bool:
+        row = self._projects.get(project_id)
+        if row is None:
+            return False
+        if workspace_id is not None and row.get("workspace_id") != workspace_id:
+            return False
         if project_id in self._projects:
             del self._projects[project_id]
             # Also remove associated runs
@@ -224,8 +245,8 @@ class ProjectService:
         )
         return Project.model_validate(row)
 
-    async def get_project(self, project_id: int) -> Project | None:
-        row = await self.db.fetch_project(project_id)
+    async def get_project(self, project_id: int, workspace_id: int | None = None) -> Project | None:
+        row = await self.db.fetch_project(project_id, workspace_id=workspace_id)
         if row is None:
             return None
 
@@ -250,17 +271,23 @@ class ProjectService:
     async def count_projects(self, workspace_id: int | None = None) -> int:
         return await self.db.count_projects(workspace_id=workspace_id)
 
-    async def update_project(self, project_id: int, title: str) -> Project | None:
+    async def update_project(
+        self, project_id: int, title: str, workspace_id: int | None = None
+    ) -> Project | None:
         """Update project title."""
-        row = await self.db.update_project(project_id, {"title": title})
+        row = await self.db.update_project(
+            project_id,
+            {"title": title},
+            workspace_id=workspace_id,
+        )
         if row is None:
             return None
         latest_run = await self.db.fetch_latest_run_summary(project_id)
         return ProjectWithLatestRun.model_validate({**row, "latest_run": latest_run})
 
-    async def delete_project(self, project_id: int) -> bool:
+    async def delete_project(self, project_id: int, workspace_id: int | None = None) -> bool:
         """Delete a project. FK cascade handles associated runs."""
-        return await self.db.delete_project(project_id)
+        return await self.db.delete_project(project_id, workspace_id=workspace_id)
 
 
 def _create_storage() -> ProjectStorageBackend:

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -19,11 +19,18 @@ class RunStorageBackend(Protocol):
         """Persist a run row and return stored row."""
         ...
 
-    async def get_run(self, run_id: int) -> dict[str, Any] | None:
+    async def get_run(self, run_id: int, workspace_id: int | None = None) -> dict[str, Any] | None:
         """Fetch run row by id."""
         ...
 
-    async def update_run(self, run_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+    async def update_run(
+        self,
+        run_id: int,
+        updates: dict[str, Any],
+        *,
+        workspace_id: int | None = None,
+        expected_version: int | None = None,
+    ) -> dict[str, Any] | None:
         """Update and return run row by id."""
         ...
 
@@ -61,6 +68,10 @@ class RunStorageBackend(Protocol):
         ...
 
 
+class ConflictError(Exception):
+    pass
+
+
 class InMemoryRunStorage:
     def __init__(self) -> None:
         self._rows: dict[int, dict[str, Any]] = {}
@@ -72,22 +83,40 @@ class InMemoryRunStorage:
             "id": self._next_id,
             "created_at": now,
             "updated_at": now,
+            "version": int(row.get("version") or 0),
             **row,
         }
         self._rows[self._next_id] = saved
         self._next_id += 1
         return dict(saved)
 
-    async def get_run(self, run_id: int) -> dict[str, Any] | None:
+    async def get_run(self, run_id: int, workspace_id: int | None = None) -> dict[str, Any] | None:
         row = self._rows.get(run_id)
-        return dict(row) if row is not None else None
+        if row is None:
+            return None
+        if workspace_id is not None and row.get("workspace_id") != workspace_id:
+            return None
+        return dict(row)
 
-    async def update_run(self, run_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+    async def update_run(
+        self,
+        run_id: int,
+        updates: dict[str, Any],
+        *,
+        workspace_id: int | None = None,
+        expected_version: int | None = None,
+    ) -> dict[str, Any] | None:
         row = self._rows.get(run_id)
         if row is None:
             raise ValueError(f"Run {run_id} not found")
+        if workspace_id is not None and row.get("workspace_id") != workspace_id:
+            raise ValueError(f"Run {run_id} not found")
+        current_version = int(row.get("version") or 0)
+        if expected_version is not None and current_version != expected_version:
+            return None
 
         row.update(updates)
+        row["version"] = current_version + 1
         row["updated_at"] = datetime.now(timezone.utc)
         self._rows[run_id] = row
         return dict(row)
@@ -228,7 +257,10 @@ class RunService:
                 "restart_from": target_stage.value,
                 "current_stage": target_stage.value,
             },
+            expected_version=int(getattr(run, "version", 0) or 0),
         )
+        if row is None:
+            raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
     async def advance_stage(self, run_id: int, target_stage: str) -> PipelineRun:
@@ -261,7 +293,10 @@ class RunService:
         row = await self.storage.update_run(
             run_id,
             {"current_stage": target.value},
+            expected_version=int(getattr(run, "version", 0) or 0),
         )
+        if row is None:
+            raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
     async def list_runs_by_project(self, project_id: int) -> list[PipelineRun]:
@@ -304,7 +339,10 @@ class RunService:
                 "status": "cancelled",
                 "current_stage": rollback_stage.value,
             },
+            expected_version=int(getattr(run, "version", 0) or 0),
         )
+        if row is None:
+            raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
     async def resume_run(self, run_id: int) -> PipelineRun:
@@ -325,7 +363,10 @@ class RunService:
         row = await self.storage.update_run(
             run_id,
             {"status": "running"},
+            expected_version=int(getattr(run, "version", 0) or 0),
         )
+        if row is None:
+            raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
     async def go_back(self, run_id: int) -> PipelineRun:

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -220,14 +220,16 @@ class RunService:
         )
         return PipelineRun.from_row(row)
 
-    async def get_run(self, run_id: int) -> PipelineRun | None:
-        row = await self.storage.get_run(run_id)
+    async def get_run(self, run_id: int, workspace_id: int | None = None) -> PipelineRun | None:
+        row = await self.storage.get_run(run_id, workspace_id=workspace_id)
         if row is None:
             return None
         return PipelineRun.from_row(row)
 
-    async def restart_run(self, run_id: int, from_stage: str) -> PipelineRun:
-        run = await self.get_run(run_id)
+    async def restart_run(
+        self, run_id: int, from_stage: str, workspace_id: int | None = None
+    ) -> PipelineRun:
+        run = await self.get_run(run_id, workspace_id=workspace_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")
 
@@ -257,18 +259,21 @@ class RunService:
                 "restart_from": target_stage.value,
                 "current_stage": target_stage.value,
             },
+            workspace_id=workspace_id,
             expected_version=int(getattr(run, "version", 0) or 0),
         )
         if row is None:
             raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
-    async def advance_stage(self, run_id: int, target_stage: str) -> PipelineRun:
+    async def advance_stage(
+        self, run_id: int, target_stage: str, workspace_id: int | None = None
+    ) -> PipelineRun:
         """Advance a run to the next stage (approval/forward progression).
 
         Unlike restart_run, this does NOT set restart_from.
         """
-        run = await self.get_run(run_id)
+        run = await self.get_run(run_id, workspace_id=workspace_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")
 
@@ -293,6 +298,7 @@ class RunService:
         row = await self.storage.update_run(
             run_id,
             {"current_stage": target.value},
+            workspace_id=workspace_id,
             expected_version=int(getattr(run, "version", 0) or 0),
         )
         if row is None:
@@ -308,13 +314,13 @@ class RunService:
         rows = await self.storage.list_runs_by_workspace(workspace_id)
         return [PipelineRun.from_row(r) for r in rows]
 
-    async def stop_run(self, run_id: int) -> PipelineRun:
+    async def stop_run(self, run_id: int, workspace_id: int | None = None) -> PipelineRun:
         """Stop a running pipeline. Only allowed during GENERATING stages.
 
         Moves current_stage back to the pre-generating actionable stage so
         any surviving worker task's CAS will fail (stage no longer in _SAFE_STAGES).
         """
-        run = await self.get_run(run_id)
+        run = await self.get_run(run_id, workspace_id=workspace_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")
 
@@ -339,19 +345,20 @@ class RunService:
                 "status": "cancelled",
                 "current_stage": rollback_stage.value,
             },
+            workspace_id=workspace_id,
             expected_version=int(getattr(run, "version", 0) or 0),
         )
         if row is None:
             raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
-    async def resume_run(self, run_id: int) -> PipelineRun:
+    async def resume_run(self, run_id: int, workspace_id: int | None = None) -> PipelineRun:
         """Resume a stopped/cancelled or failed run.
 
         After stop, current_stage is already at an actionable stage.
         Just resets status to 'running' so the user can re-trigger generation.
         """
-        run = await self.get_run(run_id)
+        run = await self.get_run(run_id, workspace_id=workspace_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")
 
@@ -363,6 +370,7 @@ class RunService:
         row = await self.storage.update_run(
             run_id,
             {"status": "running"},
+            workspace_id=workspace_id,
             expected_version=int(getattr(run, "version", 0) or 0),
         )
         if row is None:

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -378,8 +378,8 @@ class RunService:
             raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
-    async def go_back(self, run_id: int) -> PipelineRun:
-        run = await self.get_run(run_id)
+    async def go_back(self, run_id: int, workspace_id: int | None = None) -> PipelineRun:
+        run = await self.get_run(run_id, workspace_id=workspace_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")
 
@@ -408,20 +408,28 @@ class RunService:
         if not ok:
             if row is None:
                 raise ValueError(f"Run {run_id} not found")
-            raise RuntimeError(
+            raise ConflictError(
                 f"Stage conflict: expected '{current.value}' but run is at '{row.get('current_stage')}'"
             )
         if row is None:
             raise ValueError(f"Run {run_id} not found")
         return PipelineRun.from_row(row)
 
-    async def update_model_defaults(self, run_id: int, updates: dict[str, str]) -> PipelineRun:
+    async def update_model_defaults(
+        self, run_id: int, updates: dict[str, str], workspace_id: int | None = None
+    ) -> PipelineRun:
         """Atomically merge model default updates (no read-merge-write race)."""
+        run = await self.get_run(run_id, workspace_id=workspace_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
         row = await self.storage.merge_model_defaults(run_id, json.dumps(updates))
         return PipelineRun.from_row(row)
 
-    async def delete_run(self, run_id: int) -> bool:
+    async def delete_run(self, run_id: int, workspace_id: int | None = None) -> bool:
         """Delete a run and return True if deleted."""
+        run = await self.get_run(run_id, workspace_id=workspace_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
         return await self.storage.delete_run(run_id)
 
 

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -133,6 +133,7 @@ class InMemoryRunStorage:
         if row.get("current_stage") not in expected_stages:
             return False, dict(row)
         row.update(updates)
+        row["version"] = int(row.get("version") or 0) + 1
         row["updated_at"] = datetime.now(timezone.utc)
         self._rows[run_id] = row
         return True, dict(row)

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -39,6 +39,7 @@ class RunStorageBackend(Protocol):
         run_id: int,
         updates: dict[str, Any],
         expected_stages: frozenset[str],
+        workspace_id: int | None = None,
     ) -> tuple[bool, dict[str, Any] | None]:
         """Atomically update run only if current_stage is in expected_stages.
 
@@ -55,7 +56,7 @@ class RunStorageBackend(Protocol):
         """Return all run rows for a workspace, newest first."""
         ...
 
-    async def delete_run(self, run_id: int) -> bool:
+    async def delete_run(self, run_id: int, workspace_id: int | None = None) -> bool:
         """Delete a run by id. Returns True if deleted."""
         ...
 
@@ -63,7 +64,12 @@ class RunStorageBackend(Protocol):
         """Delete all runs for a project. Returns count of deleted rows."""
         ...
 
-    async def merge_model_defaults(self, run_id: int, updates_json: str) -> dict[str, Any]:
+    async def merge_model_defaults(
+        self,
+        run_id: int,
+        updates_json: str,
+        workspace_id: int | None = None,
+    ) -> dict[str, Any]:
         """Atomically merge JSON updates into model_defaults_json."""
         ...
 
@@ -126,9 +132,12 @@ class InMemoryRunStorage:
         run_id: int,
         updates: dict[str, Any],
         expected_stages: frozenset[str],
+        workspace_id: int | None = None,
     ) -> tuple[bool, dict[str, Any] | None]:
         row = self._rows.get(run_id)
         if row is None:
+            return False, None
+        if workspace_id is not None and row.get("workspace_id") != workspace_id:
             return False, None
         if row.get("current_stage") not in expected_stages:
             return False, dict(row)
@@ -148,15 +157,26 @@ class InMemoryRunStorage:
         rows.sort(key=lambda r: r.get("id", 0), reverse=True)
         return rows
 
-    async def delete_run(self, run_id: int) -> bool:
+    async def delete_run(self, run_id: int, workspace_id: int | None = None) -> bool:
+        if workspace_id is not None:
+            row = self._rows.get(run_id)
+            if row is None or row.get("workspace_id") != workspace_id:
+                return False
         if run_id in self._rows:
             del self._rows[run_id]
             return True
         return False
 
-    async def merge_model_defaults(self, run_id: int, updates_json: str) -> dict[str, Any]:
+    async def merge_model_defaults(
+        self,
+        run_id: int,
+        updates_json: str,
+        workspace_id: int | None = None,
+    ) -> dict[str, Any]:
         row = self._rows.get(run_id)
         if row is None:
+            raise ValueError(f"Run {run_id} not found")
+        if workspace_id is not None and row.get("workspace_id") != workspace_id:
             raise ValueError(f"Run {run_id} not found")
         current = json.loads(row.get("model_defaults_json") or "{}")
         updates = json.loads(updates_json)
@@ -264,6 +284,9 @@ class RunService:
             expected_version=int(getattr(run, "version", 0) or 0),
         )
         if row is None:
+            latest_run = await self.get_run(run_id, workspace_id=workspace_id)
+            if latest_run is None:
+                raise ValueError(f"Run {run_id} not found")
             raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
@@ -303,6 +326,9 @@ class RunService:
             expected_version=int(getattr(run, "version", 0) or 0),
         )
         if row is None:
+            latest_run = await self.get_run(run_id, workspace_id=workspace_id)
+            if latest_run is None:
+                raise ValueError(f"Run {run_id} not found")
             raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
@@ -350,6 +376,9 @@ class RunService:
             expected_version=int(getattr(run, "version", 0) or 0),
         )
         if row is None:
+            latest_run = await self.get_run(run_id, workspace_id=workspace_id)
+            if latest_run is None:
+                raise ValueError(f"Run {run_id} not found")
             raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
@@ -375,6 +404,9 @@ class RunService:
             expected_version=int(getattr(run, "version", 0) or 0),
         )
         if row is None:
+            latest_run = await self.get_run(run_id, workspace_id=workspace_id)
+            if latest_run is None:
+                raise ValueError(f"Run {run_id} not found")
             raise ConflictError(f"Run {run_id} has stale version")
         return PipelineRun.from_row(row)
 
@@ -404,6 +436,7 @@ class RunService:
             run_id,
             {"current_stage": target.value},
             frozenset({current.value}),
+            workspace_id=workspace_id,
         )
         if not ok:
             if row is None:
@@ -422,7 +455,11 @@ class RunService:
         run = await self.get_run(run_id, workspace_id=workspace_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")
-        row = await self.storage.merge_model_defaults(run_id, json.dumps(updates))
+        row = await self.storage.merge_model_defaults(
+            run_id,
+            json.dumps(updates),
+            workspace_id=workspace_id,
+        )
         return PipelineRun.from_row(row)
 
     async def delete_run(self, run_id: int, workspace_id: int | None = None) -> bool:
@@ -430,7 +467,7 @@ class RunService:
         run = await self.get_run(run_id, workspace_id=workspace_id)
         if run is None:
             raise ValueError(f"Run {run_id} not found")
-        return await self.storage.delete_run(run_id)
+        return await self.storage.delete_run(run_id, workspace_id=workspace_id)
 
 
 def _create_storage() -> RunStorageBackend:

--- a/packages/creator-service/creator_service/stage_review_service.py
+++ b/packages/creator-service/creator_service/stage_review_service.py
@@ -127,6 +127,7 @@ class StageReviewService:
             run_id,
             {"current_stage": target.value},
             frozenset({stage.value}),
+            workspace_id=workspace_id,
         )
 
         if not ok:

--- a/packages/creator-service/creator_service/stage_review_service.py
+++ b/packages/creator-service/creator_service/stage_review_service.py
@@ -13,9 +13,7 @@ class StageReviewStorageBackend(Protocol):
         """Persist a review row and return stored row."""
         ...
 
-    async def get_latest_review(
-        self, run_id: int, stage_name: str
-    ) -> dict[str, Any] | None:
+    async def get_latest_review(self, run_id: int, stage_name: str) -> dict[str, Any] | None:
         """Fetch the most recent review for a run and stage."""
         ...
 
@@ -36,14 +34,8 @@ class InMemoryStageReviewStorage:
         self._next_id += 1
         return dict(saved)
 
-    async def get_latest_review(
-        self, run_id: int, stage_name: str
-    ) -> dict[str, Any] | None:
-        matches = [
-            r
-            for r in self._rows
-            if r["run_id"] == run_id and r["stage_name"] == stage_name
-        ]
+    async def get_latest_review(self, run_id: int, stage_name: str) -> dict[str, Any] | None:
+        matches = [r for r in self._rows if r["run_id"] == run_id and r["stage_name"] == stage_name]
         if not matches:
             return None
         return dict(max(matches, key=lambda r: r["created_at"]))
@@ -96,6 +88,7 @@ class StageReviewService:
         target_stage: str,
         reviewer: str = "agent",
         notes: str | None = None,
+        workspace_id: int | None = None,
     ) -> Any:
         """Atomically validate stage, record approval, and advance.
 
@@ -127,9 +120,7 @@ class StageReviewService:
             raise ValueError(f"Invalid target stage '{target_stage}'") from exc
 
         if not can_transition(stage, target):
-            raise ValueError(
-                f"Cannot transition from {stage.value} to {target.value}"
-            )
+            raise ValueError(f"Cannot transition from {stage.value} to {target.value}")
 
         # 3. Atomically advance stage (CAS — fails if stage changed concurrently)
         ok, row = await run_service.storage.conditional_update_run(
@@ -157,14 +148,12 @@ class StageReviewService:
             }
         )
 
-        updated_run = await run_service.get_run(run_id)
+        updated_run = await run_service.get_run(run_id, workspace_id=workspace_id)
         if updated_run is None:
             raise ValueError(f"Run {run_id} not found")
         return updated_run
 
-    async def get_latest_review(
-        self, run_id: int, stage_name: str
-    ) -> dict[str, Any] | None:
+    async def get_latest_review(self, run_id: int, stage_name: str) -> dict[str, Any] | None:
         """Get the latest review for a run and stage."""
         return await self.storage.get_latest_review(run_id, stage_name)
 

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -247,6 +247,13 @@ class TaskDispatchService:
             expected_stages=expected_stages,
         )
         if not ok:
+            if workspace_id_for_reservation is not None and quota_operation_type is not None:
+                from creator_service.usage_service import cancel_workspace_quota_reservation
+
+                await cancel_workspace_quota_reservation(
+                    workspace_id_for_reservation,
+                    quota_operation_type,
+                )
             if row is None:
                 raise HTTPException(status_code=404, detail="Run not found")
             raise HTTPException(

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -211,6 +211,7 @@ class TaskDispatchService:
         enqueue_error_detail: str,
         restart_from_stage: str | None = None,
         quota_operation_type: str | None = None,
+        workspace_id: int | None = None,
     ) -> dict[str, object]:
         run_service_obj = cast(Any, run_service)
         workspace_id_for_reservation: int | None = None
@@ -218,10 +219,24 @@ class TaskDispatchService:
             from creator_service.project_service import project_service
             from creator_service.usage_service import check_workspace_quota
 
-            run = await run_service_obj.get_run(run_id)
+            if workspace_id is None:
+                run = await run_service_obj.get_run(run_id)
+            else:
+                try:
+                    run = await run_service_obj.get_run(run_id, workspace_id=workspace_id)
+                except TypeError:
+                    run = await run_service_obj.get_run(run_id)
             if run is None:
                 raise HTTPException(status_code=404, detail="Run not found")
-            project = await project_service.get_project(run.project_id)
+            if workspace_id is None:
+                project = await project_service.get_project(run.project_id)
+            else:
+                try:
+                    project = await project_service.get_project(
+                        run.project_id, workspace_id=workspace_id
+                    )
+                except TypeError:
+                    project = await project_service.get_project(run.project_id)
             if project is None:
                 raise HTTPException(status_code=404, detail="Project not found")
             workspace_id = cast(int | None, getattr(project, "workspace_id", None))
@@ -412,6 +427,7 @@ async def cas_dispatch_with_rollback(
     enqueue_error_detail: str,
     restart_from_stage: str | None = None,
     quota_operation_type: str | None = None,
+    workspace_id: int | None = None,
 ) -> dict[str, object]:
     return await task_dispatch_service.cas_dispatch_with_rollback(
         run_id=run_id,
@@ -425,4 +441,5 @@ async def cas_dispatch_with_rollback(
         enqueue_error_detail=enqueue_error_detail,
         restart_from_stage=restart_from_stage,
         quota_operation_type=quota_operation_type,
+        workspace_id=workspace_id,
     )

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -260,6 +260,7 @@ class TaskDispatchService:
             run_id,
             updates,
             expected_stages=expected_stages,
+            workspace_id=workspace_id,
         )
         if not ok:
             if workspace_id_for_reservation is not None and quota_operation_type is not None:
@@ -299,6 +300,7 @@ class TaskDispatchService:
                 run_id,
                 {"current_stage": rollback_stage, "restart_from": rollback_restart_from},
                 expected_stages=frozenset({target_stage}),
+                workspace_id=workspace_id,
             )
             raise HTTPException(status_code=503, detail=enqueue_error_detail) from None
 
@@ -335,6 +337,7 @@ class TaskDispatchService:
                 run_id,
                 {"current_stage": rollback_stage, "restart_from": rollback_restart_from},
                 expected_stages=frozenset({target_stage}),
+                workspace_id=workspace_id,
             )
             raise HTTPException(status_code=503, detail=enqueue_error_detail) from None
         return {

--- a/packages/creator-service/tests/test_run_service.py
+++ b/packages/creator-service/tests/test_run_service.py
@@ -170,37 +170,8 @@ def test_restart_run_allows_valid_review_stage_restart() -> None:
     assert restarted.current_stage == RunStage.SCRIPT_GENERATING.value
 
 
-class _CasAwareStorage(InMemoryRunStorage):
-    def __init__(self) -> None:
-        super().__init__()
-        self.force_conflict_next_update = False
-
-    async def update_run(
-        self,
-        run_id: int,
-        updates: dict[str, object],
-        *,
-        workspace_id: int | None = None,
-        expected_version: int | None = None,
-    ) -> dict[str, object] | None:
-        row = await self.get_run(run_id)
-        if row is None:
-            raise ValueError(f"Run {run_id} not found")
-        if workspace_id is not None and row.get("workspace_id") != workspace_id:
-            raise ValueError(f"Run {run_id} not found")
-        current_version = int(row.get("version") or 0)
-        if expected_version is not None and self.force_conflict_next_update:
-            self.force_conflict_next_update = False
-            return None  # type: ignore[return-value]
-        if expected_version is not None and expected_version != current_version:
-            return None  # type: ignore[return-value]
-        updates_with_version = dict(updates)
-        updates_with_version["version"] = current_version + 1
-        return await super().update_run(run_id, updates_with_version)
-
-
 def test_advance_stage_raises_conflict_for_stale_version() -> None:
-    storage = _CasAwareStorage()
+    storage = InMemoryRunStorage()
     service = RunService(storage)
 
     created = asyncio.run(
@@ -213,7 +184,26 @@ def test_advance_stage_raises_conflict_for_stale_version() -> None:
         )
     )
     asyncio.run(storage.update_run(created.id, {"current_stage": RunStage.SCRIPT_GENERATING.value}))
-    storage.force_conflict_next_update = True
+
+    original_update = storage.update_run
+
+    async def conflicting_update_run(
+        run_id: int,
+        updates: dict[str, object],
+        *,
+        workspace_id: int | None = None,
+        expected_version: int | None = None,
+    ):
+        if expected_version is not None:
+            await original_update(run_id, {"status": "running"}, workspace_id=workspace_id)
+        return await original_update(
+            run_id,
+            updates,
+            workspace_id=workspace_id,
+            expected_version=expected_version,
+        )
+
+    storage.update_run = conflicting_update_run  # type: ignore[method-assign]
 
     with pytest.raises(ConflictError, match="stale version"):
-        asyncio.run(service.advance_stage(created.id, RunStage.SCRIPT_REVIEW.value))
+        asyncio.run(service.advance_stage(created.id, RunStage.SCRIPT_REVIEW.value, workspace_id=1))

--- a/packages/creator-service/tests/test_run_service.py
+++ b/packages/creator-service/tests/test_run_service.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 from creator_domain.models import ModelSelection, RunStage
-from creator_service.run_service import InMemoryRunStorage, RunService
+from creator_service.run_service import ConflictError, InMemoryRunStorage, RunService
 
 
 def test_create_run_with_model_defaults_and_style_preset() -> None:
@@ -151,16 +151,69 @@ def test_restart_run_allows_valid_review_stage_restart() -> None:
     # We need to restart from SCRIPT_GENERATING to SCRIPT_REVIEW first
     # But since we can't directly manipulate, let's test SCRIPT_GENERATING -> SCRIPT_REVIEW transition
     # by using the fact that stage1 is now in SCRIPT_GENERATING
-    
+
     # Test: from SCRIPT_REVIEW, can restart to SCRIPT_GENERATING (the generating stage)
     # We'll create a test scenario differently:
     storage = InMemoryRunStorage()
     service2 = RunService(storage)
-    created2 = asyncio.run(service2.create_run(project_id=14, model_defaults={"script_model": "qwen3-4b"}, style_preset="default"))
-    
+    created2 = asyncio.run(
+        service2.create_run(
+            project_id=14, model_defaults={"script_model": "qwen3-4b"}, style_preset="default"
+        )
+    )
+
     # Simulate being in SCRIPT_REVIEW by manually updating storage
     asyncio.run(storage.update_run(created2.id, {"current_stage": RunStage.SCRIPT_REVIEW.value}))
-    
+
     # Now restart from SCRIPT_REVIEW to SCRIPT_GENERATING should succeed (per TRANSITIONS dict)
     restarted = asyncio.run(service2.restart_run(created2.id, RunStage.SCRIPT_GENERATING.value))
     assert restarted.current_stage == RunStage.SCRIPT_GENERATING.value
+
+
+class _CasAwareStorage(InMemoryRunStorage):
+    def __init__(self) -> None:
+        super().__init__()
+        self.force_conflict_next_update = False
+
+    async def update_run(
+        self,
+        run_id: int,
+        updates: dict[str, object],
+        *,
+        workspace_id: int | None = None,
+        expected_version: int | None = None,
+    ) -> dict[str, object] | None:
+        row = await self.get_run(run_id)
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+        if workspace_id is not None and row.get("workspace_id") != workspace_id:
+            raise ValueError(f"Run {run_id} not found")
+        current_version = int(row.get("version") or 0)
+        if expected_version is not None and self.force_conflict_next_update:
+            self.force_conflict_next_update = False
+            return None  # type: ignore[return-value]
+        if expected_version is not None and expected_version != current_version:
+            return None  # type: ignore[return-value]
+        updates_with_version = dict(updates)
+        updates_with_version["version"] = current_version + 1
+        return await super().update_run(run_id, updates_with_version)
+
+
+def test_advance_stage_raises_conflict_for_stale_version() -> None:
+    storage = _CasAwareStorage()
+    service = RunService(storage)
+
+    created = asyncio.run(
+        service.create_run(
+            project_id=21,
+            model_defaults=None,
+            style_preset="default",
+            current_stage=RunStage.IDEA_READY.value,
+            workspace_id=1,
+        )
+    )
+    asyncio.run(storage.update_run(created.id, {"current_stage": RunStage.SCRIPT_GENERATING.value}))
+    storage.force_conflict_next_update = True
+
+    with pytest.raises(ConflictError, match="stale version"):
+        asyncio.run(service.advance_stage(created.id, RunStage.SCRIPT_REVIEW.value))

--- a/packages/creator-service/tests/test_run_service.py
+++ b/packages/creator-service/tests/test_run_service.py
@@ -243,3 +243,99 @@ def test_conditional_update_run_increments_version_and_blocks_stale_lifecycle_wr
         )
     )
     assert stale is None
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args"),
+    [
+        ("restart_run", (RunStage.SCRIPT_GENERATING.value,)),
+        ("advance_stage", (RunStage.SCRIPT_GENERATING.value,)),
+        ("stop_run", ()),
+        ("resume_run", ()),
+    ],
+)
+def test_lifecycle_cas_miss_raises_not_found_when_run_deleted(
+    method_name: str, args: tuple[str, ...]
+) -> None:
+    storage = InMemoryRunStorage()
+    service = RunService(storage)
+
+    current_stage = (
+        RunStage.SCRIPT_GENERATING.value if method_name == "stop_run" else RunStage.IDEA_READY.value
+    )
+    status = "cancelled" if method_name == "resume_run" else "pending"
+    created = asyncio.run(
+        service.create_run(
+            project_id=30,
+            model_defaults=None,
+            style_preset="default",
+            current_stage=current_stage,
+            status=status,
+            workspace_id=5,
+        )
+    )
+
+    original_update = storage.update_run
+
+    async def deleting_update_run(
+        run_id: int,
+        updates: dict[str, object],
+        *,
+        workspace_id: int | None = None,
+        expected_version: int | None = None,
+    ):
+        if expected_version is not None:
+            storage._rows.pop(run_id, None)
+            return None
+        return await original_update(
+            run_id,
+            updates,
+            workspace_id=workspace_id,
+            expected_version=expected_version,
+        )
+
+    storage.update_run = deleting_update_run  # type: ignore[method-assign]
+    method = getattr(service, method_name)
+
+    with pytest.raises(ValueError, match=f"Run {created.id} not found"):
+        asyncio.run(method(created.id, *args, workspace_id=5))
+
+
+def test_restart_run_cas_miss_stale_still_raises_conflict() -> None:
+    storage = InMemoryRunStorage()
+    service = RunService(storage)
+
+    created = asyncio.run(
+        service.create_run(
+            project_id=31,
+            model_defaults=None,
+            style_preset="default",
+            current_stage=RunStage.IDEA_READY.value,
+            workspace_id=8,
+        )
+    )
+
+    original_update = storage.update_run
+
+    async def stale_update_run(
+        run_id: int,
+        updates: dict[str, object],
+        *,
+        workspace_id: int | None = None,
+        expected_version: int | None = None,
+    ):
+        if expected_version is not None:
+            await original_update(run_id, {"status": "running"}, workspace_id=workspace_id)
+        return await original_update(
+            run_id,
+            updates,
+            workspace_id=workspace_id,
+            expected_version=expected_version,
+        )
+
+    storage.update_run = stale_update_run  # type: ignore[method-assign]
+
+    with pytest.raises(ConflictError, match="stale version"):
+        asyncio.run(
+            service.restart_run(created.id, RunStage.SCRIPT_GENERATING.value, workspace_id=8)
+        )

--- a/packages/creator-service/tests/test_run_service.py
+++ b/packages/creator-service/tests/test_run_service.py
@@ -207,3 +207,39 @@ def test_advance_stage_raises_conflict_for_stale_version() -> None:
 
     with pytest.raises(ConflictError, match="stale version"):
         asyncio.run(service.advance_stage(created.id, RunStage.SCRIPT_REVIEW.value, workspace_id=1))
+
+
+def test_conditional_update_run_increments_version_and_blocks_stale_lifecycle_write() -> None:
+    storage = InMemoryRunStorage()
+    service = RunService(storage)
+
+    created = asyncio.run(
+        service.create_run(
+            project_id=22,
+            model_defaults=None,
+            style_preset="default",
+            current_stage=RunStage.SCRIPT_REVIEW.value,
+            workspace_id=1,
+        )
+    )
+
+    ok, updated = asyncio.run(
+        storage.conditional_update_run(
+            created.id,
+            {"current_stage": RunStage.SCRIPT_GENERATING.value},
+            frozenset({RunStage.SCRIPT_REVIEW.value}),
+        )
+    )
+    assert ok is True
+    assert updated is not None
+    assert updated["version"] == 1
+
+    stale = asyncio.run(
+        storage.update_run(
+            created.id,
+            {"status": "cancelled"},
+            workspace_id=1,
+            expected_version=0,
+        )
+    )
+    assert stale is None

--- a/packages/creator-service/tests/test_storage_workspace_enforcement.py
+++ b/packages/creator-service/tests/test_storage_workspace_enforcement.py
@@ -49,6 +49,73 @@ def test_postgres_run_storage_update_run_scopes_by_workspace(monkeypatch):
     assert calls[0][1] == (5, "running", 77)
 
 
+def test_postgres_run_storage_conditional_update_scopes_by_workspace(monkeypatch):
+    storage = PostgresRunStorage()
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fake_fetch_one(query: str, *args: object):
+        calls.append((query, args))
+        return None
+
+    monkeypatch.setattr("creator_service.postgres_run_storage.fetch_one", _fake_fetch_one)
+
+    ok, row = run(
+        storage.conditional_update_run(
+            7,
+            {"current_stage": "SCRIPT_GENERATING"},
+            frozenset({"SCRIPT_REVIEW"}),
+            workspace_id=42,
+        )
+    )
+
+    assert ok is False
+    assert row is None
+    assert len(calls) == 2
+    assert "UPDATE creator_runs SET" in calls[0][0]
+    assert "workspace_id = $" in calls[0][0]
+    assert calls[0][1] == (7, ["SCRIPT_REVIEW"], "SCRIPT_GENERATING", 42)
+    assert "SELECT * FROM creator_runs WHERE id = $1 AND workspace_id = $2" in calls[1][0]
+    assert calls[1][1] == (7, 42)
+
+
+def test_postgres_run_storage_merge_model_defaults_scopes_by_workspace(monkeypatch):
+    storage = PostgresRunStorage()
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fake_fetch_one(query: str, *args: object):
+        calls.append((query, args))
+        return None
+
+    monkeypatch.setattr("creator_service.postgres_run_storage.fetch_one", _fake_fetch_one)
+
+    with pytest.raises(ValueError, match="Run 9 not found"):
+        run(storage.merge_model_defaults(9, '{"script_model":"a"}', workspace_id=33))
+
+    assert len(calls) == 1
+    assert "WHERE id = $1 AND workspace_id = $3" in calls[0][0]
+    assert calls[0][1] == (9, '{"script_model":"a"}', 33)
+
+
+def test_postgres_run_storage_delete_run_scopes_by_workspace(monkeypatch):
+    storage = PostgresRunStorage()
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fake_fetch_one(query: str, *args: object):
+        calls.append((query, args))
+        return None
+
+    monkeypatch.setattr("creator_service.postgres_run_storage.fetch_one", _fake_fetch_one)
+
+    deleted = run(storage.delete_run(12, workspace_id=5))
+
+    assert deleted is False
+    assert len(calls) == 1
+    assert (
+        "DELETE FROM creator_runs WHERE id = $1 AND workspace_id = $2 RETURNING id" in calls[0][0]
+    )
+    assert calls[0][1] == (12, 5)
+
+
 def test_postgres_project_storage_fetch_project_scopes_by_workspace(monkeypatch):
     storage = PostgresProjectStorage()
     calls: list[tuple[str, tuple[object, ...]]] = []
@@ -120,6 +187,65 @@ def test_inmemory_run_storage_enforces_workspace_filtering_behavior():
     assert [row["id"] for row in rows] == [run_a["id"]]
     assert rows[0]["workspace_id"] == 11
     assert run(storage.get_run(run_b["id"], workspace_id=11)) is None
+
+
+def test_inmemory_conditional_update_run_scopes_by_workspace():
+    storage = InMemoryRunStorage()
+    created = run(
+        storage.create_run(
+            {
+                "project_id": 1,
+                "workspace_id": 100,
+                "current_stage": "SCRIPT_REVIEW",
+                "status": "pending",
+                "style_preset": "default",
+            }
+        )
+    )
+
+    ok, row = run(
+        storage.conditional_update_run(
+            created["id"],
+            {"current_stage": "SCRIPT_GENERATING"},
+            frozenset({"SCRIPT_REVIEW"}),
+            workspace_id=200,
+        )
+    )
+
+    assert ok is False
+    assert row is None
+    unchanged = run(storage.get_run(created["id"], workspace_id=100))
+    assert unchanged is not None
+    assert unchanged["current_stage"] == "SCRIPT_REVIEW"
+
+
+def test_inmemory_merge_model_defaults_and_delete_run_scope_by_workspace():
+    storage = InMemoryRunStorage()
+    created = run(
+        storage.create_run(
+            {
+                "project_id": 1,
+                "workspace_id": 100,
+                "current_stage": "IDEA_READY",
+                "status": "pending",
+                "style_preset": "default",
+                "model_defaults_json": "{}",
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match=f"Run {created['id']} not found"):
+        run(
+            storage.merge_model_defaults(
+                created["id"],
+                '{"script_model":"x"}',
+                workspace_id=200,
+            )
+        )
+
+    deleted = run(storage.delete_run(created["id"], workspace_id=200))
+    assert deleted is False
+    assert run(storage.get_run(created["id"], workspace_id=100)) is not None
 
 
 def test_run_service_advance_stage_conflict_with_inmemory_storage_cas(monkeypatch):

--- a/packages/creator-service/tests/test_storage_workspace_enforcement.py
+++ b/packages/creator-service/tests/test_storage_workspace_enforcement.py
@@ -1,8 +1,10 @@
 import asyncio
 
+import pytest
 from creator_service.postgres_project_storage import PostgresProjectStorage
 from creator_service.postgres_render_storage import PostgresRenderStorage
 from creator_service.postgres_run_storage import PostgresRunStorage
+from creator_service.run_service import ConflictError, InMemoryRunStorage, RunService
 
 
 def run(coro):
@@ -83,3 +85,76 @@ def test_postgres_render_storage_list_by_run_scopes_by_workspace(monkeypatch):
     assert "creator_runs" in calls[0][0]
     assert "workspace_id = $2" in calls[0][0]
     assert calls[0][1] == (9, 123)
+
+
+def test_inmemory_run_storage_enforces_workspace_filtering_behavior():
+    storage = InMemoryRunStorage()
+
+    run_a = run(
+        storage.create_run(
+            {
+                "project_id": 1,
+                "workspace_id": 11,
+                "current_stage": "IDEA_READY",
+                "status": "pending",
+                "style_preset": "default",
+            }
+        )
+    )
+    run_b = run(
+        storage.create_run(
+            {
+                "project_id": 2,
+                "workspace_id": 22,
+                "current_stage": "IDEA_READY",
+                "status": "pending",
+                "style_preset": "default",
+            }
+        )
+    )
+
+    assert run(storage.get_run(run_a["id"], workspace_id=11)) is not None
+    assert run(storage.get_run(run_a["id"], workspace_id=22)) is None
+
+    rows = run(storage.list_runs_by_workspace(11))
+    assert [row["id"] for row in rows] == [run_a["id"]]
+    assert rows[0]["workspace_id"] == 11
+    assert run(storage.get_run(run_b["id"], workspace_id=11)) is None
+
+
+def test_run_service_advance_stage_conflict_with_inmemory_storage_cas(monkeypatch):
+    storage = InMemoryRunStorage()
+    service = RunService(storage)
+
+    created = run(
+        service.create_run(
+            project_id=99,
+            model_defaults=None,
+            style_preset="default",
+            current_stage="IDEA_READY",
+            workspace_id=7,
+        )
+    )
+
+    original_update = storage.update_run
+
+    async def conflicting_update_run(
+        run_id: int,
+        updates: dict[str, object],
+        *,
+        workspace_id: int | None = None,
+        expected_version: int | None = None,
+    ):
+        if expected_version is not None:
+            await original_update(run_id, {"status": "running"}, workspace_id=7)
+        return await original_update(
+            run_id,
+            updates,
+            workspace_id=workspace_id,
+            expected_version=expected_version,
+        )
+
+    monkeypatch.setattr(storage, "update_run", conflicting_update_run)
+
+    with pytest.raises(ConflictError, match="stale version"):
+        run(service.advance_stage(created.id, "SCRIPT_GENERATING", workspace_id=7))

--- a/packages/creator-service/tests/test_storage_workspace_enforcement.py
+++ b/packages/creator-service/tests/test_storage_workspace_enforcement.py
@@ -1,0 +1,85 @@
+import asyncio
+
+from creator_service.postgres_project_storage import PostgresProjectStorage
+from creator_service.postgres_render_storage import PostgresRenderStorage
+from creator_service.postgres_run_storage import PostgresRunStorage
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_postgres_run_storage_get_run_scopes_by_workspace(monkeypatch):
+    storage = PostgresRunStorage()
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fake_fetch_one(query: str, *args: object):
+        calls.append((query, args))
+        return None
+
+    monkeypatch.setattr("creator_service.postgres_run_storage.fetch_one", _fake_fetch_one)
+
+    row = run(storage.get_run(101, workspace_id=999))
+
+    assert row is None
+    assert len(calls) == 1
+    assert "WHERE id = $1 AND workspace_id = $2" in calls[0][0]
+    assert calls[0][1] == (101, 999)
+
+
+def test_postgres_run_storage_update_run_scopes_by_workspace(monkeypatch):
+    storage = PostgresRunStorage()
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fake_fetch_one(query: str, *args: object):
+        calls.append((query, args))
+        return None
+
+    monkeypatch.setattr("creator_service.postgres_run_storage.fetch_one", _fake_fetch_one)
+
+    try:
+        run(storage.update_run(5, {"status": "running"}, workspace_id=77))
+    except ValueError:
+        pass
+
+    assert len(calls) == 1
+    assert "WHERE id = $1 AND workspace_id = $" in calls[0][0]
+    assert calls[0][1] == (5, "running", 77)
+
+
+def test_postgres_project_storage_fetch_project_scopes_by_workspace(monkeypatch):
+    storage = PostgresProjectStorage()
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fake_fetch_one(query: str, *args: object):
+        calls.append((query, args))
+        return None
+
+    monkeypatch.setattr("creator_service.postgres_project_storage.fetch_one", _fake_fetch_one)
+
+    row = run(storage.fetch_project(42, workspace_id=2))
+
+    assert row is None
+    assert len(calls) == 1
+    assert "WHERE id = $1 AND workspace_id = $2" in calls[0][0]
+    assert calls[0][1] == (42, 2)
+
+
+def test_postgres_render_storage_list_by_run_scopes_by_workspace(monkeypatch):
+    storage = PostgresRenderStorage()
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fake_fetch_all(query: str, *args: object):
+        calls.append((query, args))
+        return []
+
+    monkeypatch.setattr("creator_service.postgres_render_storage.fetch_all", _fake_fetch_all)
+
+    rows = run(storage.list_by_run(9, workspace_id=123))
+
+    assert rows == []
+    assert len(calls) == 1
+    assert "EXISTS (" in calls[0][0]
+    assert "creator_runs" in calls[0][0]
+    assert "workspace_id = $2" in calls[0][0]
+    assert calls[0][1] == (9, 123)

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -301,3 +301,79 @@ def test_cas_dispatch_with_rollback_celery_dispatch_records_task_queued(
 
     assert result["task_id"] == "celery-123"
     assert queued_calls == [(7, "generate_script", "celery-123")]
+
+
+def test_cas_dispatch_with_rollback_releases_quota_on_stage_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TaskDispatchService()
+    cancel_calls: list[tuple[int, str]] = []
+
+    class _ConflictRunStorage:
+        async def conditional_update_run(
+            self,
+            _run_id: int,
+            _updates: dict[str, object],
+            *,
+            expected_stages: frozenset[str],
+        ) -> tuple[bool, dict[str, object] | None]:
+            _ = expected_stages
+            return False, {"current_stage": "SCRIPT_GENERATING"}
+
+    class _ConflictRunService:
+        def __init__(self) -> None:
+            self.storage = _ConflictRunStorage()
+
+        async def get_run(self, _run_id: int) -> object:
+            return SimpleNamespace(project_id=55)
+
+    class _ProjectService:
+        async def get_project(self, _project_id: int) -> object:
+            return SimpleNamespace(workspace_id=999)
+
+    async def _check_workspace_quota(
+        _workspace_id: int, operation_type: str = "llm"
+    ) -> tuple[bool, str]:
+        _ = operation_type
+        return True, "ok"
+
+    async def _cancel_workspace_quota_reservation(workspace_id: int, operation_type: str) -> None:
+        cancel_calls.append((workspace_id, operation_type))
+
+    def _fake_dispatcher(**_: object) -> str:
+        return "celery-never-called"
+
+    import sys
+    import types
+
+    project_service_module = types.ModuleType("creator_service.project_service")
+    setattr(project_service_module, "project_service", _ProjectService())
+    usage_service_module = types.ModuleType("creator_service.usage_service")
+    setattr(usage_service_module, "check_workspace_quota", _check_workspace_quota)
+    setattr(
+        usage_service_module,
+        "cancel_workspace_quota_reservation",
+        _cancel_workspace_quota_reservation,
+    )
+
+    monkeypatch.setitem(sys.modules, "creator_service.project_service", project_service_module)
+    monkeypatch.setitem(sys.modules, "creator_service.usage_service", usage_service_module)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            service.cas_dispatch_with_rollback(
+                run_id=123,
+                expected_stages=frozenset({"SCRIPT_REVIEW"}),
+                target_stage="SCRIPT_GENERATING",
+                dispatcher=_fake_dispatcher,
+                dispatcher_args={"run_id": 123},
+                run_service=_ConflictRunService(),
+                rollback_stage="SCRIPT_REVIEW",
+                rollback_restart_from=None,
+                enqueue_error_detail="enqueue failed",
+                quota_operation_type="llm",
+            )
+        )
+
+    assert exc.value.status_code == 409
+    assert cancel_calls == [(999, "llm")]

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -12,7 +12,7 @@ from creator_service.task_dispatch_service import (
 
 class _FakeRunStorage:
     def __init__(self) -> None:
-        self.calls: list[tuple[int, dict[str, object], frozenset[str]]] = []
+        self.calls: list[tuple[int, dict[str, object], frozenset[str], int | None]] = []
 
     async def conditional_update_run(
         self,
@@ -20,8 +20,9 @@ class _FakeRunStorage:
         updates: dict[str, object],
         *,
         expected_stages: frozenset[str],
+        workspace_id: int | None = None,
     ) -> tuple[bool, dict[str, object] | None]:
-        self.calls.append((run_id, updates, expected_stages))
+        self.calls.append((run_id, updates, expected_stages, workspace_id))
         return True, {"current_stage": "SCRIPT_REVIEW"}
 
 
@@ -316,8 +317,10 @@ def test_cas_dispatch_with_rollback_releases_quota_on_stage_conflict(
             _updates: dict[str, object],
             *,
             expected_stages: frozenset[str],
+            workspace_id: int | None = None,
         ) -> tuple[bool, dict[str, object] | None]:
             _ = expected_stages
+            _ = workspace_id
             return False, {"current_stage": "SCRIPT_GENERATING"}
 
     class _ConflictRunService:

--- a/packages/creator-service/tests/test_telemetry.py
+++ b/packages/creator-service/tests/test_telemetry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import sys
 
 from creator_service import telemetry
 
@@ -193,6 +194,7 @@ def test_add_trace_context_to_log_adds_ids(monkeypatch) -> None:
 
 
 def test_graceful_degradation_when_otel_missing(monkeypatch) -> None:
+    sys.modules["creator_service.telemetry"] = telemetry
     module = importlib.reload(telemetry)
     module._STATE.initialized = False
     module._STATE.enabled = False
@@ -212,6 +214,7 @@ def test_graceful_degradation_when_otel_missing(monkeypatch) -> None:
 
 
 def test_load_otel_handles_import_error(monkeypatch) -> None:
+    sys.modules["creator_service.telemetry"] = telemetry
     module = importlib.reload(telemetry)
 
     import builtins


### PR DESCRIPTION
## Summary
- Enforce workspace-scoped ownership checks in critical storage-layer reads/updates (`get_run`, `update_run`, `fetch_project`, and run-artifact listing) so cross-workspace IDs resolve as not found.
- Add compare-and-swap version checks for run state mutations and raise `ConflictError` on stale writes to prevent silent concurrent overwrite.
- Release reserved quota when dispatch fails due to stage conflict to prevent leaked reservations.

## Tests
- `cd packages/creator-service && python3 -m pytest tests/ -q`
- `cd apps/api && python3 -m pytest tests/ --ignore=tests/test_production_safety_limits.py --ignore=tests/test_security_headers.py -q`

## Issues
- Closes #468
- Closes #469