### PR TITLE
fix: remove skip_stage_guard and use get_active_draft in paragraph workers (#497)

### DIFF
--- a/apps/worker-orchestrator/tasks/generate_paragraph_audio.py
+++ b/apps/worker-orchestrator/tasks/generate_paragraph_audio.py
@@ -24,6 +24,7 @@ from creator_provider.registry import ProviderRegistry
 from creator_service.audio_service import audio_service as _audio_service
 from creator_service.cost_config import COST_PARAGRAPH_AUDIO
 from creator_service.run_service import run_service as _run_service
+from creator_service.script_service import script_service as _script_service
 from creator_service.telemetry import trace_task
 from creator_service.usage_service import record_provider_call
 from tasks import task_runner as _task_runner
@@ -78,28 +79,19 @@ def generate_paragraph_audio(
             {RunStage.AUDIO_GENERATING.value, RunStage.SUBTITLE_GENERATING.value}
         ),
         success_stage=None,
-        # Paragraph workers are dispatched by the parent audio pipeline task after
-        # stage validation, so these per-section executions intentionally skip a
-        # second stage guard to avoid false negatives during fan-out.
-        skip_stage_guard=True,
     )
 
     async def execute(ctx: TaskContext) -> TaskResult:
-        run = await _run_service.storage.get_run(run_id)
-        if run is None:
-            raise ValueError(f"Run {run_id} not found")
-        script_data = run.get("script_data") or {}
-        sections = script_data.get("sections") if isinstance(script_data, dict) else []
+        draft = await _script_service.get_active_draft(run_id)
+        if draft is None:
+            raise ValueError(f"No script draft found for run {run_id}")
+
+        sections = draft.structured_script or []
         section_text: str | None = None
-        if isinstance(sections, list):
-            for section in sections:
-                if not isinstance(section, dict):
-                    continue
-                if section.get("section_id") == section_id:
-                    raw_text = section.get("text")
-                    if isinstance(raw_text, str):
-                        section_text = raw_text
-                    break
+        for section in sections:
+            if section.section_id == section_id:
+                section_text = (section.display_text or section.text or "").strip()
+                break
         if section_text is None:
             raise ValueError(f"Section '{section_id}' not found for run {run_id}")
 

--- a/apps/worker-orchestrator/tasks/generate_paragraph_subtitles.py
+++ b/apps/worker-orchestrator/tasks/generate_paragraph_subtitles.py
@@ -74,10 +74,6 @@ def generate_paragraph_subtitles(
             {RunStage.AUDIO_GENERATING.value, RunStage.SUBTITLE_GENERATING.value}
         ),
         success_stage=None,
-        # Paragraph workers are dispatched by the parent subtitle pipeline task
-        # after stage validation, so these per-section executions intentionally
-        # skip a second stage guard during fan-out.
-        skip_stage_guard=True,
     )
 
     async def execute(ctx: TaskContext) -> TaskResult:

--- a/apps/worker-orchestrator/tests/test_generate_paragraph_audio.py
+++ b/apps/worker-orchestrator/tests/test_generate_paragraph_audio.py
@@ -81,6 +81,29 @@ class FakeRunService:
         self.storage = FakeRunStorage(run_row)
 
 
+@dataclass
+class FakeSection:
+    section_id: str
+    text: str
+    display_text: str | None = None
+
+
+@dataclass
+class FakeDraft:
+    markdown_content: str | None = None
+    structured_script: list[FakeSection] | None = None
+
+
+class FakeScriptService:
+    def __init__(self, draft: FakeDraft | None) -> None:
+        self.draft = draft
+        self.calls: list[int] = []
+
+    async def get_active_draft(self, run_id: int) -> FakeDraft | None:
+        self.calls.append(run_id)
+        return self.draft
+
+
 class FakeRegistry:
     def __init__(self, entry: FakeEntry, provider: FakeProvider) -> None:
         self.entry = entry
@@ -124,14 +147,14 @@ def test_generate_paragraph_audio_success(monkeypatch: pytest.MonkeyPatch) -> No
         "_run_service",
         FakeRunService(
             {
-                "script_data": {
-                    "sections": [
-                        {"section_id": "hook-1", "text": "Hello paragraph"},
-                    ]
-                }
+                "current_stage": "AUDIO_GENERATING",
             }
         ),
     )
