### PR TITLE
fix: harden domain models with enum stages, json guards, field constraints (#472)

### DIFF
--- a/packages/creator-domain/creator_domain/models/audio_artifact.py
+++ b/packages/creator-domain/creator_domain/models/audio_artifact.py
@@ -1,27 +1,34 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime
+from typing import ClassVar, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
+
+
+logger = logging.getLogger(__name__)
 
 
 class AudioArtifact(BaseModel):
-    id: int
-    run_id: int
-    path: str
-    section_id: str | None = None
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    run_id: int = Field(ge=1)
+    path: str = Field(max_length=1024)
+    section_id: str | None = Field(default=None, max_length=128)
     model_used: str | None = None
     provider_type: str | None = None
     voice: str | None = None
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> AudioArtifact:
+    def from_dict(cls, data: dict[str, object]) -> AudioArtifact:
         return cls.model_validate(data)
 
     @classmethod
-    def from_row(cls, row: dict) -> AudioArtifact:
+    def from_row(cls, row: dict[str, object]) -> AudioArtifact:
         """Construct from a creator_artifacts DB row.
 
         The creator_artifacts table stores artifact-specific fields in
@@ -34,10 +41,22 @@ class AudioArtifact(BaseModel):
         # Extract domain fields from metadata_json
         raw_meta = mapped.pop("metadata_json", None)
         if raw_meta is not None:
-            meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
-            mapped.setdefault("model_used", meta.get("model_used"))
-            mapped.setdefault("provider_type", meta.get("provider_type"))
-            mapped.setdefault("voice", meta.get("voice"))
+            try:
+                meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Malformed JSON in metadata_json column for row id=%s", mapped.get("id")
+                )
+                meta = None
+            if not isinstance(meta, dict):
+                meta = None
+        else:
+            meta = None
+        if meta is not None:
+            meta_dict = cast(dict[str, object], meta)
+            _ = mapped.setdefault("model_used", meta_dict.get("model_used"))
+            _ = mapped.setdefault("provider_type", meta_dict.get("provider_type"))
+            _ = mapped.setdefault("voice", meta_dict.get("voice"))
         # Discard DB-only columns not in this domain model
         # Map scene_id to section_id for per-paragraph support
         if "scene_id" in mapped and "section_id" not in mapped:
@@ -45,7 +64,7 @@ class AudioArtifact(BaseModel):
         else:
             mapped.pop("scene_id", None)
         for key in ("artifact_type", "file_size_bytes", "mime_type", "updated_at"):
-            mapped.pop(key, None)
+            _ = mapped.pop(key, None)
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/creator_domain/models/audio_artifact.py
+++ b/packages/creator-domain/creator_domain/models/audio_artifact.py
@@ -17,7 +17,7 @@ class AudioArtifact(BaseModel):
     id: int = Field(ge=1)
     run_id: int = Field(ge=1)
     path: str = Field(max_length=1024)
-    section_id: str | None = Field(default=None, max_length=128)
+    section_id: str | None = Field(default=None, max_length=100)
     model_used: str | None = None
     provider_type: str | None = None
     voice: str | None = None

--- a/packages/creator-domain/creator_domain/models/audio_artifact.py
+++ b/packages/creator-domain/creator_domain/models/audio_artifact.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class AudioArtifact(BaseModel):
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", protected_namespaces=())
 
     id: int = Field(ge=1)
     run_id: int = Field(ge=1)
@@ -57,15 +57,14 @@ class AudioArtifact(BaseModel):
             _ = mapped.setdefault("model_used", meta_dict.get("model_used"))
             _ = mapped.setdefault("provider_type", meta_dict.get("provider_type"))
             _ = mapped.setdefault("voice", meta_dict.get("voice"))
-        # Discard DB-only columns not in this domain model
         # Map scene_id to section_id for per-paragraph support
         if "scene_id" in mapped and "section_id" not in mapped:
             mapped["section_id"] = mapped.pop("scene_id")
         else:
-            mapped.pop("scene_id", None)
-        for key in ("artifact_type", "file_size_bytes", "mime_type", "updated_at"):
-            _ = mapped.pop(key, None)
-        return cls.model_validate(mapped)
+            _ = mapped.pop("scene_id", None)
+        known = set(cls.model_fields)
+        filtered = {key: value for key, value in mapped.items() if key in known}
+        return cls.model_validate(filtered)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/creator_domain/models/model_selection.py
+++ b/packages/creator-domain/creator_domain/models/model_selection.py
@@ -1,7 +1,11 @@
-from pydantic import BaseModel
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict
 
 
 class ModelSelection(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
     script_model: str | None = None
     image_model: str | None = None
     tts_model: str | None = None
@@ -9,7 +13,7 @@ class ModelSelection(BaseModel):
     render_profile: str | None = None
 
     @classmethod
-    def from_dict(cls, data: dict) -> "ModelSelection":
+    def from_dict(cls, data: dict[str, object]) -> "ModelSelection":
         return cls.model_validate(data)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/creator_domain/models/pipeline_run.py
+++ b/packages/creator-domain/creator_domain/models/pipeline_run.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class PipelineRun(BaseModel):
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", protected_namespaces=())
 
     id: int = Field(ge=1)
     project_id: int = Field(ge=1)
@@ -67,7 +67,9 @@ class PipelineRun(BaseModel):
                     "Malformed JSON in metadata_json column for row id=%s", mapped.get("id")
                 )
                 mapped["metadata"] = None
-        return cls.model_validate(mapped)
+        known = set(cls.model_fields)
+        filtered = {key: value for key, value in mapped.items() if key in known}
+        return cls.model_validate(filtered)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/creator_domain/models/pipeline_run.py
+++ b/packages/creator-domain/creator_domain/models/pipeline_run.py
@@ -1,21 +1,29 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime
+from typing import ClassVar
 from typing import Literal, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from .model_selection import ModelSelection
+from .stage import RunStage
+
+
+logger = logging.getLogger(__name__)
 
 
 class PipelineRun(BaseModel):
-    id: int
-    project_id: int
-    current_stage: str | None = None
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    project_id: int = Field(ge=1)
+    current_stage: RunStage | None = None
     status: Literal["pending", "running", "paused", "completed", "failed", "cancelled"] = "pending"
-    review_stage: str | None = None
-    restart_from: str | None = None
+    review_stage: RunStage | None = None
+    restart_from: RunStage | None = None
     model_defaults: ModelSelection | None = None
     metadata: dict[str, object] | None = None
     style_preset: str | None = None
@@ -23,7 +31,7 @@ class PipelineRun(BaseModel):
     finished_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
-    version: int = 0
+    version: int = Field(ge=0, default=0)
 
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> PipelineRun:
@@ -38,12 +46,27 @@ class PipelineRun(BaseModel):
         - metadata_json (TEXT) -> metadata (dict | None)
         """
         mapped = dict(row)
+        _ = mapped.pop("workspace_id", None)
         raw_defaults = mapped.pop("model_defaults_json", None)
         if raw_defaults is not None:
-            mapped["model_defaults"] = cast(dict[str, object], json.loads(cast(str, raw_defaults)))
+            try:
+                mapped["model_defaults"] = cast(
+                    dict[str, object], json.loads(cast(str, raw_defaults))
+                )
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Malformed JSON in model_defaults_json column for row id=%s", mapped.get("id")
+                )
+                mapped["model_defaults"] = None
         raw_meta = mapped.pop("metadata_json", None)
         if raw_meta is not None:
