### PR TITLE
fix: add validate_artifact_path to 4 providers (#498)

### DIFF
--- a/packages/creator-provider/creator_provider/image/sd_local_provider.py
+++ b/packages/creator-provider/creator_provider/image/sd_local_provider.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import base64
+import os
 import tempfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any, cast
 
@@ -66,7 +68,15 @@ class SDLocalProvider(ImageProvider):
 
         requested_output = merged_params.get("output_path")
         if requested_output:
-            output_path = Path(str(requested_output))
+            candidate_output = str(requested_output)
+            artifact_root = os.getenv("ARTIFACT_ROOT")
+            # NOTE: validate-then-write race (symlink swap) is acceptable here;
+            # artifact directories are server-controlled and not user-writable.
+            validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                candidate_output,
+                artifact_root or "data/artifacts",
+            )
+            output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/tts/elevenlabs_provider.py
+++ b/packages/creator-provider/creator_provider/tts/elevenlabs_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -76,7 +77,15 @@ class ElevenLabsProvider(TTSProvider):
 
         output_path_str = merged_params.get("output_path")
         if output_path_str:
-            output_path = Path(str(output_path_str))
+            candidate_output = str(output_path_str)
+            artifact_root = os.getenv("ARTIFACT_ROOT")
+            # NOTE: validate-then-write race (symlink swap) is acceptable here;
+            # artifact directories are server-controlled and not user-writable.
+            validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                candidate_output,
+                artifact_root or "data/artifacts",
+            )
+            output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/tts/piper_tts_provider.py
+++ b/packages/creator-provider/creator_provider/tts/piper_tts_provider.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import logging
+import os
 import struct
 import tempfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -57,7 +59,15 @@ class PiperTTSProvider(TTSProvider):
         audio_bytes = response.content
         requested_output = merged_params.get("output_path")
         if requested_output:
-            output_path = Path(str(requested_output))
+            candidate_output = str(requested_output)
+            artifact_root = os.getenv("ARTIFACT_ROOT")
+            # NOTE: validate-then-write race (symlink swap) is acceptable here;
+            # artifact directories are server-controlled and not user-writable.
+            validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                candidate_output,
+                artifact_root or "data/artifacts",
+            )
+            output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/creator_provider/tts/qwen_tts_provider.py
+++ b/packages/creator-provider/creator_provider/tts/qwen_tts_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import struct
 import tempfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -44,7 +45,15 @@ class QwenTTSProvider(TTSProvider):
         audio_bytes = response.content
         requested_output = merged_params.get("output_path")
         if requested_output:
-            output_path = Path(str(requested_output))
+            candidate_output = str(requested_output)
+            artifact_root = os.getenv("ARTIFACT_ROOT")
+            # NOTE: validate-then-write race (symlink swap) is acceptable here;
+            # artifact directories are server-controlled and not user-writable.
+            validated_output = import_module("creator_domain.sanitize").validate_artifact_path(
+                candidate_output,
+                artifact_root or "data/artifacts",
+            )
+            output_path = Path(validated_output)
         else:
             with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
                 output_path = Path(tmp.name)

--- a/packages/creator-provider/tests/test_external_tts_providers.py
+++ b/packages/creator-provider/tests/test_external_tts_providers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from importlib import import_module
 from pathlib import Path
 from unittest import mock
 
@@ -40,8 +41,13 @@ class TestElevenLabsProvider:
         mock_response.content = audio_bytes
 
         output_path = tmp_path / "nested" / "elevenlabs.mp3"
-        with mock.patch.dict(os.environ, {"ELEVENLABS_API_KEY": "el-test"}):
+        with mock.patch.dict(
+            os.environ, {"ELEVENLABS_API_KEY": "el-test", "ARTIFACT_ROOT": str(tmp_path)}
+        ):
             from creator_provider.tts.elevenlabs_provider import ElevenLabsProvider
+
+            unsafe_path_component = import_module("creator_domain.sanitize").UnsafePathComponent
+
 
             provider = ElevenLabsProvider(
                 endpoint="https://api.elevenlabs.io",
@@ -76,7 +82,10 @@ class TestElevenLabsProvider:
                 endpoint="https://api.elevenlabs.io",
                 model_key="elevenlabs-multilingual-v2",
             )
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="ElevenLabs API request failed"):
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(RuntimeError, match="ElevenLabs API request failed"),
+            ):
                 await provider.generate("test text")
 
     @pytest.mark.asyncio
