### PR TITLE
fix: path sanitization across all layers (#482)

### DIFF
--- a/apps/worker-orchestrator/tasks/generate_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_subtitles.py
@@ -94,10 +94,7 @@ def generate_subtitles(
         if not audio_path:
             raise RuntimeError(f"No audio artifact found for run {run_id}; cannot transcribe")
         try:
-            if "ARTIFACT_ROOT" not in os.environ and Path(audio_path).is_absolute():
-                pass
-            else:
-                validate_artifact_path(audio_path, _ARTIFACT_ROOT)
+            validate_artifact_path(audio_path, _ARTIFACT_ROOT)
         except UnsafePathComponent as exc:
             raise RuntimeError(
                 f"Unsafe audio artifact path for run {run_id}: {audio_path!r}"

--- a/apps/worker-orchestrator/tasks/generate_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_subtitles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 redis: Any
@@ -16,6 +17,7 @@ except ImportError:
 from celery.exceptions import SoftTimeLimitExceeded
 from celery_app import celery_app
 from creator_domain.models.stage import RunStage
+from creator_domain.sanitize import UnsafePathComponent, validate_artifact_path
 from creator_provider.exceptions import ProviderError, ProviderTimeoutError, RateLimitError
 from creator_provider.gpu_lock import acquire_gpu_lock, release_gpu_lock
 from creator_provider.registry import ProviderRegistry
@@ -91,6 +93,15 @@ def generate_subtitles(
         audio_path = audio_artifact.path if audio_artifact else None
         if not audio_path:
             raise RuntimeError(f"No audio artifact found for run {run_id}; cannot transcribe")
+        try:
+            if "ARTIFACT_ROOT" not in os.environ and Path(audio_path).is_absolute():
+                pass
+            else:
+                validate_artifact_path(audio_path, _ARTIFACT_ROOT)
+        except UnsafePathComponent as exc:
+            raise RuntimeError(
+                f"Unsafe audio artifact path for run {run_id}: {audio_path!r}"
+            ) from exc
 
         registry = ProviderRegistry.create_default()
         entry = registry.resolve(subtitle_model)

--- a/apps/worker-orchestrator/tasks/render_video.py
+++ b/apps/worker-orchestrator/tasks/render_video.py
@@ -50,8 +50,6 @@ def _resolve_profile(name: str) -> RenderProfile:
 
 
 def _validate_manifest_path(path: str) -> None:
-    if "ARTIFACT_ROOT" not in os.environ and Path(path).is_absolute():
-        return
     validate_artifact_path(path, _ARTIFACT_ROOT)
 
 

--- a/apps/worker-orchestrator/tasks/render_video.py
+++ b/apps/worker-orchestrator/tasks/render_video.py
@@ -11,6 +11,7 @@ from typing import Any
 from celery.exceptions import SoftTimeLimitExceeded
 from celery_app import celery_app
 from creator_domain.models.stage import RunStage
+from creator_domain.sanitize import UnsafePathComponent, validate_artifact_path
 from creator_provider.exceptions import ProviderError, ProviderTimeoutError, RateLimitError
 from creator_service.audio_service import audio_service as _audio_service
 from creator_service.cost_config import COST_RENDER_VIDEO
@@ -46,6 +47,12 @@ def _resolve_profile(name: str) -> RenderProfile:
         logger.warning("Unknown render profile %r, falling back to default", name)
         return RenderProfile.default()
     return factory()
+
+
+def _validate_manifest_path(path: str) -> None:
+    if "ARTIFACT_ROOT" not in os.environ and Path(path).is_absolute():
+        return
+    validate_artifact_path(path, _ARTIFACT_ROOT)
 
 
 @celery_app.task(
@@ -95,13 +102,36 @@ def render_video(self, run_id: int, render_profile: str = "shorts_default") -> d
 
         profile_data = manifest["render_profile"]
         scene_count = len(manifest["scenes"])
-        image_paths = [Path(scene["asset_path"]) for scene in manifest["scenes"]]
+        image_paths: list[Path] = []
+        for scene in manifest["scenes"]:
+            asset_path = str(scene["asset_path"])
+            try:
+                _validate_manifest_path(asset_path)
+                image_paths.append(Path(asset_path))
+            except UnsafePathComponent as exc:
+                raise RuntimeError(
+                    f"Unsafe manifest path for run {run_id}: scene asset_path {asset_path!r}"
+                ) from exc
         ffmpeg = FFmpegService(profile=_resolve_profile(render_profile))
 
         paragraph_audio = await _audio_service.list_paragraph_audio(run_id)
         paragraph_subtitles = await _subtitle_service.list_paragraph_subtitles(run_id)
         run_audio_path = manifest["audio_path"]
         run_sub_path = manifest["subtitle_path"]
+        if run_audio_path:
+            try:
+                _validate_manifest_path(str(run_audio_path))
+            except UnsafePathComponent as exc:
+                raise RuntimeError(
+                    f"Unsafe manifest path for run {run_id}: audio_path {run_audio_path!r}"
+                ) from exc
+        if run_sub_path:
+            try:
+                _validate_manifest_path(str(run_sub_path))
+            except UnsafePathComponent as exc:
+                raise RuntimeError(
+                    f"Unsafe manifest path for run {run_id}: subtitle_path {run_sub_path!r}"
+                ) from exc
         audio_path: Path | None = None
         subtitle_path: Path | None = None
 
@@ -120,12 +150,23 @@ def render_video(self, run_id: int, render_profile: str = "shorts_default") -> d
                 sid in audio_by_section for sid in ordered_sections
             )
             if all_audio_covered:
-                ordered_audio_paths = [audio_by_section[sid].path for sid in ordered_sections]
+                ordered_audio_paths: list[str] = []
+                validated_audio_by_section: dict[str, str] = {}
+                for sid in ordered_sections:
+                    raw_audio_path = str(audio_by_section[sid].path)
+                    try:
+                        _validate_manifest_path(raw_audio_path)
+                        ordered_audio_paths.append(raw_audio_path)
+                        validated_audio_by_section[sid] = raw_audio_path
+                    except UnsafePathComponent as exc:
+                        raise RuntimeError(
+                            f"Unsafe manifest path for run {run_id}: paragraph audio path {raw_audio_path!r}"
+                        ) from exc
                 duration_by_section: dict[str, float] = {}
                 for sid in ordered_sections:
                     try:
                         duration_by_section[sid] = ffmpeg.get_audio_duration(
-                            audio_by_section[sid].path
+                            validated_audio_by_section[sid]
                         )
                     except Exception:
                         duration_by_section[sid] = 5.0
@@ -148,8 +189,18 @@ def render_video(self, run_id: int, render_profile: str = "shorts_default") -> d
                     )
                     if all_subtitles_covered:
                         merged_sub_path = f"{_ARTIFACT_ROOT}/{run_id}/render/subtitles_merged.srt"
+                        merged_sub_inputs: list[str] = []
+                        for sid in ordered_sections:
+                            raw_subtitle_path = str(sub_by_section[sid].path)
+                            try:
+                                _validate_manifest_path(raw_subtitle_path)
+                                merged_sub_inputs.append(raw_subtitle_path)
+                            except UnsafePathComponent as exc:
+                                raise RuntimeError(
+                                    f"Unsafe manifest path for run {run_id}: paragraph subtitle path {raw_subtitle_path!r}"
+                                ) from exc
                         ffmpeg.merge_subtitles(
-                            [sub_by_section[sid].path for sid in ordered_sections],
+                            merged_sub_inputs,
                             [duration_by_section[sid] for sid in ordered_sections],
                             merged_sub_path,
                         )

--- a/apps/worker-orchestrator/tests/test_provider_exception_passthrough.py
+++ b/apps/worker-orchestrator/tests/test_provider_exception_passthrough.py
@@ -447,6 +447,7 @@ def test_generate_subtitles_preserves_provider_timeout(monkeypatch: pytest.Monke
     monkeypatch.setattr(generate_subtitles_module, "_run_service", SimpleNamespace(storage=storage))
     monkeypatch.setattr(generate_subtitles_module, "_script_service", _FakeScriptService(draft=draft))
     monkeypatch.setattr(generate_subtitles_module, "_audio_service", _FakeAudioServiceForSubtitles())
+    monkeypatch.setattr(generate_subtitles_module, "validate_artifact_path", lambda p, r: p)
 
     task = generate_subtitles_module.generate_subtitles
     run_callable = getattr(task, "run", task)
@@ -464,6 +465,7 @@ def test_generate_subtitles_preserves_rate_limit(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(generate_subtitles_module, "_run_service", SimpleNamespace(storage=storage))
     monkeypatch.setattr(generate_subtitles_module, "_script_service", _FakeScriptService(draft=draft))
     monkeypatch.setattr(generate_subtitles_module, "_audio_service", _FakeAudioServiceForSubtitles())
+    monkeypatch.setattr(generate_subtitles_module, "validate_artifact_path", lambda p, r: p)
 
     task = generate_subtitles_module.generate_subtitles
     run_callable = getattr(task, "run", task)

--- a/apps/worker-orchestrator/tests/test_worker_path_validation.py
+++ b/apps/worker-orchestrator/tests/test_worker_path_validation.py
@@ -161,3 +161,92 @@ def test_render_video_rejects_traversal_manifest_paths(monkeypatch: pytest.Monke
     run_callable: Callable[..., dict[str, object]] = getattr(task, "run", task)
     with pytest.raises(RuntimeError, match="manifest path"):
         run_callable(run_id=run_id)
+
+
+def test_generate_subtitles_rejects_absolute_path_when_artifact_root_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: absolute audio artifact path must be rejected even without ARTIFACT_ROOT."""
+    monkeypatch.delenv("ARTIFACT_ROOT", raising=False)
+    # Force module to re-evaluate _ARTIFACT_ROOT default
+    monkeypatch.setattr(generate_subtitles_module, "_ARTIFACT_ROOT", "data/artifacts")
+    monkeypatch.setattr(generate_subtitles_module, "ProviderRegistry", _Registry)
+    monkeypatch.setattr(
+        generate_subtitles_module,
+        "_run_service",
+        SimpleNamespace(storage=_Storage(run_id=500, stage="AUDIO_GENERATING")),
+    )
+    monkeypatch.setattr(
+        generate_subtitles_module,
+        "_script_service",
+        SimpleNamespace(get_active_draft=lambda _rid: _async_return(_ScriptDraft())),
+    )
+    monkeypatch.setattr(
+        generate_subtitles_module,
+        "_audio_service",
+        SimpleNamespace(
+            get_latest=lambda _rid: _async_return(
+                _AudioArtifact(path="/etc/shadow")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        generate_subtitles_module,
+        "_subtitle_service",
+        _SubtitleService(),
+    )
+
+    task = generate_subtitles_module.generate_subtitles
+    run_callable: Callable[..., dict[str, object]] = getattr(task, "run", task)
+    with pytest.raises(RuntimeError, match="audio artifact path"):
+        run_callable(run_id=500)
+
+
+def test_render_video_rejects_absolute_path_when_artifact_root_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: absolute manifest paths must be rejected even without ARTIFACT_ROOT."""
+    monkeypatch.delenv("ARTIFACT_ROOT", raising=False)
+    monkeypatch.setattr(render_video_module, "_ARTIFACT_ROOT", "data/artifacts")
+    run_id = 501
+    manifest = {
+        "run_id": run_id,
+        "scenes": [{"scene_id": "scene-1", "asset_path": "/etc/shadow"}],
+        "audio_path": "data/artifacts/501/audio/audio.wav",
+        "subtitle_path": "data/artifacts/501/subtitles/subtitles.srt",
+        "render_profile": {"max_duration_seconds": 30.0},
+    }
+
+    monkeypatch.setattr(
+        render_video_module,
+        "_run_service",
+        SimpleNamespace(storage=_Storage(run_id=run_id, stage="RENDER_GENERATING")),
+    )
+    monkeypatch.setattr(render_video_module, "_render_service", _RenderService(manifest))
+    monkeypatch.setattr(render_video_module, "_visual_asset_service", SimpleNamespace())
+    monkeypatch.setattr(
+        render_video_module,
+        "_audio_service",
+        SimpleNamespace(list_paragraph_audio=lambda _rid: _async_return([])),
+    )
+    monkeypatch.setattr(
+        render_video_module,
+        "_subtitle_service",
+        SimpleNamespace(list_paragraph_subtitles=lambda _rid: _async_return([])),
+    )
+    monkeypatch.setattr(
+        render_video_module,
+        "_visual_plan_service",
+        SimpleNamespace(get_active_plan=lambda _rid: _async_return(None)),
+    )
+    monkeypatch.setattr(
+        render_video_module,
+        "_script_service",
+        SimpleNamespace(get_active_draft=lambda _rid: _async_return(None)),
+    )
+    monkeypatch.setattr(render_video_module, "FFmpegService", _FFmpeg)
+
+    task = render_video_module.render_video
+    run_callable: Callable[..., dict[str, object]] = getattr(task, "run", task)
+    with pytest.raises(RuntimeError, match="manifest path"):
+        run_callable(run_id=run_id)

--- a/apps/worker-orchestrator/tests/test_worker_path_validation.py
+++ b/apps/worker-orchestrator/tests/test_worker_path_validation.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import pytest
+from tasks import generate_subtitles as generate_subtitles_module
+from tasks import render_video as render_video_module
+
+
+@dataclass
+class _AudioArtifact:
+    path: str
+
+
+@dataclass
+class _ScriptDraft:
+    markdown_content: str | None = "script"
+    structured_script: list[Any] | None = None
+
+
+class _Provider:
+    async def transcribe(self, audio_path: str, params: dict[str, object] | None = None) -> None:
+        return None
+
+
+async def _async_return(value: Any) -> Any:
+    return value
+
+
+class _SubtitleService:
+    async def create_artifact(self, **kwargs: Any) -> Any:
+        return SimpleNamespace(id=1, path=kwargs["path"])
+
+
+class _RenderService:
+    def __init__(self, manifest: dict[str, Any]) -> None:
+        self.manifest = manifest
+
+    async def build_render_manifest(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return self.manifest
+
+    async def create_artifact(self, **kwargs: Any) -> Any:
+        return SimpleNamespace(id=1, path=kwargs["path"])
+
+
+class _Registry:
+    @staticmethod
+    def create_default() -> Any:
+        return SimpleNamespace(
+            resolve=lambda _model: SimpleNamespace(
+                provider_type="faster-whisper",
+                endpoint="http://whisper:8200",
+                requires_gpu=False,
+                default_params={},
+            ),
+            get_provider=lambda _model: _Provider(),
+        )
+
+
+class _Storage:
+    def __init__(self, run_id: int, stage: str) -> None:
+        self.run = {"id": run_id, "current_stage": stage}
+
+    async def get_run(self, run_id: int) -> dict[str, object] | None:
+        return self.run if self.run["id"] == run_id else None
+
+    async def conditional_update_run(
+        self, run_id: int, updates: dict[str, object], expected_stages: frozenset[str]
+    ) -> tuple[bool, dict[str, object] | None]:
+        if self.run["id"] != run_id or self.run["current_stage"] not in expected_stages:
+            return False, self.run
+        self.run.update(updates)
+        return True, self.run
+
+
+def test_generate_subtitles_rejects_traversal_audio_artifact_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(generate_subtitles_module, "ProviderRegistry", _Registry)
+    monkeypatch.setattr(
+        generate_subtitles_module,
+        "_run_service",
+        SimpleNamespace(storage=_Storage(run_id=311, stage="AUDIO_GENERATING")),
+    )
+    monkeypatch.setattr(
+        generate_subtitles_module,
+        "_script_service",
+        SimpleNamespace(get_active_draft=lambda _rid: _async_return(_ScriptDraft())),
+    )
+    monkeypatch.setattr(
+        generate_subtitles_module,
+        "_audio_service",
+        SimpleNamespace(
+            get_latest=lambda _rid: _async_return(
+                _AudioArtifact(path="data/artifacts/311/../../escape.wav")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        generate_subtitles_module,
+        "_subtitle_service",
+        _SubtitleService(),
+    )
+
+    task = generate_subtitles_module.generate_subtitles
+    run_callable: Callable[..., dict[str, object]] = getattr(task, "run", task)
+    with pytest.raises(RuntimeError, match="audio artifact path"):
+        run_callable(run_id=311)
+
+
+class _FFmpeg:
+    def __init__(self, profile: Any = None) -> None:
+        self.profile = profile
+
+    def render(self, render_input: Any, output_path: Any) -> Any:
+        return output_path
+
+
+def test_render_video_rejects_traversal_manifest_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = 401
+    manifest = {
+        "run_id": run_id,
+        "scenes": [{"scene_id": "scene-1", "asset_path": "data/artifacts/401/../../escape.png"}],
+        "audio_path": "data/artifacts/401/audio/audio.wav",
+        "subtitle_path": "data/artifacts/401/subtitles/subtitles.srt",
+        "render_profile": {"max_duration_seconds": 30.0},
+    }
+
+    monkeypatch.setattr(
+        render_video_module,
+        "_run_service",
+        SimpleNamespace(storage=_Storage(run_id=run_id, stage="RENDER_GENERATING")),
+    )
+    monkeypatch.setattr(render_video_module, "_render_service", _RenderService(manifest))
+    monkeypatch.setattr(render_video_module, "_visual_asset_service", SimpleNamespace())
+    monkeypatch.setattr(
+        render_video_module,
+        "_audio_service",
+        SimpleNamespace(list_paragraph_audio=lambda _rid: _async_return([])),
+    )
+    monkeypatch.setattr(
+        render_video_module,
+        "_subtitle_service",
+        SimpleNamespace(list_paragraph_subtitles=lambda _rid: _async_return([])),
+    )
+    monkeypatch.setattr(
+        render_video_module,
+        "_visual_plan_service",
+        SimpleNamespace(get_active_plan=lambda _rid: _async_return(None)),
+    )
+    monkeypatch.setattr(
+        render_video_module,
+        "_script_service",
+        SimpleNamespace(get_active_draft=lambda _rid: _async_return(None)),
+    )
+    monkeypatch.setattr(render_video_module, "FFmpegService", _FFmpeg)
+
+    task = render_video_module.render_video
+    run_callable: Callable[..., dict[str, object]] = getattr(task, "run", task)
+    with pytest.raises(RuntimeError, match="manifest path"):
+        run_callable(run_id=run_id)

--- a/packages/creator-domain/creator_domain/sanitize.py
+++ b/packages/creator-domain/creator_domain/sanitize.py
@@ -9,6 +9,7 @@ before being interpolated.  This prevents directory-traversal attacks such as
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 # Only allow ASCII alphanumeric, hyphens, underscores, and dots (no leading dot).
 _SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][\w.\-]*$")
@@ -46,9 +47,7 @@ def sanitize_path_component(value: str, *, label: str = "id") -> str:
         raise UnsafePathComponent(f"{label} must not be empty")
 
     if len(value) > _MAX_COMPONENT_LENGTH:
-        raise UnsafePathComponent(
-            f"{label} exceeds maximum length of {_MAX_COMPONENT_LENGTH}"
-        )
+        raise UnsafePathComponent(f"{label} exceeds maximum length of {_MAX_COMPONENT_LENGTH}")
 
     # Reject null bytes (could bypass C-level path functions).
     if "\x00" in value:
@@ -68,3 +67,21 @@ def sanitize_path_component(value: str, *, label: str = "id") -> str:
         )
 
     return value
+
+
+def validate_artifact_path(path: str, artifact_root: str) -> str:
+    if not path:
+        raise UnsafePathComponent("path must not be empty")
+    if not artifact_root:
+        raise UnsafePathComponent("artifact_root must not be empty")
+
+    resolved_root = Path(artifact_root).resolve()
+    resolved_path = Path(path).resolve()
+
+    root_str = str(resolved_root)
+    path_str = str(resolved_path)
+    root_prefix = root_str if root_str.endswith("/") else f"{root_str}/"
+    if path_str != root_str and not path_str.startswith(root_prefix):
+        raise UnsafePathComponent(f"path {path_str!r} escapes artifact root {root_str!r}")
+
+    return path_str

--- a/packages/creator-domain/tests/test_sanitize_artifact_path.py
+++ b/packages/creator-domain/tests/test_sanitize_artifact_path.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from creator_domain.sanitize import UnsafePathComponent, validate_artifact_path
+
+
+def test_validate_artifact_path_accepts_path_within_artifact_root(tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    target = artifact_root / "101" / "image.png"
+    resolved = validate_artifact_path(str(target), str(artifact_root))
+    assert resolved == str(target.resolve())
+
+
+def test_validate_artifact_path_rejects_parent_traversal(tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    with pytest.raises(UnsafePathComponent):
+        validate_artifact_path(str(artifact_root / ".." / "etc" / "passwd"), str(artifact_root))
+
+
+def test_validate_artifact_path_rejects_absolute_path_outside_root(tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    outside = tmp_path / "outside" / "file.txt"
+    with pytest.raises(UnsafePathComponent):
+        validate_artifact_path(str(outside), str(artifact_root))
+
+
+def test_validate_artifact_path_rejects_symlink_escape(tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir(parents=True, exist_ok=True)
+    link_path = artifact_root / "link"
+    link_path.symlink_to(outside_dir, target_is_directory=True)
+    with pytest.raises(UnsafePathComponent):
+        validate_artifact_path(str(link_path / "escape.txt"), str(artifact_root))
+
+
+def test_validate_artifact_path_rejects_empty_path(tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    with pytest.raises(UnsafePathComponent):
+        validate_artifact_path("", str(artifact_root))

--- a/packages/creator-provider/creator_provider/image/dalle_provider.py
+++ b/packages/creator-provider/creator_provider/image/dalle_provider.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import base64
+import os
 import tempfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -61,7 +63,16 @@ class DalleProvider(ImageProvider):
 
         output_path_str = merged.get("output_path")
         if output_path_str:
-            output_path = Path(str(output_path_str))
+            candidate_output = str(output_path_str)
+            artifact_root = os.getenv("ARTIFACT_ROOT")
+            if artifact_root is None and Path(candidate_output).is_absolute():
+                output_path = Path(candidate_output)
+            else:
+                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                    candidate_output,
+                    artifact_root or "data/artifacts",
+                )
+                output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/image/dalle_provider.py
+++ b/packages/creator-provider/creator_provider/image/dalle_provider.py
@@ -65,14 +65,11 @@ class DalleProvider(ImageProvider):
         if output_path_str:
             candidate_output = str(output_path_str)
             artifact_root = os.getenv("ARTIFACT_ROOT")
-            if artifact_root is None and Path(candidate_output).is_absolute():
-                output_path = Path(candidate_output)
-            else:
-                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
-                    candidate_output,
-                    artifact_root or "data/artifacts",
-                )
-                output_path = Path(validated_output)
+            validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                candidate_output,
+                artifact_root or "data/artifacts",
+            )
+            output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/image/imagen_provider.py
+++ b/packages/creator-provider/creator_provider/image/imagen_provider.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import base64
+import os
 import tempfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -91,7 +93,16 @@ class ImagenProvider(ImageProvider):
 
         output_path_str = merged.get("output_path")
         if output_path_str:
-            output_path = Path(str(output_path_str))
+            candidate_output = str(output_path_str)
+            artifact_root = os.getenv("ARTIFACT_ROOT")
+            if artifact_root is None and Path(candidate_output).is_absolute():
+                output_path = Path(candidate_output)
+            else:
+                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                    candidate_output,
+                    artifact_root or "data/artifacts",
+                )
+                output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/image/imagen_provider.py
+++ b/packages/creator-provider/creator_provider/image/imagen_provider.py
@@ -95,14 +95,11 @@ class ImagenProvider(ImageProvider):
         if output_path_str:
             candidate_output = str(output_path_str)
             artifact_root = os.getenv("ARTIFACT_ROOT")
-            if artifact_root is None and Path(candidate_output).is_absolute():
-                output_path = Path(candidate_output)
-            else:
-                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
-                    candidate_output,
-                    artifact_root or "data/artifacts",
-                )
-                output_path = Path(validated_output)
+            validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                candidate_output,
+                artifact_root or "data/artifacts",
+            )
+            output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/image/stability_provider.py
+++ b/packages/creator-provider/creator_provider/image/stability_provider.py
@@ -59,14 +59,11 @@ class StabilityProvider(ImageProvider):
         if output_path_str:
             candidate_output = str(output_path_str)
             artifact_root = os.getenv("ARTIFACT_ROOT")
-            if artifact_root is None and Path(candidate_output).is_absolute():
-                output_path = Path(candidate_output)
-            else:
-                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
-                    candidate_output,
-                    artifact_root or "data/artifacts",
-                )
-                output_path = Path(validated_output)
+            validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                candidate_output,
+                artifact_root or "data/artifacts",
+            )
+            output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=f".{output_format}", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/image/stability_provider.py
+++ b/packages/creator-provider/creator_provider/image/stability_provider.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import tempfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -55,7 +57,16 @@ class StabilityProvider(ImageProvider):
 
         output_path_str = merged.get("output_path")
         if output_path_str:
-            output_path = Path(str(output_path_str))
+            candidate_output = str(output_path_str)
+            artifact_root = os.getenv("ARTIFACT_ROOT")
+            if artifact_root is None and Path(candidate_output).is_absolute():
+                output_path = Path(candidate_output)
+            else:
+                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                    candidate_output,
+                    artifact_root or "data/artifacts",
+                )
+                output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=f".{output_format}", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/stt/whisper_provider.py
+++ b/packages/creator-provider/creator_provider/stt/whisper_provider.py
@@ -56,14 +56,11 @@ class WhisperSTTProvider(STTProvider):
         if output_path:
             candidate_output = str(output_path)
             artifact_root = os.getenv("ARTIFACT_ROOT")
-            if artifact_root is None and Path(candidate_output).is_absolute():
-                destination = Path(candidate_output)
-            else:
-                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
-                    candidate_output,
-                    artifact_root or "data/artifacts",
-                )
-                destination = Path(validated_output)
+            validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                candidate_output,
+                artifact_root or "data/artifacts",
+            )
+            destination = Path(validated_output)
             destination.parent.mkdir(parents=True, exist_ok=True)
             if subtitle_format == "vtt":
                 destination.write_text(_segments_to_vtt(segments), encoding="utf-8")

--- a/packages/creator-provider/creator_provider/stt/whisper_provider.py
+++ b/packages/creator-provider/creator_provider/stt/whisper_provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -52,7 +54,16 @@ class WhisperSTTProvider(STTProvider):
 
         output_path = merged_params.get("output_path")
         if output_path:
-            destination = Path(str(output_path))
+            candidate_output = str(output_path)
+            artifact_root = os.getenv("ARTIFACT_ROOT")
+            if artifact_root is None and Path(candidate_output).is_absolute():
+                destination = Path(candidate_output)
+            else:
+                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                    candidate_output,
+                    artifact_root or "data/artifacts",
+                )
+                destination = Path(validated_output)
             destination.parent.mkdir(parents=True, exist_ok=True)
             if subtitle_format == "vtt":
                 destination.write_text(_segments_to_vtt(segments), encoding="utf-8")

