### PR TITLE
test: expand test coverage — IDOR, provider failures, GPU lock (#474)

### DIFF
--- a/apps/api/tests/test_cross_workspace_idor.py
+++ b/apps/api/tests/test_cross_workspace_idor.py
@@ -1,0 +1,261 @@
+# pyright: reportMissingImports=false
+
+"""Cross-workspace IDOR tests — verify user A (workspace 1) cannot access workspace 2 resources.
+
+Extends test_security_boundaries.py with deeper coverage:
+- Visual plan endpoints (scene CRUD)
+- Script endpoints
+- Storyboard endpoints
+- Scene asset endpoints (image regeneration)
+- Run lifecycle endpoints (extended set)
+- Project CRUD
+- Artifact download
+- Anti-enumeration: always 404, never 403
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+import pytest
+from httpx import AsyncClient
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Stubs — workspace 2 objects
+# ---------------------------------------------------------------------------
+
+
+class StubProject(BaseModel):
+    id: int
+    title: str
+    source_type: Literal["idea", "markdown", "url", "pasted_json"] = "idea"
+    idea_brief: str | None = None
+    markdown_source: str | None = None
+    url_source: str | None = None
+    json_script: str | None = None
+    status: str = "draft"
+    created_at: datetime = datetime.now(timezone.utc)
+    updated_at: datetime = datetime.now(timezone.utc)
+    latest_run: dict[str, int | str | None] | None = None
+    workspace_id: int | None = None
+
+
+class StubRun(BaseModel):
+    id: int
+    project_id: int
+    current_stage: str = "IDEA_READY"
+    status: str = "active"
+    active_task_id: str | None = None
+    workspace_id: int | None = None
+    model_config = {"extra": "allow"}
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "project_id": self.project_id,
+            "current_stage": self.current_stage,
+            "status": self.status,
+            "active_task_id": self.active_task_id,
+            "workspace_id": self.workspace_id,
+        }
+
+
+_WS2_PROJECT = StubProject(id=99, title="Other WS", workspace_id=2, idea_brief="theirs")
+_WS2_RUN = StubRun(id=99, project_id=99, workspace_id=2)
+
+
+def _patch_cross_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch services so workspace-2 objects exist but workspace-1 user can't reach them."""
+
+    class CrossWsProjectService:
+        async def get_project(
+            self, project_id: int, workspace_id: int | None = None
+        ) -> StubProject | None:
+            if project_id == 99:
+                if workspace_id is not None and workspace_id != 2:
+                    return None  # workspace mismatch → triggers 404
+                return _WS2_PROJECT
+            return None
+
+    class CrossWsRunService:
+        async def get_run(self, run_id: int, workspace_id: int | None = None) -> StubRun | None:
+            if run_id == 99:
+                if workspace_id is not None and workspace_id != 2:
+                    return None
+                return _WS2_RUN
+            return None
+
+    monkeypatch.setattr("creator_service.project_service.project_service", CrossWsProjectService())
+    monkeypatch.setattr("creator_service.run_service.run_service", CrossWsRunService())
+
+
+# ---------------------------------------------------------------------------
+# Visual plan endpoints — cross-workspace denial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idor_get_visual_plan(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.get("/api/creator/runs/99/visual-plan")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_idor_patch_scene(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.patch(
+        "/api/creator/runs/99/visual-plan/scenes/scene-1",
+        json={"prompt": "hacked"},
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_idor_generate_visual_plan(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.post("/api/creator/runs/99/generate-visual-plan", json={})
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Script endpoints — cross-workspace denial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idor_get_script(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.get("/api/creator/runs/99/script")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_idor_generate_script(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.post("/api/creator/runs/99/generate-script", json={})
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Storyboard endpoints — cross-workspace denial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idor_get_storyboard(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.get("/api/creator/runs/99/storyboard")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Scene assets — cross-workspace denial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idor_regenerate_scene_image(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.post(
+        "/api/creator/runs/99/scenes/scene-1/regenerate-image",
+        json={},
+    )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Run lifecycle — extended cross-workspace denial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("post", "/api/creator/runs/99/restart"),
+        ("post", "/api/creator/runs/99/stop"),
+        ("post", "/api/creator/runs/99/resume"),
+        ("post", "/api/creator/runs/99/approve-script"),
+        ("post", "/api/creator/runs/99/approve-visual-plan"),
+        ("post", "/api/creator/runs/99/generate-script"),
+        ("post", "/api/creator/runs/99/generate-visual-plan"),
+        ("delete", "/api/creator/runs/99"),
+    ],
+)
+async def test_idor_run_lifecycle_endpoints(
+    method: str,
+    path: str,
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_cross_workspace(monkeypatch)
+    client_method = getattr(client, method)
+    if method == "post":
+        response = await client_method(path, json={})
+    else:
+        response = await client_method(path)
+    assert response.status_code == 404, f"{method.upper()} {path} returned {response.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Project endpoints — cross-workspace denial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idor_get_project(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.get("/api/creator/projects/99")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_idor_delete_project(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.delete("/api/creator/projects/99")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Artifact download — cross-workspace denial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idor_artifact_download(client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    _patch_cross_workspace(monkeypatch)
+    r = await client.get("/api/creator/runs/99/artifacts/1/download")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Anti-enumeration: all 404, never 403
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/creator/runs/99",
+        "/api/creator/runs/99/script",
+        "/api/creator/runs/99/visual-plan",
+        "/api/creator/runs/99/storyboard",
+        "/api/creator/projects/99",
+    ],
+)
+async def test_idor_never_returns_403(
+    path: str, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Cross-workspace access must return 404, never 403 (anti-enumeration)."""
+    _patch_cross_workspace(monkeypatch)
+    r = await client.get(path)
+    assert r.status_code == 404
+    body = r.json()
+    detail = body.get("detail", "")
+    assert "workspace" not in detail.lower()
+    assert "forbidden" not in detail.lower()

--- a/packages/creator-provider/tests/test_exception_mapping.py
+++ b/packages/creator-provider/tests/test_exception_mapping.py
@@ -1,0 +1,104 @@
+"""Provider exception mapping tests — verify httpx errors map to correct ProviderError subclasses.
+
+Covers:
+- TimeoutException → ProviderTimeoutError
+- ConnectError → ProviderTimeoutError
+- NetworkError → ProviderTimeoutError
+- HTTP 429 → RateLimitError
+- Other HTTP errors → ProviderError
+- Exception inheritance chain
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from creator_provider.exceptions import (
+    ProviderAuthError,
+    ProviderError,
+    ProviderTimeoutError,
+    ProviderValidationError,
+    RateLimitError,
+    map_httpx_error,
+)
+
+
+class TestMapHttpxError:
+    def test_timeout_exception(self):
+        exc = httpx.TimeoutException("read timed out")
+        result = map_httpx_error(exc, "test")
+        assert isinstance(result, ProviderTimeoutError)
+        assert "read timed out" in str(result)
+
+    def test_connect_error(self):
+        exc = httpx.ConnectError("Connection refused")
+        result = map_httpx_error(exc, "test")
+        assert isinstance(result, ProviderTimeoutError)
+
+    def test_network_error(self):
+        exc = httpx.NetworkError("DNS resolution failed")
+        result = map_httpx_error(exc, "test")
+        assert isinstance(result, ProviderTimeoutError)
+
+    def test_http_429_rate_limit(self):
+        request = httpx.Request("POST", "http://test")
+        response = httpx.Response(429, request=request)
+        exc = httpx.HTTPStatusError("429", request=request, response=response)
+        result = map_httpx_error(exc, "test")
+        assert isinstance(result, RateLimitError)
+
+    def test_http_500_generic(self):
+        request = httpx.Request("POST", "http://test")
+        response = httpx.Response(500, request=request)
+        exc = httpx.HTTPStatusError("500", request=request, response=response)
+        result = map_httpx_error(exc, "test")
+        assert isinstance(result, ProviderError)
+        assert not isinstance(result, (ProviderTimeoutError, RateLimitError))
+
+    def test_http_401_generic(self):
+        """HTTP 401 maps to generic ProviderError (not ProviderAuthError, which is for app-level auth)."""
+        request = httpx.Request("POST", "http://test")
+        response = httpx.Response(401, request=request)
+        exc = httpx.HTTPStatusError("401", request=request, response=response)
+        result = map_httpx_error(exc, "test")
+        assert isinstance(result, ProviderError)
+
+    def test_prefix_included_in_message(self):
+        exc = httpx.TimeoutException("timed out")
+        result = map_httpx_error(exc, "Ollama at http://localhost:11434")
+        assert "Ollama at http://localhost:11434" in str(result)
+
+
+class TestExceptionHierarchy:
+    """Verify all provider exceptions inherit from ProviderError."""
+
+    def test_timeout_is_provider_error(self):
+        assert issubclass(ProviderTimeoutError, ProviderError)
+
+    def test_rate_limit_is_provider_error(self):
+        assert issubclass(RateLimitError, ProviderError)
+
+    def test_validation_is_provider_error(self):
+        assert issubclass(ProviderValidationError, ProviderError)
+
+    def test_auth_is_provider_error(self):
+        assert issubclass(ProviderAuthError, ProviderError)
+
+    def test_provider_error_is_runtime_error(self):
+        assert issubclass(ProviderError, RuntimeError)
+
+    def test_all_subtypes_catchable(self):
+        """All provider exception types can be caught by except ProviderError."""
+        for cls in (
+            ProviderTimeoutError,
+            RateLimitError,
+            ProviderValidationError,
+            ProviderAuthError,
+        ):
+            try:
+                raise cls("test")
+            except ProviderError:
+                pass  # expected
+            except Exception:
+                pytest.fail(f"{cls.__name__} not caught by ProviderError handler")

--- a/packages/creator-provider/tests/test_gpu_lock_failures.py
+++ b/packages/creator-provider/tests/test_gpu_lock_failures.py
@@ -1,0 +1,101 @@
+"""GPU lock failure path tests.
+
+Covers:
+- Lock acquisition timeout
+- Lock release when task doesn't own it
+- Async context manager cleanup on exception
+- Successful acquire/release cycle
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from creator_provider.gpu_lock import (
+    acquire_gpu_lock,
+    release_gpu_lock,
+    gpu_lock_context,
+)
+
+
+class TestAcquireGPULock:
+    def test_acquire_succeeds_first_try(self):
+        redis = MagicMock()
+        redis.set.return_value = True
+        result = acquire_gpu_lock(redis, "task-1", timeout=60)
+        assert result is True
+        redis.set.assert_called_once()
+
+    def test_acquire_timeout_raises(self):
+        redis = MagicMock()
+        redis.set.return_value = False  # always fails to acquire
+        with pytest.raises(TimeoutError, match="Timed out"):
+            acquire_gpu_lock(redis, "task-1", timeout=60, max_wait=0.1, retry_interval=0.05)
+
+    def test_acquire_retries_then_succeeds(self):
+        redis = MagicMock()
+        redis.set.side_effect = [False, False, True]  # fail twice, then succeed
+        result = acquire_gpu_lock(redis, "task-1", timeout=60, retry_interval=0.01, max_wait=5.0)
+        assert result is True
+        assert redis.set.call_count == 3
+
+
+class TestReleaseGPULock:
+    def test_release_succeeds(self):
+        redis = MagicMock()
+        redis.eval.return_value = 1
+        result = release_gpu_lock(redis, "task-1")
+        assert result is True
+
+    def test_release_fails_not_owner(self):
+        redis = MagicMock()
+        redis.eval.return_value = 0
+        result = release_gpu_lock(redis, "task-1")
+        assert result is False
+
+    def test_release_script_uses_correct_key_prefix(self):
+        redis = MagicMock()
+        redis.eval.return_value = 1
+        release_gpu_lock(redis, "my-task-id")
+        args = redis.eval.call_args
+        assert "my-task-id:" in str(args)
+
+
+class TestGPULockContextManager:
+    @pytest.mark.asyncio
+    async def test_context_acquires_and_releases(self):
+        redis = MagicMock()
+        redis.set.return_value = True
+        redis.eval.return_value = 1
+
+        async with gpu_lock_context(redis, "task-1", timeout=60):
+            pass  # lock held
+
+        redis.set.assert_called_once()
+        redis.eval.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_context_releases_on_exception(self):
+        redis = MagicMock()
+        redis.set.return_value = True
+        redis.eval.return_value = 1
+
+        with pytest.raises(ValueError, match="boom"):
+            async with gpu_lock_context(redis, "task-1", timeout=60):
+                raise ValueError("boom")
+
+        # Lock must still be released
+        redis.eval.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_context_propagates_timeout(self):
+        redis = MagicMock()
+        redis.set.return_value = False
+
+        with patch("creator_provider.gpu_lock.acquire_gpu_lock", side_effect=TimeoutError("Timed out")):
+            with pytest.raises(TimeoutError):
+                async with gpu_lock_context(redis, "task-1", timeout=60):
+                    pass  # should never reach here

--- a/packages/creator-provider/tests/test_provider_failure_paths.py
+++ b/packages/creator-provider/tests/test_provider_failure_paths.py
@@ -1,0 +1,199 @@
+"""Provider adapter failure path tests — Ollama, SD Local, Piper TTS.
+
+Covers:
+- Connection refused / timeout → ProviderTimeoutError
+- HTTP 429 → RateLimitError
+- HTTP 500 → ProviderError
+- Empty/malformed response bodies
+- Prompt validation rejection → ProviderValidationError
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from creator_provider.exceptions import (
+    ProviderError,
+    ProviderTimeoutError,
+    ProviderValidationError,
+    RateLimitError,
+)
+from creator_provider.llm.ollama_provider import OllamaProvider
+from creator_provider.image.sd_local_provider import SDLocalProvider
+from creator_provider.tts.piper_tts_provider import PiperTTSProvider
+
+
+# ---------------------------------------------------------------------------
+# Ollama LLM Provider
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaFailurePaths:
+    @pytest.fixture
+    def provider(self):
+        return OllamaProvider(endpoint="http://localhost:11434", model_key="qwen3-4b")
+
+    @pytest.mark.asyncio
+    async def test_connection_refused(self, provider: OllamaProvider):
+        with patch("httpx.AsyncClient.post", side_effect=httpx.ConnectError("Connection refused")):
+            with pytest.raises(ProviderTimeoutError, match="Connection refused"):
+                await provider.generate("Hello")
+
+    @pytest.mark.asyncio
+    async def test_timeout(self, provider: OllamaProvider):
+        with patch("httpx.AsyncClient.post", side_effect=httpx.TimeoutException("read timeout")):
+            with pytest.raises(ProviderTimeoutError, match="read timeout"):
+                await provider.generate("Hello")
+
+    @pytest.mark.asyncio
+    async def test_http_429_rate_limit(self, provider: OllamaProvider):
+        mock_response = httpx.Response(429, request=httpx.Request("POST", "http://test"))
+        with patch(
+            "httpx.AsyncClient.post",
+            side_effect=httpx.HTTPStatusError(
+                "429", request=mock_response.request, response=mock_response
+            ),
+        ):
+            with pytest.raises(RateLimitError):
+                await provider.generate("Hello")
+
+    @pytest.mark.asyncio
+    async def test_http_500_server_error(self, provider: OllamaProvider):
+        mock_response = httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        with patch(
+            "httpx.AsyncClient.post",
+            side_effect=httpx.HTTPStatusError(
+                "500", request=mock_response.request, response=mock_response
+            ),
+        ):
+            with pytest.raises(ProviderError):
+                await provider.generate("Hello")
+
+    @pytest.mark.asyncio
+    async def test_empty_content_response(self, provider: OllamaProvider):
+        mock_response = httpx.Response(
+            200, json={"message": {"content": ""}}, request=httpx.Request("POST", "http://test")
+        )
+        with patch("httpx.AsyncClient.post", return_value=mock_response):
+            with pytest.raises(ProviderError, match="empty content"):
+                await provider.generate("Hello")
+
+    @pytest.mark.asyncio
+    async def test_missing_message_field(self, provider: OllamaProvider):
+        mock_response = httpx.Response(
+            200, json={"status": "ok"}, request=httpx.Request("POST", "http://test")
+        )
+        with patch("httpx.AsyncClient.post", return_value=mock_response):
+            with pytest.raises(ProviderError, match="empty content"):
+                await provider.generate("Hello")
+
+    @pytest.mark.asyncio
+    async def test_prompt_too_long(self, provider: OllamaProvider):
+        long_prompt = "x" * 40_000
+        with pytest.raises(ValueError, match="too long"):
+            await provider.generate(long_prompt)
+
+
+# ---------------------------------------------------------------------------
+# SD Local Image Provider
+# ---------------------------------------------------------------------------
+
+
+class TestSDLocalFailurePaths:
+    @pytest.fixture
+    def provider(self):
+        return SDLocalProvider(endpoint="http://localhost:7860", model_key="sd-1.5")
+
+    @pytest.mark.asyncio
+    async def test_connection_refused(self, provider: SDLocalProvider):
+        with patch("httpx.AsyncClient.post", side_effect=httpx.ConnectError("Connection refused")):
+            with pytest.raises(ProviderTimeoutError, match="Connection refused"):
+                await provider.generate("a cat")
+
+    @pytest.mark.asyncio
+    async def test_timeout(self, provider: SDLocalProvider):
+        with patch("httpx.AsyncClient.post", side_effect=httpx.TimeoutException("GPU timeout")):
+            with pytest.raises(ProviderTimeoutError, match="GPU timeout"):
+                await provider.generate("a cat")
+
+    @pytest.mark.asyncio
+    async def test_http_500(self, provider: SDLocalProvider):
+        mock_response = httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        with patch(
+            "httpx.AsyncClient.post",
+            side_effect=httpx.HTTPStatusError(
+                "500", request=mock_response.request, response=mock_response
+            ),
+        ):
+            with pytest.raises(ProviderError):
+                await provider.generate("a cat")
+
+    @pytest.mark.asyncio
+    async def test_empty_images_response(self, provider: SDLocalProvider):
+        mock_response = httpx.Response(
+            200, json={"images": []}, request=httpx.Request("POST", "http://test")
+        )
+        with patch("httpx.AsyncClient.post", return_value=mock_response):
+            with pytest.raises(ProviderError, match="no images"):
+                await provider.generate("a cat")
+
+    @pytest.mark.asyncio
+    async def test_prompt_too_long(self, provider: SDLocalProvider):
+        long_prompt = "x" * 3000
+        with pytest.raises(ValueError, match="too long"):
+            await provider.generate(long_prompt)
+
+
+# ---------------------------------------------------------------------------
+# Piper TTS Provider
+# ---------------------------------------------------------------------------
+
+
+class TestPiperTTSFailurePaths:
+    @pytest.fixture
+    def provider(self):
+        return PiperTTSProvider(endpoint="http://localhost:8100", model_key="piper")
+
+    @pytest.mark.asyncio
+    async def test_connection_refused(self, provider: PiperTTSProvider):
+        with patch("httpx.AsyncClient.post", side_effect=httpx.ConnectError("Connection refused")):
+            with pytest.raises(ProviderTimeoutError, match="Connection refused"):
+                await provider.generate("Hello world")
+
+    @pytest.mark.asyncio
+    async def test_timeout(self, provider: PiperTTSProvider):
+        with patch("httpx.AsyncClient.post", side_effect=httpx.TimeoutException("TTS timeout")):
+            with pytest.raises(ProviderTimeoutError, match="TTS timeout"):
+                await provider.generate("Hello world")
+
+    @pytest.mark.asyncio
+    async def test_http_500(self, provider: PiperTTSProvider):
+        mock_response = httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        with patch(
+            "httpx.AsyncClient.post",
+            side_effect=httpx.HTTPStatusError(
+                "500", request=mock_response.request, response=mock_response
+            ),
+        ):
+            with pytest.raises(ProviderError):
+                await provider.generate("Hello world")
+
+    @pytest.mark.asyncio
+    async def test_short_audio_returns_zero_duration(self, provider: PiperTTSProvider):
+        """WAV data too short to parse → duration = 0."""
+        short_bytes = b"\x00" * 10
+        mock_response = httpx.Response(
+            200, content=short_bytes, request=httpx.Request("POST", "http://test")
+        )
+        with patch("httpx.AsyncClient.post", return_value=mock_response):
+            result = await provider.generate("Hello")
+            assert result.duration_seconds == 0.0
+
+    @pytest.mark.asyncio
+    async def test_prompt_too_long(self, provider: PiperTTSProvider):
+        long_text = "x" * 6000
+        with pytest.raises(ValueError, match="too long"):
+            await provider.generate(long_text)


### PR DESCRIPTION
## Summary
- 23 cross-workspace IDOR tests covering visual plan, script, storyboard, scene assets, lifecycle, projects, artifacts — verifies 404 (never 403) for anti-enumeration
- 18 provider adapter failure tests for Ollama, SD Local, Piper TTS — connection refused, timeout, HTTP 429/500, empty/malformed responses, prompt length validation
- 9 GPU lock tests — acquire/release lifecycle, timeout, context manager cleanup on exception
- 12 exception hierarchy tests — httpx error mapping to ProviderError subtypes, inheritance chain verification

**Test count: 1072 passed, 0 failures** (+62 new tests)

Closes #474