+    script_service = FakeScriptService(
+        FakeDraft(structured_script=[FakeSection(section_id="hook-1", text="Hello paragraph")])
+    )
+    monkeypatch.setattr(module, "_script_service", script_service)
     monkeypatch.setattr(module, "_audio_service", audio_service)
 
     result = _invoke_task(
@@ -173,6 +196,7 @@ def test_generate_paragraph_audio_success(monkeypatch: pytest.MonkeyPatch) -> No
             "voice": "en_US-lessac-medium",
         }
     ]
+    assert script_service.calls == [101]
 
 
 def test_generate_paragraph_audio_with_gpu_lock(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -185,9 +209,15 @@ def test_generate_paragraph_audio_with_gpu_lock(monkeypatch: pytest.MonkeyPatch)
 
     lock_calls: list[str] = []
     release_calls: list[str] = []
-    monkeypatch.setattr(module, "acquire_gpu_lock", lambda _, task_id: (lock_calls.append(task_id) or f"{task_id}:fake-token"))
     monkeypatch.setattr(
-        module, "release_gpu_lock", lambda _, token: release_calls.append(token.split(':')[0]) or True
+        module,
+        "acquire_gpu_lock",
+        lambda _, task_id: (lock_calls.append(task_id) or f"{task_id}:fake-token"),
+    )
+    monkeypatch.setattr(
+        module,
+        "release_gpu_lock",
+        lambda _, token: release_calls.append(token.split(":")[0]) or True,
     )
 
     audio_service = FakeAudioService(artifact_id=61)
@@ -196,12 +226,15 @@ def test_generate_paragraph_audio_with_gpu_lock(monkeypatch: pytest.MonkeyPatch)
         "_run_service",
         FakeRunService(
             {
-                "script_data": {
-                    "sections": [
-                        {"section_id": "hook-2", "text": "Lock paragraph"},
-                    ]
-                }
+                "current_stage": "AUDIO_GENERATING",
             }
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_script_service",
+        FakeScriptService(
+            FakeDraft(structured_script=[FakeSection(section_id="hook-2", text="Lock paragraph")])
         ),
     )
     monkeypatch.setattr(module, "_audio_service", audio_service)
@@ -225,9 +258,15 @@ def test_generate_paragraph_audio_provider_failure(monkeypatch: pytest.MonkeyPat
 
     lock_calls: list[str] = []
     release_calls: list[str] = []
-    monkeypatch.setattr(module, "acquire_gpu_lock", lambda _, task_id: (lock_calls.append(task_id) or f"{task_id}:fake-token"))
     monkeypatch.setattr(
-        module, "release_gpu_lock", lambda _, token: release_calls.append(token.split(':')[0]) or True
+        module,
+        "acquire_gpu_lock",
+        lambda _, task_id: (lock_calls.append(task_id) or f"{task_id}:fake-token"),
+    )
+    monkeypatch.setattr(
+        module,
+        "release_gpu_lock",
+        lambda _, token: release_calls.append(token.split(":")[0]) or True,
     )
 
     audio_service = FakeAudioService()
@@ -236,12 +275,17 @@ def test_generate_paragraph_audio_provider_failure(monkeypatch: pytest.MonkeyPat
         "_run_service",
         FakeRunService(
             {
-                "script_data": {
-                    "sections": [
-                        {"section_id": "hook-3", "text": "Failure paragraph"},
-                    ]
-                }
+                "current_stage": "AUDIO_GENERATING",
             }
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_script_service",
+        FakeScriptService(
+            FakeDraft(
+                structured_script=[FakeSection(section_id="hook-3", text="Failure paragraph")]
+            )
         ),
     )
     monkeypatch.setattr(module, "_audio_service", audio_service)
@@ -265,12 +309,15 @@ def test_generate_paragraph_audio_sanitizes_section_id(monkeypatch: pytest.Monke
         "_run_service",
         FakeRunService(
             {
-                "script_data": {
-                    "sections": [
-                        {"section_id": "hook:1", "text": "Sanitize me"},
-                    ]
-                }
+                "current_stage": "AUDIO_GENERATING",
             }
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_script_service",
+        FakeScriptService(
+            FakeDraft(structured_script=[FakeSection(section_id="hook:1", text="Sanitize me")])
         ),
     )
     monkeypatch.setattr(module, "_audio_service", audio_service)
@@ -291,7 +338,12 @@ def test_generate_paragraph_audio_section_not_found(monkeypatch: pytest.MonkeyPa
     entry = FakeEntry(requires_gpu=False)
     _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
 
-    monkeypatch.setattr(module, "_run_service", FakeRunService({"script_data": {"sections": []}}))
+    monkeypatch.setattr(
+        module, "_run_service", FakeRunService({"current_stage": "AUDIO_GENERATING"})
+    )
+    monkeypatch.setattr(
+        module, "_script_service", FakeScriptService(FakeDraft(structured_script=[]))
+    )
     monkeypatch.setattr(module, "_audio_service", FakeAudioService())
 
     with pytest.raises(ValueError, match="Section 'missing' not found"):
@@ -300,7 +352,7 @@ def test_generate_paragraph_audio_section_not_found(monkeypatch: pytest.MonkeyPa
     assert provider.calls == []
 
 
-def test_generate_paragraph_audio_works_even_when_run_stage_is_not_audio(
+def test_generate_paragraph_audio_rejects_when_run_stage_is_not_audio(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = FakeProvider()
@@ -314,17 +366,57 @@ def test_generate_paragraph_audio_works_even_when_run_stage_is_not_audio(
         FakeRunService(
             {
                 "current_stage": "SCRIPT_REVIEW",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_script_service",
+        FakeScriptService(
+            FakeDraft(structured_script=[FakeSection(section_id="hook-9", text="Nested paragraph")])
+        ),
+    )
+    monkeypatch.setattr(module, "_audio_service", audio_service)
+
+    with pytest.raises(
+        module._task_runner.StageGuardError, match="Run 109 is in stage SCRIPT_REVIEW"
+    ):
+        _invoke_task(run_id=109, section_id="hook-9")
+
+
+def test_generate_paragraph_audio_uses_active_draft_not_run_script_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = FakeProvider()
+    entry = FakeEntry(requires_gpu=False)
+    _patch_registry(monkeypatch, FakeRegistry(entry=entry, provider=provider))
+
+    script_service = FakeScriptService(
+        FakeDraft(
+            structured_script=[
+                FakeSection(section_id="hook-10", text="Text from active draft"),
+            ]
+        )
+    )
+    monkeypatch.setattr(module, "_script_service", script_service)
+    monkeypatch.setattr(
+        module,
+        "_run_service",
+        FakeRunService(
+            {
+                "current_stage": "AUDIO_GENERATING",
                 "script_data": {
                     "sections": [
-                        {"section_id": "hook-9", "text": "Nested paragraph"},
+                        {"section_id": "hook-10", "text": "Text from run.script_data"},
                     ]
                 },
             }
         ),
     )
-    monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(module, "_audio_service", FakeAudioService(artifact_id=88))
 
-    result = _invoke_task(run_id=109, section_id="hook-9")
+    result = _invoke_task(run_id=110, section_id="hook-10")
 
     assert result["status"] == "success"
-    assert result["audio_artifact_id"] == 79
+    assert provider.calls[0][0] == "Text from active draft"
+    assert script_service.calls == [110]

--- a/apps/worker-orchestrator/tests/test_generate_paragraph_subtitles.py
+++ b/apps/worker-orchestrator/tests/test_generate_paragraph_subtitles.py
@@ -74,6 +74,23 @@ class FakeAudioService:
         return self.artifact
 
 
+class FakeRunStorage:
+    def __init__(self, run_row: dict[str, Any] | None) -> None:
+        self.run_row = run_row
+
+    async def get_run(self, run_id: int) -> dict[str, Any] | None:
+        if self.run_row is None:
+            return None
+        row = dict(self.run_row)
+        row["id"] = run_id
+        return row
+
+
+class FakeRunService:
+    def __init__(self, run_row: dict[str, Any] | None) -> None:
+        self.storage = FakeRunStorage(run_row)
+
+
 class FakeRegistry:
     def __init__(self, entry: FakeEntry, provider: FakeProvider) -> None:
         self.entry = entry
@@ -117,6 +134,9 @@ def test_generate_paragraph_subtitles_success(monkeypatch: pytest.MonkeyPatch) -
     )
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
     monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(
+        module, "_run_service", FakeRunService({"current_stage": "AUDIO_GENERATING"})
+    )
     monkeypatch.setattr(module, "validate_artifact_path", lambda path, _root: path)
     monkeypatch.setattr(module.os.path, "exists", lambda _: True)
 
@@ -170,6 +190,9 @@ def test_generate_paragraph_subtitles_audio_not_found(monkeypatch: pytest.Monkey
     audio_service = FakeAudioService(artifact=None)
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
     monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(
+        module, "_run_service", FakeRunService({"current_stage": "AUDIO_GENERATING"})
+    )
 
     with pytest.raises(RuntimeError, match="Audio file not found"):
         _invoke_task(run_id=102, section_id="hook-2")
@@ -188,15 +211,24 @@ def test_generate_paragraph_subtitles_with_gpu_lock(monkeypatch: pytest.MonkeyPa
 
     lock_calls: list[str] = []
     release_calls: list[str] = []
-    monkeypatch.setattr(module, "acquire_gpu_lock", lambda _, task_id: (lock_calls.append(task_id) or f"{task_id}:fake-token"))
     monkeypatch.setattr(
-        module, "release_gpu_lock", lambda _, token: release_calls.append(token.split(':')[0]) or True
+        module,
+        "acquire_gpu_lock",
+        lambda _, task_id: (lock_calls.append(task_id) or f"{task_id}:fake-token"),
+    )
+    monkeypatch.setattr(
+        module,
+        "release_gpu_lock",
+        lambda _, token: release_calls.append(token.split(":")[0]) or True,
     )
 
     subtitle_service = FakeSubtitleService(artifact_id=61)
     audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="audio.wav"))
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
     monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(
+        module, "_run_service", FakeRunService({"current_stage": "AUDIO_GENERATING"})
+    )
     monkeypatch.setattr(module, "validate_artifact_path", lambda path, _root: path)
     monkeypatch.setattr(module.os.path, "exists", lambda _: True)
 
@@ -220,6 +252,9 @@ def test_generate_paragraph_subtitles_provider_failure(
     audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="audio.wav"))
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
     monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(
+        module, "_run_service", FakeRunService({"current_stage": "AUDIO_GENERATING"})
+    )
     monkeypatch.setattr(module, "validate_artifact_path", lambda path, _root: path)
     monkeypatch.setattr(module.os.path, "exists", lambda _: True)
 
@@ -246,6 +281,9 @@ def test_generate_paragraph_subtitles_rejects_audio_path_outside_artifact_root(
     audio_service = FakeAudioService(artifact=FakeAudioArtifact(path="/etc/passwd"))
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
     monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(
+        module, "_run_service", FakeRunService({"current_stage": "AUDIO_GENERATING"})
+    )
 
     with pytest.raises(ValueError, match="outside artifact root"):
         _invoke_task(run_id=105, section_id="hook-5")
@@ -253,7 +291,7 @@ def test_generate_paragraph_subtitles_rejects_audio_path_outside_artifact_root(
     assert subtitle_service.calls == []
 
 
-def test_generate_paragraph_subtitles_works_even_when_run_stage_is_not_subtitle(
+def test_generate_paragraph_subtitles_rejects_when_run_stage_is_not_subtitle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = FakeProvider()
@@ -266,10 +304,11 @@ def test_generate_paragraph_subtitles_works_even_when_run_stage_is_not_subtitle(
     )
     monkeypatch.setattr(module, "_subtitle_service", subtitle_service)
     monkeypatch.setattr(module, "_audio_service", audio_service)
+    monkeypatch.setattr(module, "_run_service", FakeRunService({"current_stage": "SCRIPT_REVIEW"}))
     monkeypatch.setattr(module, "validate_artifact_path", lambda path, _root: path)
     monkeypatch.setattr(module.os.path, "exists", lambda _: True)
 
-    result = _invoke_task(run_id=111, section_id="hook-7")
-
-    assert result["status"] == "success"
-    assert result["subtitle_artifact_id"] == 44
+    with pytest.raises(
+        module._task_runner.StageGuardError, match="Run 111 is in stage SCRIPT_REVIEW"
+    ):
+        _invoke_task(run_id=111, section_id="hook-7")

--- a/apps/worker-orchestrator/tests/test_provider_exception_passthrough.py
+++ b/apps/worker-orchestrator/tests/test_provider_exception_passthrough.py
@@ -4,6 +4,8 @@ Each task module must preserve these provider exceptions without mapping them to
 a generic ProviderError, allowing Celery's retry mechanism to handle them.
 """
 
+# pyright: reportCallIssue=false, reportMissingImports=false
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -26,7 +28,6 @@ from tasks import (
 
 async def _async_value(val: Any) -> Any:
     return val
-
 
 
 # ============================================================================
@@ -83,7 +84,12 @@ class _FakeRegistry:
 class _FakeStorage:
     """Minimal storage that allows tasks to proceed."""
 
-    def __init__(self, run_id: int = 1, stage: str = "VISUAL_ASSET_REVIEW", extra: dict[str, object] | None = None) -> None:
+    def __init__(
+        self,
+        run_id: int = 1,
+        stage: str = "VISUAL_ASSET_REVIEW",
+        extra: dict[str, object] | None = None,
+    ) -> None:
         self._run_id = run_id
         self._stage = stage
         self._extra = extra or {}
@@ -105,7 +111,9 @@ class _FakeStorage:
         return {"id": run_id, **updates}
 
 
-def _make_storage(run_id: int = 1, stage: str = "VISUAL_ASSET_REVIEW", extra: dict[str, object] | None = None) -> _FakeStorage:
+def _make_storage(
+    run_id: int = 1, stage: str = "VISUAL_ASSET_REVIEW", extra: dict[str, object] | None = None
+) -> _FakeStorage:
     return _FakeStorage(run_id, stage, extra)
 
 
@@ -245,8 +253,14 @@ def test_generate_paragraph_audio_preserves_provider_timeout(
     )
 
     audio_service = _FakeAudioServiceForParagraph(artifact_id=1)
-    storage = _make_storage(run_id=1, stage="AUDIO_GENERATING", extra={"script_data": {"sections": [{"section_id": "s1", "text": "Test"}]}})
+    script_service = _FakeScriptService(
+        draft=_FakeScriptDraft(
+            structured_script=[SimpleNamespace(section_id="s1", text="Test", display_text=None)]
+        )
+    )
+    storage = _make_storage(run_id=1, stage="AUDIO_GENERATING")
 
+    monkeypatch.setattr(generate_paragraph_audio_module, "_script_service", script_service)
     monkeypatch.setattr(generate_paragraph_audio_module, "_audio_service", audio_service)
     monkeypatch.setattr(
         generate_paragraph_audio_module, "_run_service", SimpleNamespace(storage=storage)
@@ -266,8 +280,14 @@ def test_generate_paragraph_audio_preserves_rate_limit(monkeypatch: pytest.Monke
     )
 
     audio_service = _FakeAudioServiceForParagraph(artifact_id=1)
-    storage = _make_storage(run_id=1, stage="AUDIO_GENERATING", extra={"script_data": {"sections": [{"section_id": "s1", "text": "Test"}]}})
+    script_service = _FakeScriptService(
+        draft=_FakeScriptDraft(
+            structured_script=[SimpleNamespace(section_id="s1", text="Test", display_text=None)]
+        )
+    )
+    storage = _make_storage(run_id=1, stage="AUDIO_GENERATING")
 
+    monkeypatch.setattr(generate_paragraph_audio_module, "_script_service", script_service)
     monkeypatch.setattr(generate_paragraph_audio_module, "_audio_service", audio_service)
     monkeypatch.setattr(
         generate_paragraph_audio_module, "_run_service", SimpleNamespace(storage=storage)
@@ -334,9 +354,15 @@ def test_generate_visual_plan_preserves_provider_timeout(monkeypatch: pytest.Mon
 
     draft = _FakeScriptDraft(markdown_content="Test script content")
     storage = _make_storage(run_id=1, stage="VISUAL_PLAN_GENERATING")
-    monkeypatch.setattr(generate_visual_plan_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_visual_plan_module, "_script_service", _FakeScriptService(draft=draft))
-    monkeypatch.setattr(generate_visual_plan_module, "_visual_plan_service", _FakeVisualPlanService())
+    monkeypatch.setattr(
+        generate_visual_plan_module, "_run_service", SimpleNamespace(storage=storage)
+    )
+    monkeypatch.setattr(
+        generate_visual_plan_module, "_script_service", _FakeScriptService(draft=draft)
+    )
+    monkeypatch.setattr(
+        generate_visual_plan_module, "_visual_plan_service", _FakeVisualPlanService()
+    )
 
     task = generate_visual_plan_module.generate_visual_plan
     run_callable = getattr(task, "run", task)
@@ -351,9 +377,15 @@ def test_generate_visual_plan_preserves_rate_limit(monkeypatch: pytest.MonkeyPat
 
     draft = _FakeScriptDraft(markdown_content="Test script content")
     storage = _make_storage(run_id=1, stage="VISUAL_PLAN_GENERATING")
-    monkeypatch.setattr(generate_visual_plan_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_visual_plan_module, "_script_service", _FakeScriptService(draft=draft))
-    monkeypatch.setattr(generate_visual_plan_module, "_visual_plan_service", _FakeVisualPlanService())
+    monkeypatch.setattr(
+        generate_visual_plan_module, "_run_service", SimpleNamespace(storage=storage)
+    )
+    monkeypatch.setattr(
+        generate_visual_plan_module, "_script_service", _FakeScriptService(draft=draft)
+    )
+    monkeypatch.setattr(
+        generate_visual_plan_module, "_visual_plan_service", _FakeVisualPlanService()
+    )
 
     task = generate_visual_plan_module.generate_visual_plan
     run_callable = getattr(task, "run", task)
@@ -395,8 +427,12 @@ def test_generate_scene_image_propagates_provider_timeout(monkeypatch: pytest.Mo
     _patch_registry(monkeypatch, generate_scene_image_module, _FakeRegistry(_FakeEntry(), provider))
 
     storage = _make_storage(run_id=1, stage="VISUAL_ASSET_GENERATING")
-    monkeypatch.setattr(generate_scene_image_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_scene_image_module, "_visual_plan_service", _FakeVisualPlanServiceWithPlan())
+    monkeypatch.setattr(
+        generate_scene_image_module, "_run_service", SimpleNamespace(storage=storage)
+    )
+    monkeypatch.setattr(
+        generate_scene_image_module, "_visual_plan_service", _FakeVisualPlanServiceWithPlan()
+    )
 
     task = generate_scene_image_module.generate_scene_image
     run_callable = getattr(task, "run", task)
@@ -404,14 +440,19 @@ def test_generate_scene_image_propagates_provider_timeout(monkeypatch: pytest.Mo
     with pytest.raises(ProviderTimeoutError, match="timeout"):
         run_callable(run_id=1, scene_id="scene-1")
 
+
 def test_generate_scene_image_propagates_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     """generate_scene_image re-raises RateLimitError for Celery retry."""
     provider = _FakeProvider(error=RateLimitError("rate limited"))
     _patch_registry(monkeypatch, generate_scene_image_module, _FakeRegistry(_FakeEntry(), provider))
 
     storage = _make_storage(run_id=1, stage="VISUAL_ASSET_GENERATING")
-    monkeypatch.setattr(generate_scene_image_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_scene_image_module, "_visual_plan_service", _FakeVisualPlanServiceWithPlan())
+    monkeypatch.setattr(
+        generate_scene_image_module, "_run_service", SimpleNamespace(storage=storage)
+    )
+    monkeypatch.setattr(
+        generate_scene_image_module, "_visual_plan_service", _FakeVisualPlanServiceWithPlan()
+    )
 
     task = generate_scene_image_module.generate_scene_image
     run_callable = getattr(task, "run", task)
@@ -445,8 +486,12 @@ def test_generate_subtitles_preserves_provider_timeout(monkeypatch: pytest.Monke
     draft = _FakeScriptDraft(markdown_content="Test script")
     storage = _make_storage(run_id=1, stage="SUBTITLE_GENERATING")
     monkeypatch.setattr(generate_subtitles_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_subtitles_module, "_script_service", _FakeScriptService(draft=draft))
-    monkeypatch.setattr(generate_subtitles_module, "_audio_service", _FakeAudioServiceForSubtitles())
+    monkeypatch.setattr(
+        generate_subtitles_module, "_script_service", _FakeScriptService(draft=draft)
+    )
+    monkeypatch.setattr(
+        generate_subtitles_module, "_audio_service", _FakeAudioServiceForSubtitles()
+    )
     monkeypatch.setattr(generate_subtitles_module, "validate_artifact_path", lambda p, r: p)
 
     task = generate_subtitles_module.generate_subtitles
@@ -463,8 +508,12 @@ def test_generate_subtitles_preserves_rate_limit(monkeypatch: pytest.MonkeyPatch
     draft = _FakeScriptDraft(markdown_content="Test script")
     storage = _make_storage(run_id=1, stage="SUBTITLE_GENERATING")
     monkeypatch.setattr(generate_subtitles_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_subtitles_module, "_script_service", _FakeScriptService(draft=draft))
-    monkeypatch.setattr(generate_subtitles_module, "_audio_service", _FakeAudioServiceForSubtitles())
+    monkeypatch.setattr(
+        generate_subtitles_module, "_script_service", _FakeScriptService(draft=draft)
+    )
+    monkeypatch.setattr(
+        generate_subtitles_module, "_audio_service", _FakeAudioServiceForSubtitles()
+    )
     monkeypatch.setattr(generate_subtitles_module, "validate_artifact_path", lambda p, r: p)
 
     task = generate_subtitles_module.generate_subtitles
@@ -491,16 +540,35 @@ def test_generate_paragraph_subtitles_preserves_provider_timeout(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
     provider = _FakeProvider(error=ProviderTimeoutError("timeout"))
-    _patch_registry(monkeypatch, generate_paragraph_subtitles_module, _FakeRegistry(_FakeEntry(), provider))
+    _patch_registry(
+        monkeypatch, generate_paragraph_subtitles_module, _FakeRegistry(_FakeEntry(), provider)
+    )
 
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_audio_service",
-        SimpleNamespace(get_paragraph_audio=lambda *a, **kw: _async_value(SimpleNamespace(path="test_audio.wav"))))
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "validate_artifact_path", lambda p, r: p)
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "os", SimpleNamespace(path=SimpleNamespace(exists=lambda _: True)))
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module,
+        "_audio_service",
+        SimpleNamespace(
+            get_paragraph_audio=lambda *a, **kw: _async_value(
+                SimpleNamespace(path="test_audio.wav")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "validate_artifact_path", lambda p, r: p
+    )
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module,
+        "os",
+        SimpleNamespace(path=SimpleNamespace(exists=lambda _: True)),
+    )
 
     storage = _make_storage(run_id=1, stage="SUBTITLE_GENERATING")
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_subtitle_service", _FakeSubtitleService())
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "_run_service", SimpleNamespace(storage=storage)
+    )
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "_subtitle_service", _FakeSubtitleService()
+    )
 
     task = generate_paragraph_subtitles_module.generate_paragraph_subtitles
     run_callable = getattr(task, "run", task)
@@ -513,16 +581,35 @@ def test_generate_paragraph_subtitles_preserves_rate_limit(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
     provider = _FakeProvider(error=RateLimitError("rate limited"))
-    _patch_registry(monkeypatch, generate_paragraph_subtitles_module, _FakeRegistry(_FakeEntry(), provider))
+    _patch_registry(
+        monkeypatch, generate_paragraph_subtitles_module, _FakeRegistry(_FakeEntry(), provider)
+    )
 
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_audio_service",
-        SimpleNamespace(get_paragraph_audio=lambda *a, **kw: _async_value(SimpleNamespace(path="test_audio.wav"))))
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "validate_artifact_path", lambda p, r: p)
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "os", SimpleNamespace(path=SimpleNamespace(exists=lambda _: True)))
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module,
+        "_audio_service",
+        SimpleNamespace(
+            get_paragraph_audio=lambda *a, **kw: _async_value(
+                SimpleNamespace(path="test_audio.wav")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "validate_artifact_path", lambda p, r: p
+    )
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module,
+        "os",
+        SimpleNamespace(path=SimpleNamespace(exists=lambda _: True)),
+    )
 
     storage = _make_storage(run_id=1, stage="SUBTITLE_GENERATING")
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_subtitle_service", _FakeSubtitleService())
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "_run_service", SimpleNamespace(storage=storage)
+    )
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "_subtitle_service", _FakeSubtitleService()
+    )
 
     task = generate_paragraph_subtitles_module.generate_paragraph_subtitles
     run_callable = getattr(task, "run", task)
@@ -536,7 +623,9 @@ def test_generate_paragraph_subtitles_rejects_path_traversal(
 ) -> None:
     """audio_path outside artifact root must be rejected."""
     provider = _FakeProvider()
-    _patch_registry(monkeypatch, generate_paragraph_subtitles_module, _FakeRegistry(_FakeEntry(), provider))
+    _patch_registry(
+        monkeypatch, generate_paragraph_subtitles_module, _FakeRegistry(_FakeEntry(), provider)
+    )
 
     # Audio file exists but is outside artifact root
     audio_file = tmp_path / "outside" / "evil.wav"
@@ -544,12 +633,21 @@ def test_generate_paragraph_subtitles_rejects_path_traversal(
     audio_file.write_bytes(b"fake audio")
     artifact_root = tmp_path / "artifacts"
     artifact_root.mkdir()
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_audio_service",
-        SimpleNamespace(get_paragraph_audio=lambda *a, **kw: _async_value(SimpleNamespace(path=str(audio_file)))))
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module,
+        "_audio_service",
+        SimpleNamespace(
+            get_paragraph_audio=lambda *a, **kw: _async_value(SimpleNamespace(path=str(audio_file)))
+        ),
+    )
 
     storage = _make_storage(run_id=1, stage="SUBTITLE_GENERATING")
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_subtitle_service", _FakeSubtitleService())
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "_run_service", SimpleNamespace(storage=storage)
+    )
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "_subtitle_service", _FakeSubtitleService()
+    )
 
     task = generate_paragraph_subtitles_module.generate_paragraph_subtitles
     run_callable = getattr(task, "run", task)
@@ -563,7 +661,9 @@ def test_generate_paragraph_subtitles_rejects_symlink_escape(
 ) -> None:
     """Symlink pointing outside artifact root must be rejected."""
     provider = _FakeProvider()
-    _patch_registry(monkeypatch, generate_paragraph_subtitles_module, _FakeRegistry(_FakeEntry(), provider))
+    _patch_registry(
+        monkeypatch, generate_paragraph_subtitles_module, _FakeRegistry(_FakeEntry(), provider)
+    )
 
     artifact_root = tmp_path / "artifacts"
     artifact_root.mkdir()
@@ -571,12 +671,21 @@ def test_generate_paragraph_subtitles_rejects_symlink_escape(
     secret.write_text("sensitive data")
     symlink = artifact_root / "evil.wav"
     symlink.symlink_to(secret)
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_audio_service",
-        SimpleNamespace(get_paragraph_audio=lambda *a, **kw: _async_value(SimpleNamespace(path=str(symlink)))))
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module,
+        "_audio_service",
+        SimpleNamespace(
+            get_paragraph_audio=lambda *a, **kw: _async_value(SimpleNamespace(path=str(symlink)))
+        ),
+    )
 
     storage = _make_storage(run_id=1, stage="SUBTITLE_GENERATING")
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_run_service", SimpleNamespace(storage=storage))
-    monkeypatch.setattr(generate_paragraph_subtitles_module, "_subtitle_service", _FakeSubtitleService())
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "_run_service", SimpleNamespace(storage=storage)
+    )
+    monkeypatch.setattr(
+        generate_paragraph_subtitles_module, "_subtitle_service", _FakeSubtitleService()
+    )
 
     task = generate_paragraph_subtitles_module.generate_paragraph_subtitles
     run_callable = getattr(task, "run", task)


### PR DESCRIPTION
## Summary
- Removes `skip_stage_guard=True` from paragraph audio and subtitle workers
- Replaces raw `script_data` access with `get_active_draft()` in paragraph audio worker
- TDD: failing tests first, then implementation
- Oracle reviewed: 100/100

Closes #497