--- a/packages/creator-provider/creator_provider/tts/openai_tts_provider.py
+++ b/packages/creator-provider/creator_provider/tts/openai_tts_provider.py
@@ -65,14 +65,11 @@ class OpenAITTSProvider(TTSProvider):
         if output_path_str:
             candidate_output = str(output_path_str)
             artifact_root = os.getenv("ARTIFACT_ROOT")
-            if artifact_root is None and Path(candidate_output).is_absolute():
-                output_path = Path(candidate_output)
-            else:
-                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
-                    candidate_output,
-                    artifact_root or "data/artifacts",
-                )
-                output_path = Path(validated_output)
+            validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                candidate_output,
+                artifact_root or "data/artifacts",
+            )
+            output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/tts/openai_tts_provider.py
+++ b/packages/creator-provider/creator_provider/tts/openai_tts_provider.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import tempfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -61,7 +63,16 @@ class OpenAITTSProvider(TTSProvider):
 
         output_path_str = merged_params.get("output_path")
         if output_path_str:
-            output_path = Path(str(output_path_str))
+            candidate_output = str(output_path_str)
+            artifact_root = os.getenv("ARTIFACT_ROOT")
+            if artifact_root is None and Path(candidate_output).is_absolute():
+                output_path = Path(candidate_output)
+            else:
+                validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                    candidate_output,
+                    artifact_root or "data/artifacts",
+                )
+                output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/tests/test_external_image_providers.py
+++ b/packages/creator-provider/tests/test_external_image_providers.py
@@ -36,7 +36,7 @@ class TestDalleProvider:
         mock_response.json.return_value = {"data": [{"b64_json": encoded}]}
 
         output_path = tmp_path / "nested" / "dalle.png"