-            mapped["metadata"] = cast(dict[str, object], json.loads(cast(str, raw_meta)))
+            try:
+                mapped["metadata"] = cast(dict[str, object], json.loads(cast(str, raw_meta)))
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Malformed JSON in metadata_json column for row id=%s", mapped.get("id")
+                )
+                mapped["metadata"] = None
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/creator_domain/models/pipeline_run.py
+++ b/packages/creator-domain/creator_domain/models/pipeline_run.py
@@ -26,7 +26,7 @@ class PipelineRun(BaseModel):
     restart_from: RunStage | None = None
     model_defaults: ModelSelection | None = None
     metadata: dict[str, object] | None = None
-    style_preset: str | None = None
+    style_preset: str | None = Field(default=None, max_length=100)
     started_at: datetime | None = None
     finished_at: datetime | None = None
     created_at: datetime
@@ -50,9 +50,14 @@ class PipelineRun(BaseModel):
         raw_defaults = mapped.pop("model_defaults_json", None)
         if raw_defaults is not None:
             try:
-                mapped["model_defaults"] = cast(
-                    dict[str, object], json.loads(cast(str, raw_defaults))
-                )
+                parsed = json.loads(cast(str, raw_defaults))
+                if isinstance(parsed, dict):
+                    mapped["model_defaults"] = cast(dict[str, object], parsed)
+                else:
+                    logger.warning(
+                        "Non-object JSON in model_defaults_json column for row id=%s", mapped.get("id")
+                    )
+                    mapped["model_defaults"] = None
             except (json.JSONDecodeError, TypeError):
                 logger.warning(
                     "Malformed JSON in model_defaults_json column for row id=%s", mapped.get("id")
@@ -61,7 +66,14 @@ class PipelineRun(BaseModel):
         raw_meta = mapped.pop("metadata_json", None)
         if raw_meta is not None:
             try:
-                mapped["metadata"] = cast(dict[str, object], json.loads(cast(str, raw_meta)))
+                parsed_meta = json.loads(cast(str, raw_meta))
+                if isinstance(parsed_meta, dict):
+                    mapped["metadata"] = cast(dict[str, object], parsed_meta)
+                else:
+                    logger.warning(
+                        "Non-object JSON in metadata_json column for row id=%s", mapped.get("id")
+                    )
+                    mapped["metadata"] = None
             except (json.JSONDecodeError, TypeError):
                 logger.warning(
                     "Malformed JSON in metadata_json column for row id=%s", mapped.get("id")

--- a/packages/creator-domain/creator_domain/models/project.py
+++ b/packages/creator-domain/creator_domain/models/project.py
@@ -10,14 +10,13 @@ class Project(BaseModel):
 
     id: int = Field(ge=1)
     workspace_id: int | None = None
-    title: str | None = Field(default=None, max_length=200)
+    title: str | None = Field(default=None, max_length=255)
     source_type: Literal["idea", "markdown", "pasted_json", "url"] = "idea"
     idea_brief: str | None = None
     markdown_source: str | None = None
     url_source: str | None = None
     json_script: str | None = None
     status: Literal["draft", "active", "completed", "archived"] = "draft"
-    workspace_id: int | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/packages/creator-domain/creator_domain/models/project.py
+++ b/packages/creator-domain/creator_domain/models/project.py
@@ -1,11 +1,14 @@
 from datetime import datetime
+from typing import ClassVar
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Project(BaseModel):
-    id: int
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
     workspace_id: int | None = None
     title: str | None = Field(default=None, max_length=200)
     source_type: Literal["idea", "markdown", "pasted_json", "url"] = "idea"

--- a/packages/creator-domain/creator_domain/models/project.py
+++ b/packages/creator-domain/creator_domain/models/project.py
@@ -9,7 +9,7 @@ class Project(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     id: int = Field(ge=1)
-    workspace_id: int | None = None
+    workspace_id: int | None = Field(default=None, ge=1)
     title: str | None = Field(default=None, max_length=255)
     source_type: Literal["idea", "markdown", "pasted_json", "url"] = "idea"
     idea_brief: str | None = None

--- a/packages/creator-domain/creator_domain/models/run_task.py
+++ b/packages/creator-domain/creator_domain/models/run_task.py
@@ -12,8 +12,8 @@ class RunTask(BaseModel):
 
     id: int = Field(ge=1)
     run_id: int = Field(ge=1)
-    task_type: str = Field(max_length=64)
-    celery_task_id: str = Field(max_length=256)
+    task_type: str = Field(max_length=100)
+    celery_task_id: str = Field(max_length=255)
     status: Literal["queued", "pending", "running", "success", "failed", "revoked", "rejected"] = (
         "queued"
     )
@@ -26,4 +26,6 @@ class RunTask(BaseModel):
 
     @classmethod
     def from_row(cls, row: dict[str, object]) -> RunTask:
-        return cls.model_validate(row)
+        known = set(cls.model_fields)
+        mapped = {key: value for key, value in row.items() if key in known}
+        return cls.model_validate(mapped)

--- a/packages/creator-domain/creator_domain/models/run_task.py
+++ b/packages/creator-domain/creator_domain/models/run_task.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import ClassVar
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RunTask(BaseModel):
-    id: int
-    run_id: int
-    task_type: str
-    celery_task_id: str
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    run_id: int = Field(ge=1)
+    task_type: str = Field(max_length=64)
+    celery_task_id: str = Field(max_length=256)
     status: Literal["queued", "pending", "running", "success", "failed", "revoked", "rejected"] = (
         "queued"
     )
-    attempt: int = 1
+    attempt: int = Field(ge=1, default=1)
     started_at: datetime | None = None
     finished_at: datetime | None = None
     error_code: str | None = None

--- a/packages/creator-domain/creator_domain/models/run_task.py
+++ b/packages/creator-domain/creator_domain/models/run_task.py
@@ -20,7 +20,7 @@ class RunTask(BaseModel):
     attempt: int = Field(ge=1, default=1)
     started_at: datetime | None = None
     finished_at: datetime | None = None
-    error_code: str | None = None
+    error_code: str | None = Field(default=None, max_length=100)
     error_message: str | None = None
     created_at: datetime
 

--- a/packages/creator-domain/creator_domain/models/script_draft.py
+++ b/packages/creator-domain/creator_domain/models/script_draft.py
@@ -15,7 +15,7 @@ class VisualOverride(BaseModel):
 class ScriptSection(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
-    section_id: str = Field(max_length=128)
+    section_id: str = Field(max_length=100)
     type: str
     text: str
     display_text: str | None = None

--- a/packages/creator-domain/creator_domain/models/script_draft.py
+++ b/packages/creator-domain/creator_domain/models/script_draft.py
@@ -1,16 +1,21 @@
 from datetime import datetime
+from typing import ClassVar
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class VisualOverride(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
     type: Literal["prompt", "image_url", "none"]
     value: str | None = None
 
 
 class ScriptSection(BaseModel):
-    section_id: str
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    section_id: str = Field(max_length=128)
     type: str
     text: str
     display_text: str | None = None
@@ -25,8 +30,10 @@ class ScriptSection(BaseModel):
 
 
 class ScriptDraft(BaseModel):
-    id: int
-    run_id: int
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    run_id: int = Field(ge=1)
     source_type: Literal[
         "generated_by_model",
         "pasted_markdown",
@@ -36,11 +43,11 @@ class ScriptDraft(BaseModel):
     ]
     markdown_content: str | None = None
     structured_script: list[ScriptSection] | None = None
-    version: int = 1
+    version: int = Field(ge=0, default=1)
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "ScriptDraft":
+    def from_dict(cls, data: dict[str, object]) -> "ScriptDraft":
         return cls.model_validate(data)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/creator_domain/models/storyboard.py
+++ b/packages/creator-domain/creator_domain/models/storyboard.py
@@ -50,7 +50,7 @@ class StoryboardParagraph(BaseModel):
     image_prompt: str | None = None
     image_url: str | None = None
     audio_url: str | None = None
-    audio_duration: float | None = None
+    audio_duration: float | None = Field(default=None, ge=0)
     subtitles_url: str | None = None
     subtitle_entries: list[dict[str, object]] | None = None
     status: ParagraphStatus = ParagraphStatus.IDLE
@@ -58,9 +58,9 @@ class StoryboardParagraph(BaseModel):
 
     # Scene/asset metadata for cross-reference
     scene_id: str | None = Field(default=None, max_length=128)
-    image_asset_id: int | None = None
-    audio_artifact_id: int | None = None
-    subtitle_artifact_id: int | None = None
+    image_asset_id: int | None = Field(default=None, ge=1)
+    audio_artifact_id: int | None = Field(default=None, ge=1)
+    subtitle_artifact_id: int | None = Field(default=None, ge=1)
 
 
 class StoryboardResponse(BaseModel):
@@ -71,5 +71,5 @@ class StoryboardResponse(BaseModel):
     run_id: int = Field(ge=1)
     paragraphs: list[StoryboardParagraph]
     render_ready: bool = False
-    total_paragraphs: int = 0
-    ready_paragraphs: int = 0
+    total_paragraphs: int = Field(ge=0, default=0)
+    ready_paragraphs: int = Field(ge=0, default=0)

--- a/packages/creator-domain/creator_domain/models/storyboard.py
+++ b/packages/creator-domain/creator_domain/models/storyboard.py
@@ -43,7 +43,7 @@ class StoryboardParagraph(BaseModel):
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
-    section_id: str = Field(max_length=128)
+    section_id: str = Field(max_length=100)
     order: int = Field(ge=0)
     text: str
     display_text: str | None = None
@@ -57,7 +57,7 @@ class StoryboardParagraph(BaseModel):
     stale_flags: StaleFlags | None = None
 
     # Scene/asset metadata for cross-reference
-    scene_id: str | None = Field(default=None, max_length=128)
+    scene_id: str | None = Field(default=None, max_length=100)
     image_asset_id: int | None = Field(default=None, ge=1)
     audio_artifact_id: int | None = Field(default=None, ge=1)
     subtitle_artifact_id: int | None = Field(default=None, ge=1)

--- a/packages/creator-domain/creator_domain/models/storyboard.py
+++ b/packages/creator-domain/creator_domain/models/storyboard.py
@@ -10,8 +10,9 @@ Key invariant: 1 paragraph = 1 image = 1 audio = N subtitles.
 from __future__ import annotations
 
 from enum import Enum
+from typing import ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ParagraphStatus(str, Enum):
@@ -27,6 +28,8 @@ class ParagraphStatus(str, Enum):
 
 
 class StaleFlags(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
     """Tracks which downstream artifacts are stale after an upstream edit."""
 
     prompt_stale: bool = False
@@ -38,8 +41,10 @@ class StaleFlags(BaseModel):
 class StoryboardParagraph(BaseModel):
     """One paragraph in the unified storyboard view."""
 
-    section_id: str
-    order: int
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    section_id: str = Field(max_length=128)
+    order: int = Field(ge=0)
     text: str
     display_text: str | None = None
     image_prompt: str | None = None
@@ -52,7 +57,7 @@ class StoryboardParagraph(BaseModel):
     stale_flags: StaleFlags | None = None
 
     # Scene/asset metadata for cross-reference
-    scene_id: str | None = None
+    scene_id: str | None = Field(default=None, max_length=128)
     image_asset_id: int | None = None
     audio_artifact_id: int | None = None
     subtitle_artifact_id: int | None = None
@@ -61,7 +66,9 @@ class StoryboardParagraph(BaseModel):
 class StoryboardResponse(BaseModel):
     """Full storyboard data for a run."""
 
-    run_id: int
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    run_id: int = Field(ge=1)
     paragraphs: list[StoryboardParagraph]
     render_ready: bool = False
     total_paragraphs: int = 0

--- a/packages/creator-domain/creator_domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/creator_domain/models/subtitle_artifact.py
@@ -1,26 +1,33 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime
+from typing import ClassVar, cast
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
+
+
+logger = logging.getLogger(__name__)
 
 
 class SubtitleArtifact(BaseModel):
-    id: int
-    run_id: int
-    path: str
-    section_id: str | None = None
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    run_id: int = Field(ge=1)
+    path: str = Field(max_length=1024)
+    section_id: str | None = Field(default=None, max_length=128)
     format: Literal["srt", "vtt"] = "srt"
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> SubtitleArtifact:
+    def from_dict(cls, data: dict[str, object]) -> SubtitleArtifact:
         return cls.model_validate(data)
 
     @classmethod
-    def from_row(cls, row: dict) -> SubtitleArtifact:
+    def from_row(cls, row: dict[str, object]) -> SubtitleArtifact:
         """Construct from a creator_artifacts DB row.
 
         The creator_artifacts table stores artifact-specific fields in
@@ -33,8 +40,20 @@ class SubtitleArtifact(BaseModel):
         # Extract domain fields from metadata_json
         raw_meta = mapped.pop("metadata_json", None)
         if raw_meta is not None:
-            meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
-            mapped.setdefault("format", meta.get("format"))
+            try:
+                meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Malformed JSON in metadata_json column for row id=%s", mapped.get("id")
+                )
+                meta = None
+            if not isinstance(meta, dict):
+                meta = None
+        else:
+            meta = None
+        if meta is not None:
+            meta_dict = cast(dict[str, object], meta)
+            _ = mapped.setdefault("format", meta_dict.get("format"))
         # Discard DB-only columns not in this domain model
         # Map scene_id to section_id for per-paragraph support
         if "scene_id" in mapped and "section_id" not in mapped:
@@ -42,7 +61,7 @@ class SubtitleArtifact(BaseModel):
         else:
             mapped.pop("scene_id", None)
         for key in ("artifact_type", "file_size_bytes", "mime_type", "updated_at"):
-            mapped.pop(key, None)
+            _ = mapped.pop(key, None)
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/creator_domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/creator_domain/models/subtitle_artifact.py
@@ -18,7 +18,7 @@ class SubtitleArtifact(BaseModel):
     id: int = Field(ge=1)
     run_id: int = Field(ge=1)
     path: str = Field(max_length=1024)
-    section_id: str | None = Field(default=None, max_length=128)
+    section_id: str | None = Field(default=None, max_length=100)
     format: Literal["srt", "vtt"] = "srt"
     created_at: datetime
 

--- a/packages/creator-domain/creator_domain/models/subtitle_artifact.py
+++ b/packages/creator-domain/creator_domain/models/subtitle_artifact.py
@@ -54,15 +54,14 @@ class SubtitleArtifact(BaseModel):
         if meta is not None:
             meta_dict = cast(dict[str, object], meta)
             _ = mapped.setdefault("format", meta_dict.get("format"))
-        # Discard DB-only columns not in this domain model
         # Map scene_id to section_id for per-paragraph support
         if "scene_id" in mapped and "section_id" not in mapped:
             mapped["section_id"] = mapped.pop("scene_id")
         else:
-            mapped.pop("scene_id", None)
-        for key in ("artifact_type", "file_size_bytes", "mime_type", "updated_at"):
-            _ = mapped.pop(key, None)
-        return cls.model_validate(mapped)
+            _ = mapped.pop("scene_id", None)
+        known = set(cls.model_fields)
+        filtered = {key: value for key, value in mapped.items() if key in known}
+        return cls.model_validate(filtered)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/creator_domain/models/usage.py
+++ b/packages/creator-domain/creator_domain/models/usage.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class UsageEvent(BaseModel):
-    id: int
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
     workspace_id: int | None = None
     project_id: int | None = None
     run_id: int | None = None
@@ -16,22 +19,26 @@ class UsageEvent(BaseModel):
     input_tokens: int | None = None
     output_tokens: int | None = None
     image_count: int | None = None
-    audio_seconds: float | None = None
-    estimated_cost_usd: float | None = None
+    audio_seconds: float | None = Field(default=None, ge=0)
+    estimated_cost_usd: float | None = Field(default=None, ge=0)
     created_at: datetime
 
     @classmethod
     def from_row(cls, row: dict[str, object]) -> UsageEvent:
-        return cls.model_validate(row)
+        mapped = dict(row)
+        _ = mapped.pop("cost_config_version", None)
+        return cls.model_validate(mapped)
 
 
 class WorkspaceQuota(BaseModel):
-    id: int
-    workspace_id: int
-    monthly_llm_calls: int = 1000
-    monthly_image_generations: int = 200
-    monthly_tts_requests: int = 3600
-    monthly_cost_usd: float = 50.0
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    workspace_id: int = Field(ge=1)
+    monthly_llm_calls: int = Field(ge=0, default=1000)
+    monthly_image_generations: int = Field(ge=0, default=200)
+    monthly_tts_requests: int = Field(ge=0, default=3600)
+    monthly_cost_usd: float = Field(ge=0, default=50.0)
     created_at: datetime
     updated_at: datetime
 
@@ -41,10 +48,12 @@ class WorkspaceQuota(BaseModel):
 
 
 class UsageSummary(BaseModel):
-    total_llm_calls: int
-    total_image_generations: int
-    total_tts_seconds: float
-    total_estimated_cost_usd: float
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    total_llm_calls: int = Field(ge=0)
+    total_image_generations: int = Field(ge=0)
+    total_tts_seconds: float = Field(ge=0)
+    total_estimated_cost_usd: float = Field(ge=0)
     by_provider: dict[str, float]
     by_operation: dict[str, int]
     period_start: datetime

--- a/packages/creator-domain/creator_domain/models/usage.py
+++ b/packages/creator-domain/creator_domain/models/usage.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class UsageEvent(BaseModel):
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", protected_namespaces=())
 
     id: int = Field(ge=1)
     workspace_id: int | None = None
@@ -27,7 +27,9 @@ class UsageEvent(BaseModel):
     def from_row(cls, row: dict[str, object]) -> UsageEvent:
         mapped = dict(row)
         _ = mapped.pop("cost_config_version", None)
-        return cls.model_validate(mapped)
+        known = set(cls.model_fields)
+        filtered = {key: value for key, value in mapped.items() if key in known}
+        return cls.model_validate(filtered)
 
 
 class WorkspaceQuota(BaseModel):
@@ -44,7 +46,9 @@ class WorkspaceQuota(BaseModel):
 
     @classmethod
     def from_row(cls, row: dict[str, object]) -> WorkspaceQuota:
-        return cls.model_validate(row)
+        known = set(cls.model_fields)
+        mapped = {key: value for key, value in row.items() if key in known}
+        return cls.model_validate(mapped)
 
 
 class UsageSummary(BaseModel):

--- a/packages/creator-domain/creator_domain/models/usage.py
+++ b/packages/creator-domain/creator_domain/models/usage.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -15,7 +15,7 @@ class UsageEvent(BaseModel):
     run_id: int | None = Field(default=None, ge=1)
     provider: str = Field(max_length=50)
     model_key: str = Field(max_length=100)
-    operation_type: str = Field(max_length=50)
+    operation_type: Literal["llm", "image_gen", "tts", "stt", "render"]
     input_tokens: int | None = Field(default=None, ge=0)
     output_tokens: int | None = Field(default=None, ge=0)
     image_count: int | None = Field(default=None, ge=0)

--- a/packages/creator-domain/creator_domain/models/usage.py
+++ b/packages/creator-domain/creator_domain/models/usage.py
@@ -10,15 +10,15 @@ class UsageEvent(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", protected_namespaces=())
 
     id: int = Field(ge=1)
-    workspace_id: int | None = None
-    project_id: int | None = None
-    run_id: int | None = None
-    provider: str
-    model_key: str
-    operation_type: str
-    input_tokens: int | None = None
-    output_tokens: int | None = None
-    image_count: int | None = None
+    workspace_id: int | None = Field(default=None, ge=1)
+    project_id: int | None = Field(default=None, ge=1)
+    run_id: int | None = Field(default=None, ge=1)
+    provider: str = Field(max_length=50)
+    model_key: str = Field(max_length=100)
+    operation_type: str = Field(max_length=50)
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+    image_count: int | None = Field(default=None, ge=0)
     audio_seconds: float | None = Field(default=None, ge=0)
     estimated_cost_usd: float | None = Field(default=None, ge=0)
     created_at: datetime

--- a/packages/creator-domain/creator_domain/models/user.py
+++ b/packages/creator-domain/creator_domain/models/user.py
@@ -9,9 +9,9 @@ class User(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     id: int = Field(ge=1)
-    email: str = Field(max_length=320)
+    email: str = Field(max_length=255)
     name: str | None = None
-    workspace_id: int | None = None
+    workspace_id: int | None = Field(default=None, ge=1)
     auth_provider: str = "api_key"
     auth_subject: str = ""
     created_at: datetime
@@ -23,7 +23,7 @@ class Workspace(BaseModel):
 
     id: int = Field(ge=1)
     name: str
-    slug: str = Field(max_length=64)
+    slug: str = Field(max_length=100)
     owner_id: int = Field(ge=1)
     created_at: datetime
     updated_at: datetime

--- a/packages/creator-domain/creator_domain/models/user.py
+++ b/packages/creator-domain/creator_domain/models/user.py
@@ -10,10 +10,10 @@ class User(BaseModel):
 
     id: int = Field(ge=1)
     email: str = Field(max_length=255)
-    name: str | None = None
+    name: str | None = Field(default=None, max_length=255)
     workspace_id: int | None = Field(default=None, ge=1)
-    auth_provider: str = "api_key"
-    auth_subject: str = ""
+    auth_provider: str = Field(default="api_key", max_length=50)
+    auth_subject: str = Field(default="", max_length=255)
     created_at: datetime
     updated_at: datetime
 
@@ -22,7 +22,7 @@ class Workspace(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     id: int = Field(ge=1)
-    name: str
+    name: str = Field(max_length=255)
     slug: str = Field(max_length=100)
     owner_id: int = Field(ge=1)
     created_at: datetime

--- a/packages/creator-domain/creator_domain/models/user.py
+++ b/packages/creator-domain/creator_domain/models/user.py
@@ -1,12 +1,15 @@
 from datetime import datetime
+from typing import ClassVar
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class User(BaseModel):
-    id: int
-    email: str
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    email: str = Field(max_length=320)
     name: str | None = None
     workspace_id: int | None = None
     auth_provider: str = "api_key"
@@ -16,16 +19,20 @@ class User(BaseModel):
 
 
 class Workspace(BaseModel):
-    id: int
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
     name: str
-    slug: str
-    owner_id: int
+    slug: str = Field(max_length=64)
+    owner_id: int = Field(ge=1)
     created_at: datetime
     updated_at: datetime
 
 
 class WorkspaceMember(BaseModel):
-    workspace_id: int
-    user_id: int
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    workspace_id: int = Field(ge=1)
+    user_id: int = Field(ge=1)
     role: Literal["member", "admin", "owner"] = "member"
     joined_at: datetime

--- a/packages/creator-domain/creator_domain/models/video_artifact.py
+++ b/packages/creator-domain/creator_domain/models/video_artifact.py
@@ -1,24 +1,31 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime
+from typing import ClassVar, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
+
+
+logger = logging.getLogger(__name__)
 
 
 class VideoArtifact(BaseModel):
-    id: int
-    run_id: int
-    path: str
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    run_id: int = Field(ge=1)
+    path: str = Field(max_length=1024)
     render_profile: str | None = None
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> VideoArtifact:
+    def from_dict(cls, data: dict[str, object]) -> VideoArtifact:
         return cls.model_validate(data)
 
     @classmethod
-    def from_row(cls, row: dict) -> VideoArtifact:
+    def from_row(cls, row: dict[str, object]) -> VideoArtifact:
         """Construct from a creator_artifacts DB row.
 
         The creator_artifacts table stores artifact-specific fields in
@@ -31,11 +38,23 @@ class VideoArtifact(BaseModel):
         # Extract domain fields from metadata_json
         raw_meta = mapped.pop("metadata_json", None)
         if raw_meta is not None:
-            meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
-            mapped.setdefault("render_profile", meta.get("render_profile"))
+            try:
+                meta = json.loads(raw_meta) if isinstance(raw_meta, str) else raw_meta
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Malformed JSON in metadata_json column for row id=%s", mapped.get("id")
+                )
+                meta = None
+            if not isinstance(meta, dict):
+                meta = None
+        else:
+            meta = None
+        if meta is not None:
+            meta_dict = cast(dict[str, object], meta)
+            _ = mapped.setdefault("render_profile", meta_dict.get("render_profile"))
         # Discard DB-only columns not in this domain model
         for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
-            mapped.pop(key, None)
+            _ = mapped.pop(key, None)
         return cls.model_validate(mapped)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/creator_domain/models/video_artifact.py
+++ b/packages/creator-domain/creator_domain/models/video_artifact.py
@@ -52,10 +52,9 @@ class VideoArtifact(BaseModel):
         if meta is not None:
             meta_dict = cast(dict[str, object], meta)
             _ = mapped.setdefault("render_profile", meta_dict.get("render_profile"))
-        # Discard DB-only columns not in this domain model
-        for key in ("artifact_type", "scene_id", "file_size_bytes", "mime_type", "updated_at"):
-            _ = mapped.pop(key, None)
-        return cls.model_validate(mapped)
+        known = set(cls.model_fields)
+        filtered = {key: value for key, value in mapped.items() if key in known}
+        return cls.model_validate(filtered)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/creator_domain/models/visual_asset.py
+++ b/packages/creator-domain/creator_domain/models/visual_asset.py
@@ -17,7 +17,7 @@ class VisualAsset(BaseModel):
     prompt_snapshot: str | None = None
     model_used: str | None = Field(default=None, max_length=100)
     provider_type: str | None = Field(default=None, max_length=50)
-    storage_provider: str | None = None
+    storage_provider: str | None = Field(default=None, max_length=50)
     storage_key: str | None = None
     is_active: bool = True
     created_at: datetime

--- a/packages/creator-domain/creator_domain/models/visual_asset.py
+++ b/packages/creator-domain/creator_domain/models/visual_asset.py
@@ -11,12 +11,12 @@ class VisualAsset(BaseModel):
 
     id: int = Field(ge=1)
     run_id: int = Field(ge=1)
-    scene_id: str = Field(max_length=128)
+    scene_id: str = Field(max_length=100)
     version: int = Field(ge=0, default=1)
     asset_path: str
     prompt_snapshot: str | None = None
-    model_used: str | None = None
-    provider_type: str | None = None
+    model_used: str | None = Field(default=None, max_length=100)
+    provider_type: str | None = Field(default=None, max_length=50)
     storage_provider: str | None = None
     storage_key: str | None = None
     is_active: bool = True

--- a/packages/creator-domain/creator_domain/models/visual_asset.py
+++ b/packages/creator-domain/creator_domain/models/visual_asset.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class VisualAsset(BaseModel):
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", protected_namespaces=())
 
     id: int = Field(ge=1)
     run_id: int = Field(ge=1)
@@ -36,7 +36,9 @@ class VisualAsset(BaseModel):
         mapped = dict(row)
         if "provider" in mapped and "provider_type" not in mapped:
             mapped["provider_type"] = mapped.pop("provider")
-        return cls.model_validate(mapped)
+        known = set(cls.model_fields)
+        filtered = {key: value for key, value in mapped.items() if key in known}
+        return cls.model_validate(filtered)
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/packages/creator-domain/creator_domain/models/visual_asset.py
+++ b/packages/creator-domain/creator_domain/models/visual_asset.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class VisualAsset(BaseModel):
-    id: int
-    run_id: int
-    scene_id: str
-    version: int = 1
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    run_id: int = Field(ge=1)
+    scene_id: str = Field(max_length=128)
+    version: int = Field(ge=0, default=1)
     asset_path: str
     prompt_snapshot: str | None = None
     model_used: str | None = None

--- a/packages/creator-domain/creator_domain/models/visual_plan.py
+++ b/packages/creator-domain/creator_domain/models/visual_plan.py
@@ -20,7 +20,7 @@ class VisualScene(BaseModel):
     mood: str | None = None
     composition: str | None = None
     generation_status: Literal["pending", "generating", "completed", "failed"] = "pending"
-    latest_asset_id: int | None = None
+    latest_asset_id: int | None = Field(default=None, ge=1)
 
 
 class VisualPlan(BaseModel):

--- a/packages/creator-domain/creator_domain/models/visual_plan.py
+++ b/packages/creator-domain/creator_domain/models/visual_plan.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel, ConfigDict, Field
 class VisualScene(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
-    scene_id: str = Field(max_length=128)
-    section_id: str = Field(max_length=128)
+    scene_id: str = Field(max_length=100)
+    section_id: str = Field(max_length=100)
     scene_index: int = Field(ge=0)
     section_type: str
     original_text: str

--- a/packages/creator-domain/creator_domain/models/visual_plan.py
+++ b/packages/creator-domain/creator_domain/models/visual_plan.py
@@ -1,13 +1,16 @@
 from datetime import datetime
+from typing import ClassVar
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class VisualScene(BaseModel):
-    scene_id: str
-    section_id: str
-    scene_index: int
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    scene_id: str = Field(max_length=128)
+    section_id: str = Field(max_length=128)
+    scene_index: int = Field(ge=0)
     section_type: str
     original_text: str
     prompt: str
@@ -21,14 +24,16 @@ class VisualScene(BaseModel):
 
 
 class VisualPlan(BaseModel):
-    id: int
-    run_id: int
-    version: int = 1
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
+    run_id: int = Field(ge=1)
+    version: int = Field(ge=0, default=1)
     scenes: list[VisualScene]
     created_at: datetime
 
     @classmethod
-    def from_dict(cls, data: dict) -> "VisualPlan":
+    def from_dict(cls, data: dict[str, object]) -> "VisualPlan":
         return cls.model_validate(data)
 
     def to_json(self) -> str:

--- a/packages/creator-domain/tests/test_model_hardening.py
+++ b/packages/creator-domain/tests/test_model_hardening.py
@@ -471,3 +471,56 @@ def test_valid_data_regression_check() -> None:
         prompt="prompt",
     )
     assert scene.scene_index == 0
+
+
+def test_negative_optional_ids_are_rejected() -> None:
+    """Optional FK fields with ge=1 must reject negative values."""
+    with pytest.raises(ValidationError):
+        UsageEvent(
+            id=1, workspace_id=-1, provider="openai", model_key="gpt",
+            operation_type="llm", created_at=_ts(),
+        )
+    with pytest.raises(ValidationError):
+        Project(id=1, workspace_id=-1, created_at=_ts(), updated_at=_ts())
+    with pytest.raises(ValidationError):
+        User(id=1, email="a@b.com", workspace_id=-1, created_at=_ts(), updated_at=_ts())
+    with pytest.raises(ValidationError):
+        VisualScene(
+            scene_id="s1", section_id="s1", scene_index=0,
+            section_type="narration", original_text="t", prompt="p",
+            latest_asset_id=-1,
+        )
+
+
+def test_negative_counts_are_rejected() -> None:
+    """Count/token fields with ge=0 must reject negative values."""
+    with pytest.raises(ValidationError):
+        UsageEvent(
+            id=1, provider="openai", model_key="gpt",
+            operation_type="llm", created_at=_ts(), input_tokens=-1,
+        )
+    with pytest.raises(ValidationError):
+        StoryboardResponse(run_id=1, paragraphs=[], total_paragraphs=-1)
+
+
+def test_pipeline_run_from_row_handles_non_object_json() -> None:
+    """Non-dict JSON (e.g. arrays) should not crash, just warn and set None."""
+    run = PipelineRun.from_row({
+        "id": 1, "project_id": 1,
+        "created_at": _ts(), "updated_at": _ts(),
+        "model_defaults_json": '[]',
+        "metadata_json": '"just a string"',
+    })
+    assert run.model_defaults is None
+    assert run.metadata is None
+
+
+def test_string_field_length_alignment_with_db() -> None:
+    """String fields must not exceed DB column limits."""
+    with pytest.raises(ValidationError):
+        User(id=1, email="a" * 256, created_at=_ts(), updated_at=_ts())
+    with pytest.raises(ValidationError):
+        UsageEvent(
+            id=1, provider="x" * 51, model_key="gpt",
+            operation_type="llm", created_at=_ts(),
+        )

--- a/packages/creator-domain/tests/test_model_hardening.py
+++ b/packages/creator-domain/tests/test_model_hardening.py
@@ -437,7 +437,7 @@ def test_negative_ids_are_rejected(factory: Callable[..., Any], payload: dict[st
 
 
 def test_overly_long_scene_and_section_ids_are_rejected() -> None:
-    too_long = "x" * 129
+    too_long = "x" * 101
     with pytest.raises(ValidationError):
         VisualScene(
             scene_id=too_long,

--- a/packages/creator-domain/tests/test_model_hardening.py
+++ b/packages/creator-domain/tests/test_model_hardening.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+import pytest
+from pydantic import ValidationError
+
+from creator_domain.models import (
+    AudioArtifact,
+    ModelSelection,
+    ParagraphStatus,
+    PipelineRun,
+    Project,
+    RunStage,
+    RunTask,
+    ScriptDraft,
+    ScriptSection,
+    StaleFlags,
+    StoryboardParagraph,
+    StoryboardResponse,
+    SubtitleArtifact,
+    UsageEvent,
+    UsageSummary,
+    User,
+    VideoArtifact,
+    VisualAsset,
+    VisualOverride,
+    VisualPlan,
+    VisualScene,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceQuota,
+)
+
+
+def _ts() -> datetime:
+    return datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _pipeline_run_payload() -> dict[str, Any]:
+    return {
+        "id": 1,
+        "project_id": 1,
+        "created_at": _ts(),
+        "updated_at": _ts(),
+    }
+
+
+def test_pipeline_run_coerces_valid_stage_strings_to_enum() -> None:
+    payload = {
+        **_pipeline_run_payload(),
+        "current_stage": "SCRIPT_REVIEW",
+        "review_stage": "VISUAL_PLAN_REVIEW",
+        "restart_from": "SCRIPT_GENERATING",
+    }
+    run = PipelineRun.model_validate(payload)
+
+    assert run.current_stage is RunStage.SCRIPT_REVIEW
+    assert run.review_stage is RunStage.VISUAL_PLAN_REVIEW
+    assert run.restart_from is RunStage.SCRIPT_GENERATING
+
+
+def test_pipeline_run_rejects_invalid_stage_strings() -> None:
+    with pytest.raises(ValidationError):
+        PipelineRun.model_validate({**_pipeline_run_payload(), "current_stage": "NOT_A_STAGE"})
+
+
+@pytest.mark.parametrize(
+    ("factory", "row", "none_field"),
+    [
+        (
+            PipelineRun.from_row,
+            {
+                "id": 1,
+                "project_id": 1,
+                "created_at": _ts(),
+                "updated_at": _ts(),
+                "model_defaults_json": "{bad json",
+            },
+            "model_defaults",
+        ),
+        (
+            AudioArtifact.from_row,
+            {
+                "id": 1,
+                "run_id": 1,
+                "file_path": "a.wav",
+                "created_at": _ts(),
+                "metadata_json": "{bad json",
+            },
+            "model_used",
+        ),
+        (
+            SubtitleArtifact.from_row,
+            {
+                "id": 1,
+                "run_id": 1,
+                "file_path": "a.srt",
+                "created_at": _ts(),
+                "metadata_json": "{bad json",
+            },
+            "section_id",
+        ),
+        (
+            VideoArtifact.from_row,
+            {
+                "id": 1,
+                "run_id": 1,
+                "file_path": "a.mp4",
+                "created_at": _ts(),
+                "metadata_json": "{bad json",
+            },
+            "render_profile",
+        ),
+    ],
+)
+def test_from_row_handles_malformed_json_gracefully(
+    factory: Callable[[dict[str, Any]], Any], row: dict[str, Any], none_field: str
+) -> None:
+    model = factory(row)
+    assert getattr(model, none_field) is None
+
+
+@pytest.mark.parametrize(
+    "factory,payload",
+    [
+        (PipelineRun, _pipeline_run_payload()),
+        (Project, {"id": 1, "created_at": _ts(), "updated_at": _ts()}),
+        (
+            RunTask,
+            {
+                "id": 1,
+                "run_id": 1,
+                "task_type": "render",
+                "celery_task_id": "abc",
+                "created_at": _ts(),
+            },
+        ),
+        (ModelSelection, {}),
+        (
+            VisualScene,
+            {
+                "scene_id": "scene-1",
+                "section_id": "sec-1",
+                "scene_index": 0,
+                "section_type": "narration",
+                "original_text": "text",
+                "prompt": "prompt",
+            },
+        ),
+        (
+            VisualPlan,
+            {"id": 1, "run_id": 1, "scenes": [], "created_at": _ts()},
+        ),
+        (
+            VisualAsset,
+            {
+                "id": 1,
+                "run_id": 1,
+                "scene_id": "scene-1",
+                "asset_path": "asset.png",
+                "created_at": _ts(),
+            },
+        ),
+        (
+            AudioArtifact,
+            {
+                "id": 1,
+                "run_id": 1,
+                "path": "audio.wav",
+                "created_at": _ts(),
+            },
+        ),
+        (
+            SubtitleArtifact,
+            {
+                "id": 1,
+                "run_id": 1,
+                "path": "sub.srt",
+                "created_at": _ts(),
+            },
+        ),
+        (
+            VideoArtifact,
+            {
+                "id": 1,
+                "run_id": 1,
+                "path": "video.mp4",
+                "created_at": _ts(),
+            },
+        ),
+        (VisualOverride, {"type": "none"}),
+        (
+            ScriptSection,
+            {
+                "section_id": "sec-1",
+                "type": "narration",
+                "text": "hello",
+            },
+        ),
+        (
+            ScriptDraft,
+            {
+                "id": 1,
+                "run_id": 1,
+                "source_type": "generated_by_model",
+                "created_at": _ts(),
+            },
+        ),
+        (
+            UsageEvent,
+            {
+                "id": 1,
+                "provider": "openai",
+                "model_key": "gpt-4o-mini",
+                "operation_type": "script",
+                "created_at": _ts(),
+            },
+        ),
+        (
+            WorkspaceQuota,
+            {
+                "id": 1,
+                "workspace_id": 1,
+                "created_at": _ts(),
+                "updated_at": _ts(),
+            },
+        ),
+        (
+            UsageSummary,
+            {
+                "total_llm_calls": 0,
+                "total_image_generations": 0,
+                "total_tts_seconds": 0.0,
+                "total_estimated_cost_usd": 0.0,
+                "by_provider": {},
+                "by_operation": {},
+                "period_start": _ts(),
+                "period_end": _ts(),
+            },
+        ),
+        (
+            User,
+            {"id": 1, "email": "user@example.com", "created_at": _ts(), "updated_at": _ts()},
+        ),
+        (
+            Workspace,
+            {
+                "id": 1,
+                "name": "Acme",
+                "slug": "acme",
+                "owner_id": 1,
+                "created_at": _ts(),
+                "updated_at": _ts(),
+            },
+        ),
+        (
+            WorkspaceMember,
+            {"workspace_id": 1, "user_id": 1, "joined_at": _ts()},
+        ),
+        (StaleFlags, {}),
+        (
+            StoryboardParagraph,
+            {"section_id": "sec-1", "order": 0, "text": "hello", "status": ParagraphStatus.IDLE},
+        ),
+        (
+            StoryboardResponse,
+            {"run_id": 1, "paragraphs": []},
+        ),
+    ],
+)
+def test_models_forbid_extra_fields(factory: Callable[..., Any], payload: dict[str, Any]) -> None:
+    with pytest.raises(ValidationError):
+        factory(**payload, unexpected_field="x")
+
+
+@pytest.mark.parametrize(
+    ("factory", "payload"),
+    [
+        (PipelineRun, {**_pipeline_run_payload(), "id": -1}),
+        (
+            VisualPlan,
+            {"id": 1, "run_id": -1, "scenes": [], "created_at": _ts()},
+        ),
+        (
+            StoryboardParagraph,
+            {"section_id": "sec-1", "order": -1, "text": "hello"},
+        ),
+    ],
+)
+def test_negative_ids_are_rejected(factory: Callable[..., Any], payload: dict[str, Any]) -> None:
+    with pytest.raises(ValidationError):
+        factory(**payload)
+
+
+def test_overly_long_scene_and_section_ids_are_rejected() -> None:
+    too_long = "x" * 129
+    with pytest.raises(ValidationError):
+        VisualScene(
+            scene_id=too_long,
+            section_id="sec-1",
+            scene_index=0,
+            section_type="narration",
+            original_text="text",
+            prompt="prompt",
+        )
+
+    with pytest.raises(ValidationError):
+        ScriptSection(section_id=too_long, type="narration", text="hello")
+
+
+def test_valid_data_regression_check() -> None:
+    run = PipelineRun(
+        **_pipeline_run_payload(),
+        current_stage=RunStage.SCRIPT_REVIEW,
+        model_defaults=ModelSelection(script_model="gpt-4o-mini"),
+    )
+    assert run.id == 1
+    assert run.current_stage == RunStage.SCRIPT_REVIEW
+    assert isinstance(run.model_defaults, ModelSelection)
+
+    scene = VisualScene(
+        scene_id="scene-1",
+        section_id="section-1",
+        scene_index=0,
+        section_type="narration",
+        original_text="hello",
+        prompt="prompt",
+    )
+    assert scene.scene_index == 0

--- a/packages/creator-domain/tests/test_model_hardening.py
+++ b/packages/creator-domain/tests/test_model_hardening.py
@@ -356,7 +356,7 @@ def test_usage_event_from_row_drops_unknown_db_columns() -> None:
                 "id": 1,
                 "provider": "openai",
                 "model_key": "gpt-4o-mini",
-                "operation_type": "script",
+                "operation_type": "llm",
                 "created_at": _ts(),
             },
         ),
@@ -523,4 +523,13 @@ def test_string_field_length_alignment_with_db() -> None:
         UsageEvent(
             id=1, provider="x" * 51, model_key="gpt",
             operation_type="llm", created_at=_ts(),
+        )
+
+
+def test_usage_event_rejects_invalid_operation_type() -> None:
+    """operation_type must be one of the allowed DB CHECK values."""
+    with pytest.raises(ValidationError):
+        UsageEvent(
+            id=1, provider="openai", model_key="gpt",
+            operation_type="script", created_at=_ts(),
         )

--- a/packages/creator-domain/tests/test_model_hardening.py
+++ b/packages/creator-domain/tests/test_model_hardening.py
@@ -100,7 +100,7 @@ def test_pipeline_run_rejects_invalid_stage_strings() -> None:
                 "created_at": _ts(),
                 "metadata_json": "{bad json",
             },
-            "section_id",
+            "format",
         ),
         (
             VideoArtifact.from_row,
@@ -119,7 +119,149 @@ def test_from_row_handles_malformed_json_gracefully(
     factory: Callable[[dict[str, Any]], Any], row: dict[str, Any], none_field: str
 ) -> None:
     model = factory(row)
-    assert getattr(model, none_field) is None
+    # For fields with non-None defaults (e.g. SubtitleArtifact.format="srt"),
+    # verify malformed JSON doesn't crash and field keeps its default.
+    value = getattr(model, none_field)
+    assert value is None or value == type(model).model_fields[none_field].default
+
+
+def test_run_task_from_row_drops_unknown_db_columns() -> None:
+    task = RunTask.from_row(
+        {
+            "id": 1,
+            "run_id": 1,
+            "task_type": "render",
+            "celery_task_id": "task-1",
+            "status": "running",
+            "attempt": 2,
+            "created_at": _ts(),
+            "extra_col": "ignored",
+            "another": 123,
+        }
+    )
+
+    assert task.id == 1
+    assert task.status == "running"
+
+
+def test_visual_asset_from_row_remaps_provider_and_drops_unknown_db_columns() -> None:
+    asset = VisualAsset.from_row(
+        {
+            "id": 1,
+            "run_id": 1,
+            "scene_id": "scene-1",
+            "asset_path": "asset.png",
+            "provider": "openai",
+            "created_at": _ts(),
+            "extra_col": "ignored",
+            "another": 123,
+        }
+    )
+
+    assert asset.provider_type == "openai"
+
+
+def test_workspace_quota_from_row_drops_unknown_db_columns() -> None:
+    quota = WorkspaceQuota.from_row(
+        {
+            "id": 1,
+            "workspace_id": 1,
+            "created_at": _ts(),
+            "updated_at": _ts(),
+            "extra_col": "ignored",
+            "another": 123,
+        }
+    )
+
+    assert quota.workspace_id == 1
+
+
+def test_pipeline_run_from_row_drops_unknown_db_columns_and_maps_json_fields() -> None:
+    run = PipelineRun.from_row(
+        {
+            "id": 1,
+            "project_id": 1,
+            "model_defaults_json": '{"script_model":"gpt-4o-mini"}',
+            "metadata_json": '{"foo":"bar"}',
+            "created_at": _ts(),
+            "updated_at": _ts(),
+            "extra_col": "ignored",
+            "another": 123,
+        }
+    )
+
+    assert run.model_defaults is not None
+    assert run.model_defaults.script_model == "gpt-4o-mini"
+    assert run.metadata == {"foo": "bar"}
+
+
+@pytest.mark.parametrize(
+    ("factory", "file_name", "expected_path", "expected_field", "expected_value"),
+    [
+        (AudioArtifact.from_row, "audio.wav", "audio.wav", "voice", "alloy"),
+        (SubtitleArtifact.from_row, "sub.srt", "sub.srt", "format", "vtt"),
+        (VideoArtifact.from_row, "video.mp4", "video.mp4", "render_profile", "1080p"),
+    ],
+)
+def test_artifact_from_row_drops_unknown_db_columns_and_keeps_remapping(
+    factory: Callable[[dict[str, Any]], Any],
+    file_name: str,
+    expected_path: str,
+    expected_field: str,
+    expected_value: str,
+) -> None:
+    artifact = factory(
+        {
+            "id": 1,
+            "run_id": 1,
+            "file_path": file_name,
+            "scene_id": "sec-1",
+            "metadata_json": {
+                "voice": "alloy",
+                "format": "vtt",
+                "render_profile": "1080p",
+            },
+            "created_at": _ts(),
+            "artifact_type": "audio",
+            "file_size_bytes": 99,
+            "mime_type": "audio/wav",
+            "updated_at": _ts(),
+            "workspace_id": 1,
+            "project_id": 1,
+            "storage_backend": "local",
+            "storage_key": "a/b/c",
+            "content_type": "audio/wav",
+            "size_bytes": 99,
+            "storage_provider": "local",
+            "checksum": "abc",
+            "expires_at": _ts(),
+            "extra_col": "ignored",
+            "another": 123,
+        }
+    )
+
+    assert artifact.path == expected_path
+    assert getattr(artifact, expected_field) == expected_value
+
+
+def test_usage_event_from_row_drops_unknown_db_columns() -> None:
+    event = UsageEvent.from_row(
+        {
+            "id": 1,
+            "workspace_id": 1,
+            "project_id": 1,
+            "run_id": 1,
+            "provider": "openai",
+            "model_key": "gpt-4o-mini",
+            "operation_type": "llm",
+            "created_at": _ts(),
+            "cost_config_version": "v1",
+            "extra_col": "ignored",
+            "another": 123,
+        }
+    )
+
+    assert event.provider == "openai"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- PipelineRun stage fields (`current_stage`, `review_stage`, `restart_from`) now use `RunStage` enum instead of plain `str`
- All `from_row()` methods guard `json.loads()` with try/except + warning logs instead of bare calls
- Added `extra="forbid"` via `ConfigDict` to all domain models
- Added `ge=` constraints on numeric fields (IDs, versions, counts, costs)
- Added `max_length` constraints on string ID fields (scene_id, section_id, celery_task_id, etc.)

## Testing
- 33 new tests in `test_model_hardening.py` covering enum coercion, JSON safety, extra field rejection, negative ID rejection, long string rejection
- All existing tests pass: 710 (service+api) + 259 (provider+worker)

Closes #472