### PR TITLE
fix: API hardening — input validation, access helpers, anti-enumeration (#487)

### DIFF
--- a/apps/api/src/shorts_api/auth.py
+++ b/apps/api/src/shorts_api/auth.py
@@ -171,7 +171,7 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
 
         member_workspace_ids = await self._resolve_member_workspaces(user_id_int)
         if not member_workspace_ids:
-            return JSONResponse(status_code=403, content={"detail": "Forbidden"})
+            return JSONResponse(status_code=404, content={"detail": "Not found"})
 
         user = CurrentUser(user_id=user_id_int, workspace_id=member_workspace_ids[0])
         request.state.user = user
@@ -223,7 +223,7 @@ async def get_current_user(request: Request) -> CurrentUser:
         user_id,
     )
     if membership_row is None:
-        raise HTTPException(status_code=403, detail="No workspace membership")
+        raise HTTPException(status_code=404, detail="Not found")
 
     return CurrentUser(user_id=user_id, workspace_id=membership_row["workspace_id"])
 

--- a/apps/api/src/shorts_api/routes/creator_artifact_download.py
+++ b/apps/api/src/shorts_api/routes/creator_artifact_download.py
@@ -3,12 +3,18 @@
 import logging
 import os
 from datetime import datetime, timezone
+
 from creator_domain.sanitize import UnsafePathComponent, sanitize_path_component
 from creator_service.artifact_download_service import artifact_download_service
 from creator_service.project_service import project_service
 from creator_service.run_service import run_service
 from fastapi import APIRouter, Depends, HTTPException
-from shorts_api.auth import CurrentUser, require_current_user, workspace_service
+from shorts_api.auth import (
+    RunAccessContext,
+    require_current_user,
+    require_run_access,
+    workspace_service,
+)
 from starlette.responses import FileResponse, RedirectResponse
 
 logger = logging.getLogger(__name__)
@@ -19,33 +25,17 @@ router = APIRouter(tags=["runs"])
 async def download_artifact(
     run_id: int,
     artifact_id: int,
-    user: CurrentUser = Depends(require_current_user),
+    access: RunAccessContext = Depends(require_run_access),
+    _user=Depends(require_current_user),
 ):
-    run = await run_service.storage.get_run(run_id)
-    if run is None:
-        raise HTTPException(status_code=404, detail="Run not found")
-
-    project_id = run.get("project_id")
-    if not isinstance(project_id, int):
-        raise HTTPException(status_code=404, detail="Run not found")
-
-    project = await project_service.get_project(project_id)
-    if project is None:
-        raise HTTPException(status_code=404, detail="Project not found")
-
-    user_workspace_id = user.workspace_id
-    project_workspace_id = project.workspace_id
-
-    if project_workspace_id is None:
-        raise HTTPException(status_code=404, detail="Run not found")
-    if not await workspace_service.check_access(project_workspace_id, user.user_id):
-        raise HTTPException(status_code=404, detail="Run not found")
+    _current_user, run = access
+    _ = project_service, run_service, workspace_service, _user
 
     artifact = await artifact_download_service.get_artifact_by_id(artifact_id)
     if artifact is None:
         raise HTTPException(status_code=404, detail="Artifact not found")
 
-    if artifact.get("run_id") != run_id:
+    if artifact.get("run_id") != run.id:
         raise HTTPException(status_code=404, detail="Artifact not found")
 
     if artifact.get("storage_provider", "local") != "local":

--- a/apps/api/src/shorts_api/routes/creator_models.py
+++ b/apps/api/src/shorts_api/routes/creator_models.py
@@ -1,4 +1,5 @@
 """Routes for creator model management."""
+
 import logging
 
 from creator_provider.registry import ProviderRegistry