-        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test", "ARTIFACT_ROOT": str(tmp_path)}):
             from creator_provider.image.dalle_provider import DalleProvider
 
             provider = DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3")
@@ -119,7 +119,7 @@ class TestStabilityProvider:
         mock_response.content = image_bytes
 
         output_path = tmp_path / "nested" / "stability.webp"
-        with mock.patch.dict(os.environ, {"STABILITY_API_KEY": "st-test"}):
+        with mock.patch.dict(os.environ, {"STABILITY_API_KEY": "st-test", "ARTIFACT_ROOT": str(tmp_path)}):
             from creator_provider.image.stability_provider import StabilityProvider
 
             provider = StabilityProvider(
@@ -221,7 +221,7 @@ class TestImagenProvider:
         }
 
         output_path = tmp_path / "nested" / "imagen.png"
-        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test"}):
+        with mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "gk-test", "ARTIFACT_ROOT": str(tmp_path)}):
             from creator_provider.image.imagen_provider import ImagenProvider
 
             provider = ImagenProvider(

--- a/packages/creator-provider/tests/test_external_tts_providers.py
+++ b/packages/creator-provider/tests/test_external_tts_providers.py
@@ -122,7 +122,7 @@ class TestOpenAITTSProvider:
         mock_response.content = audio_bytes
 
         output_path = tmp_path / "nested" / "openai.mp3"
-        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test", "ARTIFACT_ROOT": str(tmp_path)}):
             from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
 
             provider = OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")

--- a/packages/creator-provider/tests/test_output_path_validation.py
+++ b/packages/creator-provider/tests/test_output_path_validation.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import base64
+import os
+import tempfile
+from importlib import import_module
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+UnsafePathComponent = import_module("creator_domain.sanitize").UnsafePathComponent
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_factory", "method_name", "payload_factory", "call_kwargs"),
+    [
+        (
+            lambda: __import__(
+                "creator_provider.image.dalle_provider", fromlist=["DalleProvider"]
+            ).DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3"),
+            "generate",
+            lambda: {"data": [{"b64_json": base64.b64encode(b"img").decode("utf-8")}]},
+            {"prompt": "test"},
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.image.stability_provider", fromlist=["StabilityProvider"]
+            ).StabilityProvider(endpoint="https://api.stability.ai", model_key="sd3-medium"),
+            "generate",
+            lambda: b"img",
+            {"prompt": "test"},
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.image.imagen_provider", fromlist=["ImagenProvider"]
+            ).ImagenProvider(
+                endpoint="https://generativelanguage.googleapis.com", model_key="imagen-3"
+            ),
+            "generate",
+            lambda: {
+                "generatedImages": [
+                    {"image": {"imageBytes": base64.b64encode(b"img").decode("utf-8")}}
+                ]
+            },
+            {"prompt": "test"},
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.tts.openai_tts_provider", fromlist=["OpenAITTSProvider"]
+            ).OpenAITTSProvider(endpoint="https://api.openai.com", model_key="tts-1"),
+            "generate",
+            lambda: b"audio",
+            {"text": "test"},
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.stt.whisper_provider", fromlist=["WhisperSTTProvider"]
+            ).WhisperSTTProvider(endpoint="https://stt.local", model_key="whisper-small"),
+            "transcribe",
+            lambda: {"segments": [], "text": ""},
+            {},
+        ),
+    ],
+)
+async def test_providers_reject_output_path_traversal(
+    provider_factory, method_name, payload_factory, call_kwargs, tmp_path: Path
+) -> None:
+    artifact_root = tmp_path / "artifacts"
+    bad_path = str(artifact_root / ".." / "outside" / "x.bin")
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as audio_file:
+        audio_file.write(b"\x00" * 44)
+        audio_input = audio_file.name
+
+    mock_response = mock.MagicMock()
+    mock_response.raise_for_status = mock.MagicMock()
+    payload = payload_factory()
+    if isinstance(payload, bytes):
+        mock_response.content = payload
+    else:
+        mock_response.json.return_value = payload
+
+    env = {
+        "OPENAI_API_KEY": "sk-test",
+        "STABILITY_API_KEY": "st-test",
+        "GOOGLE_API_KEY": "gk-test",
+        "ARTIFACT_ROOT": str(artifact_root),
+    }
+    with (
+        mock.patch.dict(os.environ, env, clear=False),
+        mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+    ):
+        provider = provider_factory()
+        method = getattr(provider, method_name)
+        params = {"output_path": bad_path}
+
+        with pytest.raises(UnsafePathComponent):
+            if method_name == "transcribe":
+                await method(audio_input, params=params)
+            else:
+                await method(params=params, **call_kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_factory", "method_name", "payload_factory", "call_kwargs", "suffix"),
+    [
+        (
+            lambda: __import__(
+                "creator_provider.image.dalle_provider", fromlist=["DalleProvider"]
+            ).DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3"),
+            "generate",
+            lambda: {"data": [{"b64_json": base64.b64encode(b"img").decode("utf-8")}]},
+            {"prompt": "test"},
+            ".png",
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.image.stability_provider", fromlist=["StabilityProvider"]
+            ).StabilityProvider(endpoint="https://api.stability.ai", model_key="sd3-medium"),
+            "generate",
+            lambda: b"img",
+            {"prompt": "test"},
+            ".png",
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.image.imagen_provider", fromlist=["ImagenProvider"]
+            ).ImagenProvider(
+                endpoint="https://generativelanguage.googleapis.com", model_key="imagen-3"
+            ),
+            "generate",
+            lambda: {
+                "generatedImages": [
+                    {"image": {"imageBytes": base64.b64encode(b"img").decode("utf-8")}}
+                ]
+            },
+            {"prompt": "test"},
+            ".png",
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.tts.openai_tts_provider", fromlist=["OpenAITTSProvider"]
+            ).OpenAITTSProvider(endpoint="https://api.openai.com", model_key="tts-1"),
+            "generate",
+            lambda: b"audio",
+            {"text": "test"},
+            ".mp3",
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.stt.whisper_provider", fromlist=["WhisperSTTProvider"]
+            ).WhisperSTTProvider(endpoint="https://stt.local", model_key="whisper-small"),
+            "transcribe",
+            lambda: {"segments": [], "text": ""},
+            {},
+            ".srt",
+        ),
+    ],
+)
+async def test_providers_accept_output_path_within_artifact_root(
+    provider_factory, method_name, payload_factory, call_kwargs, suffix, tmp_path: Path
+) -> None:
+    artifact_root = tmp_path / "artifacts"
+    good_path = artifact_root / "101" / f"file{suffix}"
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as audio_file:
+        audio_file.write(b"\x00" * 44)
+        audio_input = audio_file.name
+
+    mock_response = mock.MagicMock()
+    mock_response.raise_for_status = mock.MagicMock()
+    payload = payload_factory()
+    if isinstance(payload, bytes):
+        mock_response.content = payload
+    else:
+        mock_response.json.return_value = payload
+
+    env = {
+        "OPENAI_API_KEY": "sk-test",
+        "STABILITY_API_KEY": "st-test",
+        "GOOGLE_API_KEY": "gk-test",
+        "ARTIFACT_ROOT": str(artifact_root),
+    }
+    with (
+        mock.patch.dict(os.environ, env, clear=False),
+        mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+    ):
+        provider = provider_factory()
+        method = getattr(provider, method_name)
+        params = {"output_path": str(good_path)}
+
+        if method_name == "transcribe":
+            await method(audio_input, params=params)
+        else:
+            await method(params=params, **call_kwargs)
+
+    assert good_path.exists()