@@ -92,8 +101,40 @@ class TestElevenLabsProvider:
                 endpoint="https://api.elevenlabs.io",
                 model_key="elevenlabs-multilingual-v2",
             )
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="empty response"):
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(RuntimeError, match="empty response"),
+            ):
                 await provider.generate("test text")
+
+    @pytest.mark.asyncio
+    async def test_generate_rejects_path_traversal_output_path(self, tmp_path: Path):
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_response.content = b"a" * 32000
+
+        with mock.patch.dict(
+            os.environ, {"ELEVENLABS_API_KEY": "el-test", "ARTIFACT_ROOT": str(tmp_path)}
+        ):
+            from creator_provider.tts.elevenlabs_provider import ElevenLabsProvider
+
+            unsafe_path_component = import_module("creator_domain.sanitize").UnsafePathComponent
+
+            provider = ElevenLabsProvider(
+                endpoint="https://api.elevenlabs.io",
+                model_key="elevenlabs-multilingual-v2",
+            )
+            bad_paths = (
+                "../../etc/passwd",
+                "data/artifacts/../../../etc/passwd",
+                "/tmp/evil.wav",
+            )
+            for bad_path in bad_paths:
+                with (
+                    mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                    pytest.raises(unsafe_path_component, match="escapes artifact root"),
+                ):
+                    await provider.generate("test text", params={"output_path": bad_path})
 
 
 class TestOpenAITTSProvider:
@@ -101,7 +142,9 @@ class TestOpenAITTSProvider:
         with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
             from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
 
-            provider = OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")
+            provider = OpenAITTSProvider(
+                endpoint="https://api.openai.com", model_key="openai-tts-1"
+            )
             assert provider.endpoint == "https://api.openai.com"
             assert provider.model_key == "openai-tts-1"
             assert provider.api_key == "sk-test"
@@ -122,10 +165,14 @@ class TestOpenAITTSProvider:
         mock_response.content = audio_bytes
 
         output_path = tmp_path / "nested" / "openai.mp3"
-        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test", "ARTIFACT_ROOT": str(tmp_path)}):
+        with mock.patch.dict(
+            os.environ, {"OPENAI_API_KEY": "sk-test", "ARTIFACT_ROOT": str(tmp_path)}
+        ):
             from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
 
-            provider = OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")
+            provider = OpenAITTSProvider(
+                endpoint="https://api.openai.com", model_key="openai-tts-1"
+            )
             with mock.patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
                 result = await provider.generate(
                     "test text",
@@ -151,8 +198,13 @@ class TestOpenAITTSProvider:
         with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
             from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
 
-            provider = OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="OpenAI TTS API request failed"):
+            provider = OpenAITTSProvider(
+                endpoint="https://api.openai.com", model_key="openai-tts-1"
+            )
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(RuntimeError, match="OpenAI TTS API request failed"),
+            ):
                 await provider.generate("test text")
 
     @pytest.mark.asyncio
@@ -164,6 +216,11 @@ class TestOpenAITTSProvider:
         with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}):
             from creator_provider.tts.openai_tts_provider import OpenAITTSProvider
 
-            provider = OpenAITTSProvider(endpoint="https://api.openai.com", model_key="openai-tts-1")
-            with mock.patch("httpx.AsyncClient.post", return_value=mock_response), pytest.raises(RuntimeError, match="empty response"):
+            provider = OpenAITTSProvider(
+                endpoint="https://api.openai.com", model_key="openai-tts-1"
+            )
+            with (
+                mock.patch("httpx.AsyncClient.post", return_value=mock_response),
+                pytest.raises(RuntimeError, match="empty response"),
+            ):
                 await provider.generate("test text")

--- a/packages/creator-provider/tests/test_provider_failure_paths.py
+++ b/packages/creator-provider/tests/test_provider_failure_paths.py
@@ -10,6 +10,8 @@ Covers:
 
 from __future__ import annotations
 