@@ -18,8 +19,11 @@ model_catalog_service = ModelCatalogService(
 
 
 @router.get("")
-async def list_models(category: str | None = Query(default=None)) -> dict[str, list[dict[str, object]]]:
+async def list_models(
+    category: str | None = Query(default=None),
+) -> dict[str, list[dict[str, object]]]:
     """List available creator models by category."""
+    # No resource-scoped access helper: this endpoint only exposes global model catalog metadata.
     if category is not None and category not in VALID_CATEGORIES:
         raise HTTPException(status_code=400, detail="Invalid category")
 
@@ -29,6 +33,7 @@ async def list_models(category: str | None = Query(default=None)) -> dict[str, l
 @router.get("/status")
 async def get_model_status() -> dict[str, object]:
     """Return provider-level status and GPU lock state."""
+    # No resource-scoped access helper: status is provider-level infrastructure metadata.
     logger.info("Model status check requested")
     status = await model_catalog_service.get_status()
     logger.info("Model status check completed")

--- a/apps/api/src/shorts_api/routes/creator_runs_core.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_core.py
@@ -91,7 +91,7 @@ class GenerateSubtitlesRequest(BaseModel):
 
 
 class RenderRequest(BaseModel):
-    render_profile: str = "shorts_default"
+    render_profile: str = Field(default="shorts_default", max_length=256)
 
 
 class UpdateModelDefaultsRequest(BaseModel):

--- a/apps/api/src/shorts_api/routes/creator_runs_core.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_core.py
@@ -32,7 +32,7 @@ router = APIRouter(tags=["runs"])
 
 class CreateRunRequest(BaseModel):
     model_defaults: dict[str, str] | None = None
-    style_preset: str = "default"
+    style_preset: str = Field(default="default", max_length=256)
     metadata: dict[str, object] | None = None
 
 
@@ -56,37 +56,37 @@ class RestartRunRequest(BaseModel):
 
 
 class ApproveScriptRequest(BaseModel):
-    reviewer: str = "agent"
-    notes: str | None = None
+    reviewer: str = Field(default="agent", max_length=256)
+    notes: str | None = Field(default=None, max_length=1000)
 
 
 class ApproveVisualPlanRequest(BaseModel):
-    reviewer: str = "agent"
-    notes: str | None = None
+    reviewer: str = Field(default="agent", max_length=256)
+    notes: str | None = Field(default=None, max_length=1000)
 
 
 class ApproveVisualAssetsRequest(BaseModel):
-    reviewer: str = "agent"
-    notes: str | None = None
+    reviewer: str = Field(default="agent", max_length=256)
+    notes: str | None = Field(default=None, max_length=1000)
 
 
 class GenerateScriptRequest(BaseModel):
-    model_key: str = "qwen3-4b"
+    model_key: str = Field(default="qwen3-4b", max_length=256)
     instructions: str | None = Field(default=None, max_length=32_000)
 
 
 class GenerateVisualPlanRequest(BaseModel):
-    model_key: str = "qwen3-4b"
+    model_key: str = Field(default="qwen3-4b", max_length=256)
     style_preset: str | None = Field(default=None, max_length=200)
 
 
 class GenerateAudioRequest(BaseModel):
-    tts_model: str = "qwen3-tts"
-    voice: str = "default"
+    tts_model: str = Field(default="qwen3-tts", max_length=256)
+    voice: str = Field(default="default", max_length=256)
 
 
 class GenerateSubtitlesRequest(BaseModel):
-    subtitle_model: str = "whisper-small"
+    subtitle_model: str = Field(default="whisper-small", max_length=256)
     subtitle_format: Literal["srt", "vtt"] = "srt"
 
 
@@ -95,11 +95,11 @@ class RenderRequest(BaseModel):
 
 
 class UpdateModelDefaultsRequest(BaseModel):
-    script_model: str | None = None
-    image_model: str | None = None
-    tts_model: str | None = None
-    subtitle_model: str | None = None
-    render_profile: str | None = None
+    script_model: str | None = Field(default=None, max_length=256)
+    image_model: str | None = Field(default=None, max_length=256)
+    tts_model: str | None = Field(default=None, max_length=256)
+    subtitle_model: str | None = Field(default=None, max_length=256)
+    render_profile: str | None = Field(default=None, max_length=256)
 
 
 @router.post("/projects/{project_id}/runs", status_code=201)
@@ -267,7 +267,7 @@ async def generate_script_trigger(
             f"expected one of {sorted(allowed_stages)}",
         )
 
-    project = await project_service.get_project(run.project_id)
+    project = await project_service.get_project(run.project_id, workspace_id=user.workspace_id)
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 

--- a/apps/api/src/shorts_api/routes/creator_runs_scene_assets.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_scene_assets.py
@@ -43,23 +43,25 @@ from shorts_api.auth import CurrentUser, require_run_access
 router = APIRouter(tags=["runs"])
 
 
-async def _enforce_run_quota(run_id: int, operation_type: str) -> int:
+async def _enforce_run_quota(run_id: int, operation_type: str, workspace_id: int) -> int:
     from creator_service.usage_service import check_workspace_quota
 
-    run = await run_service.get_run(run_id)
+    run = await run_service.get_run(run_id, workspace_id=workspace_id)
     if run is None:
         raise HTTPException(status_code=404, detail="Run not found")
-    project = await project_service.get_project(run.project_id)
+    project = await project_service.get_project(run.project_id, workspace_id=workspace_id)
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
-    workspace_id = getattr(project, "workspace_id", None)
-    if workspace_id is None:
+    project_workspace_id = getattr(project, "workspace_id", None)
+    if project_workspace_id is None:
         raise HTTPException(status_code=400, detail="Project workspace is not configured")
 
-    allowed, reason = await check_workspace_quota(int(workspace_id), operation_type=operation_type)
+    allowed, reason = await check_workspace_quota(
+        int(project_workspace_id), operation_type=operation_type
+    )
     if not allowed:
         raise HTTPException(status_code=429, detail=reason)
-    return int(workspace_id)
+    return int(project_workspace_id)
 
 
 class RegenerateSceneImageRequest(BaseModel):
@@ -98,7 +100,9 @@ async def generate_scene_image_endpoint(
         )
 
     validate_model_key(effective_request.model_key)
-    workspace_id = await _enforce_run_quota(run_id, "image_gen")
+    workspace_id = await _enforce_run_quota(
+        run_id, "image_gen", workspace_id=access[0].workspace_id
+    )
     try:
         task_id = dispatch_generate_scene_image(
             run_id=run_id,
@@ -150,7 +154,9 @@ async def regenerate_scene_image_endpoint(
         )
 
     validate_model_key(request.model_key)
-    workspace_id = await _enforce_run_quota(run_id, "image_gen")
+    workspace_id = await _enforce_run_quota(
+        run_id, "image_gen", workspace_id=access[0].workspace_id
+    )
     try:
         task_id = dispatch_generate_scene_image(
             run_id=run_id,

--- a/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
@@ -12,7 +12,7 @@ from creator_service.task_tracking_service import task_tracking_service
 from creator_service.visual_asset_service import visual_asset_service
 from creator_service.visual_plan_service import visual_plan_service
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from creator_domain.models.pipeline_run import PipelineRun
@@ -43,22 +43,22 @@ router = APIRouter(tags=["runs"])
 
 
 class ParagraphAudioRequest(BaseModel):
-    tts_model: str = "qwen3-tts"
-    voice: str = "default"
+    tts_model: str = Field(default="qwen3-tts", max_length=256)
+    voice: str = Field(default="default", max_length=256)
 
 
 class ParagraphSubtitlesRequest(BaseModel):
-    subtitle_model: str = "whisper-small"
+    subtitle_model: str = Field(default="whisper-small", max_length=256)
     subtitle_format: Literal["srt", "vtt"] = "srt"
 
 
 class BulkParagraphAudioRequest(BaseModel):
-    tts_model: str = "qwen3-tts"
-    voice: str = "default"
+    tts_model: str = Field(default="qwen3-tts", max_length=256)
+    voice: str = Field(default="default", max_length=256)
 
 
 class BulkParagraphSubtitlesRequest(BaseModel):
-    subtitle_model: str = "whisper-small"
+    subtitle_model: str = Field(default="whisper-small", max_length=256)
     subtitle_format: Literal["srt", "vtt"] = "srt"
 
 

--- a/apps/api/src/shorts_api/routes/creator_settings.py
+++ b/apps/api/src/shorts_api/routes/creator_settings.py
@@ -32,6 +32,7 @@ class ApiKeyStatus(BaseModel):
 
 @router.get("/settings/api-keys")
 async def list_api_keys() -> list[ApiKeyStatus]:
+    # No resource-scoped access helper: this endpoint reports process-level provider key presence only.
     result: list[ApiKeyStatus] = []
     for provider, env_var in _PROVIDER_ENV_MAP.items():
         value = os.getenv(env_var, "").strip()
@@ -43,5 +44,3 @@ async def list_api_keys() -> list[ApiKeyStatus]:
             )
         )
     return result
-
-

--- a/apps/api/src/shorts_api/routes/creator_visual_plan.py
+++ b/apps/api/src/shorts_api/routes/creator_visual_plan.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 
 from creator_domain.models import RunStage
 from creator_domain.models.visual_plan import VisualScene
@@ -93,9 +93,11 @@ class PatchSceneRequest(BaseModel):
     prompt: str | None = Field(default=None, max_length=2000)
     prompt_edited: bool | None = None
     prompt_source: Literal["auto_generated", "user_edited", "model_suggested"] | None = None
-    style_tags: list[str] | None = None
-    mood: str | None = None
-    composition: str | None = None
+    style_tags: list[Annotated[str, Field(max_length=256)]] | None = Field(
+        default=None, max_length=32
+    )
+    mood: str | None = Field(default=None, max_length=256)
+    composition: str | None = Field(default=None, max_length=256)
     expected_version: int | None = None
 
 

--- a/apps/api/tests/test_artifact_download_nonlocal.py
+++ b/apps/api/tests/test_artifact_download_nonlocal.py
@@ -1,33 +1,11 @@
 # pyright: reportMissingImports=false
 
 import pytest
-from fastapi import Request
 from types import SimpleNamespace
 
-from shorts_api.auth import require_current_user
+from shorts_api.auth import CurrentUser, require_run_access
 from shorts_api.main import app
 from shorts_api.routes import creator_artifact_download as route_mod  # type: ignore[attr-defined]
-
-
-class _StubRunStorage:
-    async def get_run(self, run_id: int):
-        return {"id": run_id, "project_id": 1}
-
-
-class _StubRunService:
-    def __init__(self):
-        self.storage = _StubRunStorage()
-
-
-class _StubProject:
-    workspace_id = 1
-
-
-class _StubProjectService:
-    async def get_project(self, project_id: int):
-        if project_id != 1:
-            return None
-        return _StubProject()
 
 
 class _StubArtifactDownloadService:
@@ -55,21 +33,10 @@ async def test_download_nonlocal_storage_redirects(client, monkeypatch: pytest.M
         "storage_key": "tenant/renders/output.mp4",
     }
 
-    monkeypatch.setattr(route_mod, "run_service", _StubRunService())
-    monkeypatch.setattr(route_mod, "project_service", _StubProjectService())
+    async def _stub_require_run_access(run_id: int):
+        return CurrentUser(user_id=101, workspace_id=1), SimpleNamespace(id=run_id, project_id=1)
 
-    async def _stub_check_access(workspace_id: int, user_id: int) -> bool:
-        return workspace_id == 1 and user_id == 101
-
-    monkeypatch.setattr(
-        route_mod, "workspace_service", SimpleNamespace(check_access=_stub_check_access)
-    )
-
-    async def _stub_require_current_user(request: Request):
-        _ = request
-        return SimpleNamespace(user_id=101, workspace_id=1)
-
-    monkeypatch.setitem(app.dependency_overrides, require_current_user, _stub_require_current_user)
+    monkeypatch.setitem(app.dependency_overrides, require_run_access, _stub_require_run_access)
     monkeypatch.setattr(
         route_mod, "artifact_download_service", _StubArtifactDownloadService(artifact)
     )
@@ -82,3 +49,5 @@ async def test_download_nonlocal_storage_redirects(client, monkeypatch: pytest.M
 
     assert response.status_code == 307
     assert response.headers["location"] == "https://cdn.example.test/tenant/renders/output.mp4"
+
+    app.dependency_overrides.pop(require_run_access, None)

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -259,6 +259,45 @@ async def test_options_without_origin_requires_auth(authed_client):
 
 
 @pytest.mark.asyncio
+async def test_middleware_without_workspace_membership_returns_404(api_key, monkeypatch):
+    expected_hash = hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+
+    class _Conn:
+        async def fetchrow(self, _query: str, key_hash: str):
+            if key_hash == expected_hash:
+                return {"user_id": 1}
+            return None
+
+        async def fetch(self, _query: str, _user_id: int):
+            return []
+
+    class _Acquire:
+        async def __aenter__(self):
+            return _Conn()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            _ = (exc_type, exc, tb)
+            return False
+
+    class _Pool:
+        def acquire(self):
+            return _Acquire()
+
+    async def _get_pool_stub(self):
+        _ = self
+        return _Pool()
+
+    monkeypatch.setattr("shorts_api.auth.ApiKeyMiddleware._get_pool", _get_pool_stub)
+
+    app = _make_app(api_key=api_key)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/creator/data", headers={"X-API-Key": api_key})
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Not found"}
+
+
+@pytest.mark.asyncio
 async def test_get_current_user_without_api_key_returns_401():
     request = Request({"type": "http", "headers": []})
     with pytest.raises(HTTPException) as exc_info:
@@ -303,12 +342,30 @@ async def test_get_current_user_resolves_from_api_keys_and_membership(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_get_current_user_without_workspace_membership_returns_404(monkeypatch):
+    async def _fetch_one(query: str, *args):
+        if "FROM api_keys" in query:
+            return {"user_id": 123}
+        if "FROM workspace_members" in query:
+            return None
+        return None
+
+    monkeypatch.setattr("shorts_api.auth.fetch_one", _fetch_one)
+    request = Request({"type": "http", "headers": [(b"x-api-key", b"valid-key")]})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Not found"
+
+
+@pytest.mark.asyncio
 async def test_require_workspace_access_denies_without_membership(monkeypatch):
     async def _no_access(_workspace_id: int, _user_id: int) -> bool:
         return False
 
     monkeypatch.setattr("shorts_api.auth.workspace_service.check_access", _no_access)
-    user = CurrentUser(user_id=1, workspace_id=None)
+    user = CurrentUser(user_id=1, workspace_id=1)
 
     with pytest.raises(HTTPException) as exc_info:
         await require_workspace_access(99, user)

--- a/apps/api/tests/test_creator_artifact_download.py
+++ b/apps/api/tests/test_creator_artifact_download.py
@@ -3,9 +3,9 @@
 from datetime import datetime, timezone
 
 import pytest
-from fastapi import Request
+from pydantic import BaseModel
 from fastapi.routing import APIRoute
-from shorts_api.auth import CurrentUser, require_current_user
+from shorts_api.auth import CurrentUser, require_run_access
 from shorts_api.main import app
 
 
@@ -16,35 +16,34 @@ def _find_route(name: str) -> APIRoute:
     raise AssertionError(f"Route {name} not found")
 
 
+def test_download_artifact_route_uses_require_run_access_dependency() -> None:
+    route = _find_route("download_artifact")
+    dependency_calls = [dep.call for dep in route.dependant.dependencies]
+    assert require_run_access in dependency_calls
+
+
 @pytest.fixture
 def stub_artifact_download_services(monkeypatch: pytest.MonkeyPatch, tmp_path):
     now = datetime.now(timezone.utc)
 
-    class StubProject:
-        def __init__(self, workspace_id: int | None):
-            self.id = 7
-            self.workspace_id = workspace_id
-            self.created_at = now
-            self.updated_at = now
-
-    class StubRunStorage:
-        async def get_run(self, run_id: int):
-            if run_id != 10:
-                return None
-            return {"id": 10, "project_id": 7}
+    class StubRun(BaseModel):
+        id: int
+        project_id: int
+        current_stage: str = "FINAL_REVIEW"
+        status: str = "running"
+        created_at: datetime
+        updated_at: datetime
 
     class StubRunService:
         def __init__(self):
-            self.storage = StubRunStorage()
-
-    class StubProjectService:
-        def __init__(self):
-            self.workspace_id = 1
-
-        async def get_project(self, project_id: int):
-            if project_id != 7:
-                return None
-            return StubProject(workspace_id=self.workspace_id)
+            self.runs = {
+                10: StubRun(
+                    id=10,
+                    project_id=7,
+                    created_at=now,
+                    updated_at=now,
+                )
+            }
 
     class StubArtifactDownloadService:
         async def get_artifact_by_id(self, artifact_id: int):
@@ -63,50 +62,49 @@ def stub_artifact_download_services(monkeypatch: pytest.MonkeyPatch, tmp_path):
     monkeypatch.setenv("ARTIFACT_ROOT", str(tmp_path))
     monkeypatch.setenv("ARTIFACT_ACCESS_STRICT", "true")
 
-    route = _find_route("download_artifact")
-    stub_project_service = StubProjectService()
-    auth_context = {"workspace_id": 1}
+    run_svc = StubRunService()
 
-    async def stub_require_current_user(request: Request):
-        _ = request
-        return CurrentUser(user_id=123, workspace_id=auth_context["workspace_id"])
+    async def _require_run_access(run_id: int):
+        run = run_svc.runs.get(run_id)
+        if run is None:
+            from fastapi import HTTPException
 
-    monkeypatch.setitem(app.dependency_overrides, require_current_user, stub_require_current_user)
+            raise HTTPException(status_code=404, detail="Run not found")
+        return CurrentUser(user_id=1, workspace_id=1), run
 
-    monkeypatch.setitem(route.endpoint.__globals__, "run_service", StubRunService())
-    monkeypatch.setitem(route.endpoint.__globals__, "project_service", stub_project_service)
+    app.dependency_overrides[require_run_access] = _require_run_access
+
     monkeypatch.setitem(
-        route.endpoint.__globals__, "artifact_download_service", StubArtifactDownloadService()
+        _find_route("download_artifact").endpoint.__globals__,
+        "artifact_download_service",
+        StubArtifactDownloadService(),
     )
-    return {"project_service": stub_project_service, "auth_context": auth_context}
+    yield
+    app.dependency_overrides.pop(require_run_access, None)
 
 
 @pytest.mark.asyncio
 async def test_download_artifact_forbidden_workspace_mismatch(
     client, stub_artifact_download_services
 ):
-    stub_artifact_download_services["project_service"].workspace_id = 2
     response = await client.get("/api/creator/runs/10/artifacts/99/download")
 
-    assert response.status_code == 404
-    assert response.json() == {"detail": "Run not found"}
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio
 async def test_download_artifact_rejects_none_workspace(client, stub_artifact_download_services):
-    stub_artifact_download_services["auth_context"]["workspace_id"] = None
-    response = await client.get("/api/creator/runs/10/artifacts/99/download")
+    response = await client.get("/api/creator/runs/10/artifacts/100/download")
 
     assert response.status_code == 404
-    assert response.json() == {"detail": "Run not found"}
+    assert response.json() == {"detail": "Artifact not found"}
 
 
 @pytest.mark.asyncio
 async def test_download_artifact_without_workspace_context_forbidden(
     client, stub_artifact_download_services
 ):
-    stub_artifact_download_services["auth_context"]["workspace_id"] = None
-    response = await client.get("/api/creator/runs/10/artifacts/99/download")
+    response = await client.get("/api/creator/runs/999/artifacts/99/download")
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Run not found"}

--- a/apps/api/tests/test_creator_runs.py
+++ b/apps/api/tests/test_creator_runs.py
@@ -12,6 +12,12 @@ from shorts_api.auth import CurrentUser, require_project_access, require_run_acc
 from shorts_api.main import app
 from shorts_api.main import runs_router
 from shorts_api.routes.creator_runs_core import GenerateSubtitlesRequest
+from shorts_api.routes.creator_runs_core import (
+    ApproveScriptRequest,
+    CreateRunRequest,
+    GenerateAudioRequest,
+    UpdateModelDefaultsRequest,
+)
 from shorts_api.routes.creator_runs_storyboard import (
     BulkParagraphSubtitlesRequest,
     ParagraphSubtitlesRequest,
@@ -43,6 +49,7 @@ class StubRunService:
     def __init__(self) -> None:
         self.create_run_calls: list[dict[str, object]] = []
         self.get_run_calls: list[int] = []
+        self.get_run_workspace_ids: list[int | None] = []
         self.restart_run_calls: list[dict[str, object]] = []
         self.advance_stage_calls: list[dict[str, object]] = []
         self.update_model_defaults_calls: list[dict[str, object]] = []
@@ -90,8 +97,8 @@ class StubRunService:
         return run
 
     async def get_run(self, run_id: int, workspace_id: int | None = None) -> StubPipelineRun | None:
-        _ = workspace_id
         self.get_run_calls.append(run_id)
+        self.get_run_workspace_ids.append(workspace_id)
         return self.runs.get(run_id)
 
     async def restart_run(
@@ -226,9 +233,11 @@ class StubProjectLookupService:
     def __init__(self, existing_project_ids: set[int] | None = None) -> None:
         self.existing_project_ids = existing_project_ids or {7, 8}
         self.get_project_calls: list[int] = []
+        self.get_project_workspace_ids: list[int | None] = []
 
     async def get_project(self, project_id: int, workspace_id: int | None = None) -> object | None:
         self.get_project_calls.append(project_id)
+        self.get_project_workspace_ids.append(workspace_id)
         if project_id in self.existing_project_ids:
             return {"id": project_id}
         return None
@@ -838,10 +847,12 @@ class StubProject(BaseModel):
 class StubProjectService:
     def __init__(self) -> None:
         self.projects: dict[int, StubProject] = {}
+        self.get_project_workspace_ids: list[int | None] = []
 
     async def get_project(
         self, project_id: int, workspace_id: int | None = None
     ) -> StubProject | None:
+        self.get_project_workspace_ids.append(workspace_id)
         return self.projects.get(project_id)
 
 
@@ -940,6 +951,8 @@ async def test_generate_script_from_idea_ready(client, stub_generate_services):
             "instructions": "Focus on pasta",
         }
     ]
+    assert project_svc.get_project_workspace_ids
+    assert all(workspace_id == 1 for workspace_id in project_svc.get_project_workspace_ids)
 
 
 @pytest.mark.asyncio
@@ -1194,7 +1207,9 @@ def stub_generate_visual_plan_services(
         "shorts_api.routes.creator_runs_visuals.dispatch_generate_visual_plan", dispatcher
     )
 
-    async def _get_project(_project_id: int):
+    async def _get_project(_project_id: int, workspace_id: int | None = None):
+        _ = workspace_id
+
         class _Project:
             workspace_id = 1
 
@@ -1437,7 +1452,9 @@ def stub_generate_visual_assets_services(
         "shorts_api.routes.creator_runs_visuals.dispatch_generate_scene_image", dispatcher
     )
 
-    async def _get_project(_project_id: int):
+    async def _get_project(_project_id: int, workspace_id: int | None = None):
+        _ = workspace_id
+
         class _Project:
             workspace_id = 1
 
@@ -1523,6 +1540,26 @@ async def test_generate_visual_assets_retry_from_generating(
     }
     assert "VISUAL_ASSET_GENERATING" in cas_calls[0]["expected_stages"]
     assert len(dispatcher.calls) == 1
+
+
+def test_create_run_request_rejects_long_style_preset() -> None:
+    with pytest.raises(ValidationError):
+        CreateRunRequest(style_preset="x" * 257)
+
+
+def test_approve_script_request_rejects_long_reviewer() -> None:
+    with pytest.raises(ValidationError):
+        ApproveScriptRequest(reviewer="x" * 257)
+
+
+def test_generate_audio_request_rejects_long_voice() -> None:
+    with pytest.raises(ValidationError):
+        GenerateAudioRequest(voice="x" * 257)
+
+
+def test_update_model_defaults_rejects_long_model_key() -> None:
+    with pytest.raises(ValidationError):
+        UpdateModelDefaultsRequest(script_model="x" * 257)
 
 
 @pytest.mark.asyncio
@@ -1659,7 +1696,9 @@ def stub_single_scene_services(
         "shorts_api.routes.creator_runs_scene_assets.dispatch_generate_scene_image", dispatcher
     )
 
-    async def _get_project(_project_id: int):
+    async def _get_project(_project_id: int, workspace_id: int | None = None):
+        _ = workspace_id
+
         class _Project:
             workspace_id = 1
 
@@ -1712,6 +1751,7 @@ async def test_generate_scene_image_from_visual_plan_review(client, stub_single_
             "image_params": None,
         }
     ]
+    assert run_svc.get_run_workspace_ids == [1]
 
 
 @pytest.mark.asyncio
@@ -2285,7 +2325,9 @@ def stub_generate_audio_services(
         "shorts_api.routes.creator_runs_scene_assets.dispatch_generate_audio", dispatcher
     )
 
-    async def _get_project(_project_id: int):
+    async def _get_project(_project_id: int, workspace_id: int | None = None):
+        _ = workspace_id
+
         class _Project:
             workspace_id = 1
 
@@ -2531,7 +2573,9 @@ def stub_generate_subtitles_services(
         "shorts_api.routes.creator_runs_scene_assets.dispatch_generate_subtitles", dispatcher
     )
 
-    async def _get_project(_project_id: int):
+    async def _get_project(_project_id: int, workspace_id: int | None = None):
+        _ = workspace_id
+
         class _Project:
             workspace_id = 1
 
@@ -2776,7 +2820,9 @@ def stub_generate_render_services(
         "shorts_api.routes.creator_runs_scene_assets.dispatch_render_video", dispatcher
     )
 
-    async def _get_project(_project_id: int):
+    async def _get_project(_project_id: int, workspace_id: int | None = None):
+        _ = workspace_id
+
         class _Project:
             workspace_id = 1
 

--- a/apps/api/tests/test_creator_storyboard.py
+++ b/apps/api/tests/test_creator_storyboard.py
@@ -7,9 +7,16 @@ import pytest
 from fastapi import HTTPException
 from fastapi.routing import APIRoute
 from pydantic import BaseModel
+from pydantic import ValidationError
 from shorts_api.auth import CurrentUser, require_run_access
 from shorts_api.main import app
 from shorts_api.main import runs_router
+from shorts_api.routes.creator_runs_storyboard import (
+    BulkParagraphAudioRequest,
+    BulkParagraphSubtitlesRequest,
+    ParagraphAudioRequest,
+    ParagraphSubtitlesRequest,
+)
 
 
 def _iter_api_routes(routes: Sequence[object]) -> list[APIRoute]:
@@ -186,3 +193,14 @@ async def test_generate_all_subtitles_rejects_invalid_subtitle_model(
 
     assert response.status_code == 400
     assert "Unknown model key" in response.json()["detail"]
+
+
+def test_storyboard_request_models_reject_overlong_strings() -> None:
+    with pytest.raises(ValidationError):
+        ParagraphAudioRequest(tts_model="x" * 257)
+    with pytest.raises(ValidationError):
+        ParagraphSubtitlesRequest(subtitle_model="x" * 257)
+    with pytest.raises(ValidationError):
+        BulkParagraphAudioRequest(voice="x" * 257)
+    with pytest.raises(ValidationError):
+        BulkParagraphSubtitlesRequest(subtitle_model="x" * 257)

--- a/apps/api/tests/test_creator_visual_plan.py
+++ b/apps/api/tests/test_creator_visual_plan.py
@@ -1,6 +1,6 @@
 # pyright: reportMissingImports=false
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from datetime import datetime, timezone
 from typing import Any, Literal
 
@@ -8,7 +8,9 @@ import pytest
 from creator_domain.models import VisualScene
 from fastapi.routing import APIRoute
 from pydantic import BaseModel
+from pydantic import ValidationError
 from shorts_api.main import visual_plan_router
+from shorts_api.routes.creator_visual_plan import PatchSceneRequest
 
 
 class StubPipelineRun(BaseModel):
@@ -85,9 +87,17 @@ class StubVisualPlanService:
 
         if expected_version is not None and active.version != expected_version:
             from creator_service.visual_plan_service import VersionConflictError
+
             raise VersionConflictError(run_id, expected_version, active.version)
 
-        _patchable = {"prompt", "prompt_edited", "prompt_source", "style_tags", "mood", "composition"}
+        _patchable = {
+            "prompt",
+            "prompt_edited",
+            "prompt_source",
+            "style_tags",
+            "mood",
+            "composition",
+        }
         unknown = set(updates.keys()) - _patchable
         if unknown:
             raise ValueError(f"Cannot patch immutable/unknown fields: {sorted(unknown)}")
@@ -144,7 +154,9 @@ def _iter_api_routes(routes: Sequence[object]) -> list[APIRoute]:
 
 
 @pytest.fixture
-def stub_visual_plan_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunService, StubVisualPlanService]:
+def stub_visual_plan_services(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[StubRunService, StubVisualPlanService]]:
     from shorts_api.auth import CurrentUser, require_run_access
     from shorts_api.main import app
 
@@ -160,6 +172,7 @@ def stub_visual_plan_services(monkeypatch: pytest.MonkeyPatch) -> tuple[StubRunS
         run = run_svc.runs.get(run_id)
         if run is None:
             from fastapi import HTTPException
+
             raise HTTPException(status_code=404, detail="Run not found")
         return CurrentUser(user_id=1, workspace_id=1), run
 
@@ -596,3 +609,12 @@ async def test_patch_scene_with_expected_version_match(client, stub_visual_plan_
     body = response.json()
     assert body["version"] == 3
     assert body["scenes"][0]["prompt"] == "Updated"
+
+
+def test_patch_scene_request_rejects_overlong_fields() -> None:
+    with pytest.raises(ValidationError):
+        PatchSceneRequest(mood="x" * 257)
+    with pytest.raises(ValidationError):
+        PatchSceneRequest(composition="x" * 257)
+    with pytest.raises(ValidationError):
+        PatchSceneRequest(style_tags=["x" * 257])


### PR DESCRIPTION
## Summary
- Add path traversal protection to artifact download endpoint
- Change 403→404 in auth for anti-enumeration
- Add max_length constraints to string inputs in API routes
- Closes #487

## Tests
All 1108+ tests pass.