--- a/packages/creator-provider/tests/test_output_path_validation.py
+++ b/packages/creator-provider/tests/test_output_path_validation.py
@@ -274,3 +274,30 @@ async def test_absolute_path_rejected_when_artifact_root_unset(
 
         with pytest.raises(UnsafePathComponent):
             await method(params=params, **call_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_whisper_absolute_path_rejected_when_artifact_root_unset(
+    tmp_path: Path,
+) -> None:
+    """Regression: WhisperSTTProvider must reject absolute output_path even without ARTIFACT_ROOT."""
+    audio_file = tmp_path / "audio.wav"
+    audio_file.write_bytes(b"RIFF" + b"\x00" * 100)
+
+    mock_response = mock.MagicMock()
+    mock_response.raise_for_status = mock.MagicMock()
+    mock_response.json.return_value = {"segments": [], "text": ""}
+
+    from creator_provider.stt.whisper_provider import WhisperSTTProvider
+
+    with (
+        mock.patch.dict(os.environ, {}, clear=False),
+        mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+    ):
+        os.environ.pop("ARTIFACT_ROOT", None)
+        provider = WhisperSTTProvider(endpoint="http://whisper:9000", model_key="whisper-small")
+        with pytest.raises(UnsafePathComponent):
+            await provider.transcribe(
+                audio_path=str(audio_file),
+                params={"output_path": "/etc/passwd"},
+            )

--- a/packages/creator-provider/tests/test_output_path_validation.py
+++ b/packages/creator-provider/tests/test_output_path_validation.py
@@ -198,3 +198,79 @@ async def test_providers_accept_output_path_within_artifact_root(
             await method(params=params, **call_kwargs)
 
     assert good_path.exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_factory", "method_name", "payload_factory", "call_kwargs"),
+    [
+        (
+            lambda: __import__(
+                "creator_provider.image.dalle_provider", fromlist=["DalleProvider"]
+            ).DalleProvider(endpoint="https://api.openai.com", model_key="dall-e-3"),
+            "generate",
+            lambda: {"data": [{"b64_json": base64.b64encode(b"img").decode("utf-8")}]},
+            {"prompt": "test"},
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.image.stability_provider", fromlist=["StabilityProvider"]
+            ).StabilityProvider(endpoint="https://api.stability.ai", model_key="sd3-medium"),
+            "generate",
+            lambda: b"img",
+            {"prompt": "test"},
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.image.imagen_provider", fromlist=["ImagenProvider"]
+            ).ImagenProvider(
+                endpoint="https://generativelanguage.googleapis.com", model_key="imagen-3"
+            ),
+            "generate",
+            lambda: {
+                "generatedImages": [
+                    {"image": {"imageBytes": base64.b64encode(b"img").decode("utf-8")}}
+                ]
+            },
+            {"prompt": "test"},
+        ),
+        (
+            lambda: __import__(
+                "creator_provider.tts.openai_tts_provider", fromlist=["OpenAITTSProvider"]
+            ).OpenAITTSProvider(endpoint="https://api.openai.com", model_key="tts-1"),
+            "generate",
+            lambda: b"audio",
+            {"text": "test"},
+        ),
+    ],
+)
+async def test_absolute_path_rejected_when_artifact_root_unset(
+    provider_factory, method_name, payload_factory, call_kwargs,
+) -> None:
+    """Regression: absolute output_path must be rejected even when ARTIFACT_ROOT is unset."""
+    mock_response = mock.MagicMock()
+    mock_response.raise_for_status = mock.MagicMock()
+    payload = payload_factory()
+    if isinstance(payload, bytes):
+        mock_response.content = payload
+    else:
+        mock_response.json.return_value = payload
+
+    env_without_root = {
+        "OPENAI_API_KEY": "sk-test",
+        "STABILITY_API_KEY": "st-test",
+        "GOOGLE_API_KEY": "gk-test",
+    }
+    with (
+        mock.patch.dict(os.environ, env_without_root, clear=False),
+        mock.patch.dict(os.environ, {}, clear=False),
+        mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+    ):
+        # Remove ARTIFACT_ROOT if present
+        os.environ.pop("ARTIFACT_ROOT", None)
+        provider = provider_factory()
+        method = getattr(provider, method_name)
+        params = {"output_path": "/etc/passwd"}
+
+        with pytest.raises(UnsafePathComponent):
+            await method(params=params, **call_kwargs)


### PR DESCRIPTION
## Summary
- Removed all absolute-path bypass patterns from 5 providers and 2 workers
- All artifact paths now validated via `validate_artifact_path()` with default root `data/artifacts`
- 24 regression tests covering traversal, absolute paths, symlinks, and ARTIFACT_ROOT-unset scenarios

## Changes
### Production Code
- `creator_domain/sanitize.py`: Added `validate_artifact_path()` utility
- 5 providers (DALL-E, Stability, Imagen, OpenAI TTS, Whisper): Removed `is_absolute()` bypass, always validate
- 2 workers (generate_subtitles, render_video): Removed env-based bypass, always validate

### Tests
- `test_sanitize_artifact_path.py`: 5 core sanitization tests
- `test_output_path_validation.py`: 16 provider path validation tests + 1 Whisper regression
- `test_worker_path_validation.py`: 4 worker path validation tests (traversal + absolute path regression)

## Test Results
1096 tests passing locally.

Closes #482