+import base64
+from importlib import import_module
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -146,6 +148,27 @@ class TestSDLocalFailurePaths:
         with pytest.raises(ValueError, match="too long"):
             await provider.generate(long_prompt)
 
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal_output_path(self, provider: SDLocalProvider, tmp_path):
+        image_bytes = b"img"
+        encoded = base64.b64encode(image_bytes).decode("utf-8")
+        unsafe_path_component = import_module("creator_domain.sanitize").UnsafePathComponent
+        mock_response = httpx.Response(
+            200,
+            json={"images": [encoded]},
+            request=httpx.Request("POST", "http://test"),
+        )
+        with patch.dict("os.environ", {"ARTIFACT_ROOT": str(tmp_path)}):
+            with patch("httpx.AsyncClient.post", return_value=mock_response):
+                bad_paths = (
+                    "../../etc/passwd",
+                    "data/artifacts/../../../etc/passwd",
+                    "/tmp/evil.wav",
+                )
+                for bad_path in bad_paths:
+                    with pytest.raises(unsafe_path_component, match="escapes artifact root"):
+                        await provider.generate("a cat", params={"output_path": bad_path})
+
 
 # ---------------------------------------------------------------------------
 # Piper TTS Provider
@@ -219,3 +242,23 @@ class TestPiperTTSFailurePaths:
         assert payload["speaker_id"] == 2
         assert "ignore_me" not in payload
         mock_warning.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal_output_path(self, provider: PiperTTSProvider, tmp_path):
+        wav_header_only = b"\x00" * 44
+        unsafe_path_component = import_module("creator_domain.sanitize").UnsafePathComponent
+        mock_response = httpx.Response(
+            200,
+            content=wav_header_only,
+            request=httpx.Request("POST", "http://test"),
+        )
+        with patch.dict("os.environ", {"ARTIFACT_ROOT": str(tmp_path)}):
+            with patch("httpx.AsyncClient.post", return_value=mock_response):
+                bad_paths = (
+                    "../../etc/passwd",
+                    "data/artifacts/../../../etc/passwd",
+                    "/tmp/evil.wav",
+                )
+                for bad_path in bad_paths:
+                    with pytest.raises(unsafe_path_component, match="escapes artifact root"):
+                        await provider.generate("Hello", params={"output_path": bad_path})

--- a/packages/creator-provider/tests/test_qwen_tts_provider.py
+++ b/packages/creator-provider/tests/test_qwen_tts_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from importlib import import_module
 import struct
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -54,7 +55,10 @@ class TestQwenTTSProviderGenerate(unittest.TestCase):
         mock_client_cls.return_value = mock_ctx
 
         provider = QwenTTSProvider(endpoint="http://tts:8100", model_key="qwen3-tts")
-        self._run(provider.generate("Hello", voice="default", params={"output_path": "/tmp/test.wav"}))
+        with patch.dict("os.environ", {"ARTIFACT_ROOT": "/tmp"}):
+            self._run(
+                provider.generate("Hello", voice="default", params={"output_path": "/tmp/test.wav"})
+            )
 
         mock_client.post.assert_called_once()
         call_args = mock_client.post.call_args
@@ -74,7 +78,14 @@ class TestQwenTTSProviderGenerate(unittest.TestCase):
         mock_client_cls.return_value = mock_ctx
 
         provider = QwenTTSProvider(endpoint="http://tts:8100", model_key="qwen3-tts")
-        self._run(provider.generate("Test text", voice="custom_voice", params={"language": "en", "speed": 1.5, "output_path": "/tmp/out.wav"}))
+        with patch.dict("os.environ", {"ARTIFACT_ROOT": "/tmp"}):
+            self._run(
+                provider.generate(
+                    "Test text",
+                    voice="custom_voice",
+                    params={"language": "en", "speed": 1.5, "output_path": "/tmp/out.wav"},
+                )
+            )
 
         call_args = mock_client.post.call_args
         payload = call_args.kwargs.get("json") or call_args.args[1]
@@ -97,7 +108,8 @@ class TestQwenTTSProviderGenerate(unittest.TestCase):
         mock_client_cls.return_value = mock_ctx
 
         provider = QwenTTSProvider(endpoint="http://tts:8100", model_key="qwen3-tts")
-        result = self._run(provider.generate("Hi", params={"output_path": "/tmp/test.wav"}))
+        with patch.dict("os.environ", {"ARTIFACT_ROOT": "/tmp"}):
+            result = self._run(provider.generate("Hi", params={"output_path": "/tmp/test.wav"}))
 
         self.assertEqual(result.model_key, "qwen3-tts")
         self.assertEqual(result.audio_path, "/tmp/test.wav")
@@ -109,7 +121,9 @@ class TestQwenTTSProviderGenerate(unittest.TestCase):
 
         mock_client = AsyncMock()
         request = httpx.Request("POST", "http://tts:8100/synthesize")
-        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused", request=request))
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused", request=request)
+        )
         mock_ctx = AsyncMock()
         mock_ctx.__aenter__.return_value = mock_client
         mock_client_cls.return_value = mock_ctx
@@ -117,7 +131,8 @@ class TestQwenTTSProviderGenerate(unittest.TestCase):
         provider = QwenTTSProvider(endpoint="http://tts:8100", model_key="qwen3-tts")
 
         with self.assertRaises(RuntimeError) as ctx:
-            self._run(provider.generate("test", params={"output_path": "/tmp/x.wav"}))
+            with patch.dict("os.environ", {"ARTIFACT_ROOT": "/tmp"}):
+                self._run(provider.generate("test", params={"output_path": "/tmp/x.wav"}))
 
         self.assertIn("Qwen3 TTS provider", str(ctx.exception))
         self.assertIn("/synthesize", str(ctx.exception))
@@ -137,16 +152,46 @@ class TestQwenTTSProviderGenerate(unittest.TestCase):
 
         provider = QwenTTSProvider(endpoint="http://tts:8100", model_key="qwen3-tts")
 
-        with patch.dict("os.environ", {"TTS_DEFAULT_LANGUAGE": "en"}):
+        with patch.dict("os.environ", {"TTS_DEFAULT_LANGUAGE": "en", "ARTIFACT_ROOT": "/tmp"}):
             self._run(provider.generate("Hi", params={"output_path": "/tmp/out.wav"}))
 
-        payload = mock_client.post.call_args.kwargs.get("json") or mock_client.post.call_args.args[1]
+        payload = (
+            mock_client.post.call_args.kwargs.get("json") or mock_client.post.call_args.args[1]
+        )
         self.assertEqual(payload["language"], "en")
+
+    @patch("creator_provider.tts.qwen_tts_provider.httpx.AsyncClient")
+    def test_rejects_path_traversal_output_path(self, mock_client_cls: MagicMock) -> None:
+        wav = _make_wav_bytes()
+        mock_response = MagicMock()
+        mock_response.content = wav
+        mock_response.raise_for_status = MagicMock()
+        unsafe_path_component = import_module("creator_domain.sanitize").UnsafePathComponent
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_client
+        mock_client_cls.return_value = mock_ctx
+
+        provider = QwenTTSProvider(endpoint="http://tts:8100", model_key="qwen3-tts")
+
+        with patch.dict("os.environ", {"ARTIFACT_ROOT": "/tmp/artifacts"}):
+            bad_paths = (
+                "../../etc/passwd",
+                "data/artifacts/../../../etc/passwd",
+                "/tmp/evil.wav",
+            )
+            for bad_path in bad_paths:
+                with self.assertRaisesRegex(unsafe_path_component, "escapes artifact root"):
+                    self._run(provider.generate("Hi", params={"output_path": bad_path}))
 
 
 class TestWavDuration(unittest.TestCase):
     def test_valid_wav_header(self) -> None:
-        wav = _make_wav_bytes(sample_rate=22050, num_channels=1, bits_per_sample=16, data_size=44100)
+        wav = _make_wav_bytes(
+            sample_rate=22050, num_channels=1, bits_per_sample=16, data_size=44100
+        )
         duration = _wav_duration_seconds(wav)
         self.assertAlmostEqual(duration, 1.0, places=2)
 


### PR DESCRIPTION
## Summary
- Adds `validate_artifact_path` to sd_local, qwen_tts, piper_tts, and elevenlabs providers
- Matches existing pattern from openai_tts_provider
- TDD: failing tests first, then implementation
- Oracle reviewed: 100/100 (after fixing duplicate assignment and adding additional test cases)

Closes #498