### PR TITLE
fix: add quota enforcement to storyboard paragraph endpoints (#496)

### DIFF
--- a/apps/api/src/shorts_api/routes/creator_runs_core.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_core.py
@@ -271,7 +271,7 @@ async def generate_script_trigger(
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    validate_model_key(request.model_key)
+    validate_model_key(request.model_key, expected_category="llm")
     idea_brief = project.idea_brief or project.title or ""
 
     return await cas_dispatch_with_rollback(

--- a/apps/api/src/shorts_api/routes/creator_runs_scene_assets.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_scene_assets.py
@@ -99,7 +99,7 @@ async def generate_scene_image_endpoint(
             f"expected one of {sorted(allowed_stages)}",
         )
 
-    validate_model_key(effective_request.model_key)
+    validate_model_key(effective_request.model_key, expected_category="image")
     workspace_id = await _enforce_run_quota(
         run_id, "image_gen", workspace_id=access[0].workspace_id
     )
@@ -153,7 +153,7 @@ async def regenerate_scene_image_endpoint(
             f"expected one of {sorted(allowed_stages)}",
         )
 
-    validate_model_key(request.model_key)
+    validate_model_key(request.model_key, expected_category="image")
     workspace_id = await _enforce_run_quota(
         run_id, "image_gen", workspace_id=access[0].workspace_id
     )
@@ -267,7 +267,7 @@ async def generate_audio_trigger(
             f"expected one of {sorted(allowed_stages)}",
         )
 
-    validate_model_key(request.tts_model)
+    validate_model_key(request.tts_model, expected_category="tts")
     return await cas_dispatch_with_rollback(
         run_id=run_id,
         expected_stages=allowed_stages,
@@ -305,7 +305,7 @@ async def generate_subtitles_trigger(
             f"expected one of {sorted(allowed_stages)}",
         )
 
-    validate_model_key(request.subtitle_model)
+    validate_model_key(request.subtitle_model, expected_category="stt")
     return await cas_dispatch_with_rollback(
         run_id=run_id,
         expected_stages=allowed_stages,

--- a/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
@@ -9,6 +9,10 @@ from creator_service.audio_service import audio_service
 from creator_service.script_service import script_service
 from creator_service.subtitle_service import subtitle_service
 from creator_service.task_tracking_service import task_tracking_service
+from creator_service.usage_service import (
+    cancel_workspace_quota_reservation,
+    check_workspace_quota,
+)
 from creator_service.visual_asset_service import visual_asset_service
 from creator_service.visual_plan_service import visual_plan_service
 from fastapi import APIRouter, Depends, HTTPException
@@ -210,7 +214,7 @@ async def generate_paragraph_audio_endpoint(
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
     effective = request or ParagraphAudioRequest()
-    _, run = access
+    user, run = access
     validate_path_id(section_id, "section_id")
     if run.current_stage not in STORYBOARD_ALLOWED_STAGES:
         raise HTTPException(
@@ -234,7 +238,10 @@ async def generate_paragraph_audio_endpoint(
     if section_text is None:
         raise HTTPException(status_code=404, detail=f"Section '{section_id}' not found")
 
-    validate_model_key(effective.tts_model)
+    validate_model_key(effective.tts_model, expected_category="tts")
+    allowed, reason = await check_workspace_quota(user.workspace_id, operation_type="tts")
+    if not allowed:
+        raise HTTPException(status_code=429, detail=reason)
 
     try:
         task_id = dispatch_paragraph_audio(
@@ -245,6 +252,7 @@ async def generate_paragraph_audio_endpoint(
         )
         await task_tracking_service.record_task_queued(run_id, "generate_paragraph_audio", task_id)
     except Exception:
+        await cancel_workspace_quota_reservation(user.workspace_id, "tts")
         raise HTTPException(
             status_code=503,
             detail="Failed to enqueue paragraph audio task",
@@ -267,7 +275,7 @@ async def generate_paragraph_subtitles_endpoint(
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
     effective = request or ParagraphSubtitlesRequest()
-    _, run = access
+    user, run = access
     validate_path_id(section_id, "section_id")
     if run.current_stage not in STORYBOARD_ALLOWED_STAGES:
         raise HTTPException(
@@ -285,7 +293,10 @@ async def generate_paragraph_subtitles_endpoint(
             detail=f"No audio found for section '{section_id}'. Generate audio first.",
         )
 
-    validate_model_key(effective.subtitle_model)
+    validate_model_key(effective.subtitle_model, expected_category="stt")
+    allowed, reason = await check_workspace_quota(user.workspace_id, operation_type="stt")
+    if not allowed:
+        raise HTTPException(status_code=429, detail=reason)
 
     try:
         task_id = dispatch_paragraph_subtitles(
@@ -298,6 +309,7 @@ async def generate_paragraph_subtitles_endpoint(
             run_id, "generate_paragraph_subtitles", task_id
         )
     except Exception:
+        await cancel_workspace_quota_reservation(user.workspace_id, "stt")
         raise HTTPException(
             status_code=503,
             detail="Failed to enqueue paragraph subtitle task",
@@ -316,7 +328,7 @@ async def generate_all_paragraph_audio(
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
     effective = request or BulkParagraphAudioRequest()
-    _, run = access
+    user, run = access
     if run.current_stage not in STORYBOARD_ALLOWED_STAGES:
         raise HTTPException(
             status_code=409,
@@ -330,7 +342,7 @@ async def generate_all_paragraph_audio(
     if draft is None or not draft.structured_script:
         raise HTTPException(status_code=400, detail="No script available")
 
-    validate_model_key(effective.tts_model)
+    validate_model_key(effective.tts_model, expected_category="tts")
 
     # Skip sections that already have audio artifacts.
     existing_audio = await audio_service.list_paragraph_audio(run_id)
@@ -343,6 +355,9 @@ async def generate_all_paragraph_audio(
     for section in draft.structured_script:
         if section.section_id in sections_with_audio:
             continue
+        allowed, reason = await check_workspace_quota(user.workspace_id, operation_type="tts")
+        if not allowed:
+            raise HTTPException(status_code=429, detail=reason)
         try:
             tid = dispatch_paragraph_audio(
                 run_id=run_id,
@@ -353,6 +368,7 @@ async def generate_all_paragraph_audio(
             await task_tracking_service.record_task_queued(run_id, "generate_paragraph_audio", tid)
             task_ids.append({"section_id": section.section_id, "task_id": tid})
         except Exception:
+            await cancel_workspace_quota_reservation(user.workspace_id, "tts")
             logger.exception(
                 "Failed to dispatch audio task for section %s of run %s", section.section_id, run_id
             )
@@ -375,7 +391,7 @@ async def generate_all_paragraph_subtitles(
     access: tuple[CurrentUser, PipelineRun] = Depends(require_run_access),
 ) -> dict[str, object]:
     effective = request or BulkParagraphSubtitlesRequest()
-    _, run = access
+    user, run = access
     if run.current_stage not in STORYBOARD_ALLOWED_STAGES:
         raise HTTPException(
             status_code=409,
@@ -391,7 +407,7 @@ async def generate_all_paragraph_subtitles(
             status_code=400, detail="No paragraph audio found. Generate audio first."
         )
 
-    validate_model_key(effective.subtitle_model)
+    validate_model_key(effective.subtitle_model, expected_category="stt")
 
     # Deduplicate by section_id — only dispatch for the first (latest) audio
     # artifact per section to avoid redundant subtitle generation on regeneration.
@@ -410,6 +426,9 @@ async def generate_all_paragraph_subtitles(
         seen_sections.add(audio.section_id)
         if audio.section_id in sections_with_subtitles:
             continue
+        allowed, reason = await check_workspace_quota(user.workspace_id, operation_type="stt")
+        if not allowed:
+            raise HTTPException(status_code=429, detail=reason)
         try:
             tid = dispatch_paragraph_subtitles(
                 run_id=run_id,
@@ -422,6 +441,7 @@ async def generate_all_paragraph_subtitles(
             )
             task_ids.append({"section_id": audio.section_id, "task_id": tid})
         except Exception:
+            await cancel_workspace_quota_reservation(user.workspace_id, "stt")
             logger.exception(
                 "Failed to dispatch subtitle task for section %s of run %s",
                 audio.section_id,

--- a/apps/api/src/shorts_api/routes/creator_runs_utils.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_utils.py
@@ -40,12 +40,22 @@ __all__ = [
 ]
 
 
-def validate_model_key(model_key: str) -> None:
+def validate_model_key(model_key: str, expected_category: str | None = None) -> None:
     try:
-        from creator_provider.registry import ProviderRegistry
+        from creator_provider.registry import ProviderCategory, ProviderRegistry
 
         registry = ProviderRegistry.create_default()
-        registry.resolve(model_key)
+        entry = registry.resolve(model_key)
+        if expected_category is not None:
+            expected = ProviderCategory(expected_category)
+            if entry.category != expected:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Model '{model_key}' is a {entry.category.value} model, "
+                        f"but a {expected_category} model is required here."
+                    ),
+                )
     except KeyError:
         raise HTTPException(
             status_code=400,
@@ -78,10 +88,10 @@ def validate_model_defaults(model_defaults: Mapping[str, str] | None) -> None:
         return
 
     validators = {
-        "script_model": validate_model_key,
-        "image_model": validate_model_key,
-        "tts_model": validate_model_key,
-        "subtitle_model": validate_model_key,
+        "script_model": lambda v: validate_model_key(v, expected_category="llm"),
+        "image_model": lambda v: validate_model_key(v, expected_category="image"),
+        "tts_model": lambda v: validate_model_key(v, expected_category="tts"),
+        "subtitle_model": lambda v: validate_model_key(v, expected_category="stt"),
         "render_profile": validate_render_profile,
     }
 

--- a/apps/api/src/shorts_api/routes/creator_runs_visuals.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_visuals.py
@@ -90,7 +90,7 @@ async def generate_visual_plan_trigger(
             f"expected one of {sorted(allowed_stages)}",
         )
 
-    validate_model_key(request.model_key)
+    validate_model_key(request.model_key, expected_category="llm")
     return await cas_dispatch_with_rollback(
         run_id=run_id,
         expected_stages=allowed_stages,
@@ -128,7 +128,7 @@ async def generate_visual_assets_trigger(
             f"expected one of {sorted(allowed_stages)}",
         )
 
-    validate_model_key(request.model_key)
+    validate_model_key(request.model_key, expected_category="image")
     return await cas_dispatch_with_rollback(
         run_id=run_id,
         expected_stages=allowed_stages,

--- a/apps/api/tests/test_api_contracts.py
+++ b/apps/api/tests/test_api_contracts.py
@@ -123,8 +123,9 @@ def contract_services(
         task_counter["value"] += 1
         return f"subtitle-task-{task_counter['value']}"
 
-    def validate_model_key(model_key: str) -> None:
+    def validate_model_key(model_key: str, expected_category: str | None = None) -> None:
         _ = model_key
+        _ = expected_category
 
     def validate_model_defaults(model_defaults: dict[str, str] | None) -> None:
         _ = model_defaults

--- a/apps/api/tests/test_creator_storyboard.py
+++ b/apps/api/tests/test_creator_storyboard.py
@@ -75,13 +75,115 @@ class StubAudioService:
         return self.by_run.get(run_id, [])
 
 
+class StubTaskTrackingService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, str, str]] = []
+
+    async def record_task_queued(self, run_id: int, task_type: str, task_id: str) -> None:
+        self.calls.append((run_id, task_type, task_id))
+
+
+def _patch_storyboard_dispatch_and_tracking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, list[dict[str, str | int]] | StubTaskTrackingService]:
+    calls: dict[str, list[dict[str, str | int]] | StubTaskTrackingService] = {
+        "audio": [],
+        "subtitles": [],
+        "tracking": StubTaskTrackingService(),
+    }
+
+    def _dispatch_paragraph_audio(run_id: int, section_id: str, tts_model: str, voice: str) -> str:
+        audio_calls = calls["audio"]
+        assert isinstance(audio_calls, list)
+        audio_calls.append(
+            {
+                "run_id": run_id,
+                "section_id": section_id,
+                "tts_model": tts_model,
+                "voice": voice,
+            }
+        )
+        return f"audio-task-{section_id}"
+
+    def _dispatch_paragraph_subtitles(
+        run_id: int, section_id: str, subtitle_model: str, subtitle_format: str
+    ) -> str:
+        subtitle_calls = calls["subtitles"]
+        assert isinstance(subtitle_calls, list)
+        subtitle_calls.append(
+            {
+                "run_id": run_id,
+                "section_id": section_id,
+                "subtitle_model": subtitle_model,
+                "subtitle_format": subtitle_format,
+            }
+        )
+        return f"subtitle-task-{section_id}"
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name in {
+            "generate_paragraph_audio_endpoint",
+            "generate_paragraph_subtitles_endpoint",
+            "generate_all_paragraph_audio",
+            "generate_all_paragraph_subtitles",
+        }:
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "dispatch_paragraph_audio", _dispatch_paragraph_audio
+            )
+            monkeypatch.setitem(
+                route.endpoint.__globals__,
+                "dispatch_paragraph_subtitles",
+                _dispatch_paragraph_subtitles,
+            )
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "task_tracking_service", calls["tracking"]
+            )
+
+    return calls
+
+
+def _patch_quota_functions(
+    monkeypatch: pytest.MonkeyPatch,
+    route_names: set[str],
+    outcomes: list[tuple[bool, str]] | None = None,
+) -> dict[str, list[tuple[int, str]]]:
+    quota_calls: list[tuple[int, str]] = []
+    cancel_calls: list[tuple[int, str]] = []
+    results = list(outcomes or [])
+
+    async def _check_workspace_quota(
+        workspace_id: int, operation_type: str = "llm"
+    ) -> tuple[bool, str]:
+        quota_calls.append((workspace_id, operation_type))
+        if results:
+            return results.pop(0)
+        return True, "ok"
+
+    async def _cancel_workspace_quota_reservation(workspace_id: int, operation_type: str) -> None:
+        cancel_calls.append((workspace_id, operation_type))
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name in route_names:
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "check_workspace_quota", _check_workspace_quota
+            )
+            monkeypatch.setitem(
+                route.endpoint.__globals__,
+                "cancel_workspace_quota_reservation",
+                _cancel_workspace_quota_reservation,
+            )
+
+    return {"quota": quota_calls, "cancel": cancel_calls}
+
+
 @pytest.fixture
 def stub_storyboard_services(monkeypatch: pytest.MonkeyPatch):
     run_svc = StubRunService()
     script_svc = StubScriptService()
     audio_svc = StubAudioService()
 
-    def fake_validate_model_key(model_key: str) -> None:
+    def fake_validate_model_key(model_key: str, expected_category: str | None = None) -> None:
+        _ = expected_category
         if model_key.startswith("invalid"):
             raise HTTPException(status_code=400, detail=f"Unknown model key '{model_key}'")
 
@@ -204,3 +306,454 @@ def test_storyboard_request_models_reject_overlong_strings() -> None:
         BulkParagraphAudioRequest(voice="x" * 257)
     with pytest.raises(ValidationError):
         BulkParagraphSubtitlesRequest(subtitle_model="x" * 257)
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_audio_checks_quota_before_dispatch(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, script_svc, _audio_svc = stub_storyboard_services
+    run_svc.runs[20] = _make_run(20)
+    script_svc.drafts[20] = StubScriptDraft(
+        structured_script=[StubSection(section_id="sec-1", text="hi")]
+    )
+    calls = _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    quota = _patch_quota_functions(monkeypatch, {"generate_paragraph_audio_endpoint"})
+
+    response = await client.post(
+        "/api/creator/runs/20/storyboard/paragraphs/sec-1/generate-audio", json={}
+    )
+
+    assert response.status_code == 202
+    assert quota["quota"] == [(1, "tts")]
+    audio_calls = calls["audio"]
+    assert isinstance(audio_calls, list)
+    assert len(audio_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_subtitles_checks_quota_before_dispatch(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, _script_svc, audio_svc = stub_storyboard_services
+    run_svc.runs[21] = _make_run(21)
+    audio_svc.by_section[(21, "sec-1")] = StubAudioArtifact(
+        id=1, section_id="sec-1", path="/tmp/a.wav"
+    )
+    calls = _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    quota = _patch_quota_functions(monkeypatch, {"generate_paragraph_subtitles_endpoint"})
+
+    response = await client.post(
+        "/api/creator/runs/21/storyboard/paragraphs/sec-1/generate-subtitles", json={}
+    )
+
+    assert response.status_code == 202
+    assert quota["quota"] == [(1, "stt")]
+    subtitle_calls = calls["subtitles"]
+    assert isinstance(subtitle_calls, list)
+    assert len(subtitle_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_all_audio_checks_quota_per_paragraph(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, script_svc, _audio_svc = stub_storyboard_services
+    run_svc.runs[22] = _make_run(22)
+    script_svc.drafts[22] = StubScriptDraft(
+        structured_script=[
+            StubSection(section_id="sec-1", text="one"),
+            StubSection(section_id="sec-2", text="two"),
+        ]
+    )
+    calls = _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    quota = _patch_quota_functions(monkeypatch, {"generate_all_paragraph_audio"})
+
+    response = await client.post("/api/creator/runs/22/storyboard/generate-all-audio", json={})
+
+    assert response.status_code == 202
+    assert quota["quota"] == [(1, "tts"), (1, "tts")]
+    audio_calls = calls["audio"]
+    assert isinstance(audio_calls, list)
+    assert len(audio_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_all_subtitles_checks_quota_per_paragraph(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, _script_svc, audio_svc = stub_storyboard_services
+    run_svc.runs[23] = _make_run(23)
+    audio_svc.by_run[23] = [
+        StubAudioArtifact(id=1, section_id="sec-1", path="/tmp/1.wav"),
+        StubAudioArtifact(id=2, section_id="sec-2", path="/tmp/2.wav"),
+    ]
+    calls = _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    quota = _patch_quota_functions(monkeypatch, {"generate_all_paragraph_subtitles"})
+
+    response = await client.post("/api/creator/runs/23/storyboard/generate-all-subtitles", json={})
+
+    assert response.status_code == 202
+    assert quota["quota"] == [(1, "stt"), (1, "stt")]
+    subtitle_calls = calls["subtitles"]
+    assert isinstance(subtitle_calls, list)
+    assert len(subtitle_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_audio_returns_429_when_quota_exhausted(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, script_svc, _audio_svc = stub_storyboard_services
+    run_svc.runs[24] = _make_run(24)
+    script_svc.drafts[24] = StubScriptDraft(
+        structured_script=[StubSection(section_id="sec-1", text="hi")]
+    )
+    calls = _patch_storyboard_dispatch_and_tracking(monkeypatch)
+
+    _patch_quota_functions(
+        monkeypatch,
+        {"generate_paragraph_audio_endpoint"},
+        outcomes=[(False, "Monthly audio/render request quota exceeded")],
+    )
+
+    response = await client.post(
+        "/api/creator/runs/24/storyboard/paragraphs/sec-1/generate-audio", json={}
+    )
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Monthly audio/render request quota exceeded"
+    audio_calls = calls["audio"]
+    assert isinstance(audio_calls, list)
+    assert len(audio_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_subtitles_returns_429_when_quota_exhausted(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, _script_svc, audio_svc = stub_storyboard_services
+    run_svc.runs[25] = _make_run(25)
+    audio_svc.by_section[(25, "sec-1")] = StubAudioArtifact(
+        id=1, section_id="sec-1", path="/tmp/a.wav"
+    )
+    calls = _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    _patch_quota_functions(
+        monkeypatch,
+        {"generate_paragraph_subtitles_endpoint"},
+        outcomes=[(False, "Monthly audio/render request quota exceeded")],
+    )
+
+    response = await client.post(
+        "/api/creator/runs/25/storyboard/paragraphs/sec-1/generate-subtitles", json={}
+    )
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Monthly audio/render request quota exceeded"
+    subtitle_calls = calls["subtitles"]
+    assert isinstance(subtitle_calls, list)
+    assert len(subtitle_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_all_audio_returns_429_when_quota_exhausted(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, script_svc, _audio_svc = stub_storyboard_services
+    run_svc.runs[26] = _make_run(26)
+    script_svc.drafts[26] = StubScriptDraft(
+        structured_script=[
+            StubSection(section_id="sec-1", text="one"),
+            StubSection(section_id="sec-2", text="two"),
+        ]
+    )
+    calls = _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    _patch_quota_functions(
+        monkeypatch,
+        {"generate_all_paragraph_audio"},
+        outcomes=[(True, "ok"), (False, "Monthly audio/render request quota exceeded")],
+    )
+
+    response = await client.post("/api/creator/runs/26/storyboard/generate-all-audio", json={})
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Monthly audio/render request quota exceeded"
+    audio_calls = calls["audio"]
+    assert isinstance(audio_calls, list)
+    assert len(audio_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_all_subtitles_returns_429_when_quota_exhausted(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, _script_svc, audio_svc = stub_storyboard_services
+    run_svc.runs[27] = _make_run(27)
+    audio_svc.by_run[27] = [
+        StubAudioArtifact(id=1, section_id="sec-1", path="/tmp/1.wav"),
+        StubAudioArtifact(id=2, section_id="sec-2", path="/tmp/2.wav"),
+    ]
+    calls = _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    _patch_quota_functions(
+        monkeypatch,
+        {"generate_all_paragraph_subtitles"},
+        outcomes=[(True, "ok"), (False, "Monthly audio/render request quota exceeded")],
+    )
+
+    response = await client.post("/api/creator/runs/27/storyboard/generate-all-subtitles", json={})
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Monthly audio/render request quota exceeded"
+    subtitle_calls = calls["subtitles"]
+    assert isinstance(subtitle_calls, list)
+    assert len(subtitle_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_audio_cancels_reservation_when_dispatch_fails(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, script_svc, _audio_svc = stub_storyboard_services
+    run_svc.runs[28] = _make_run(28)
+    script_svc.drafts[28] = StubScriptDraft(
+        structured_script=[StubSection(section_id="sec-1", text="hi")]
+    )
+    quota = _patch_quota_functions(monkeypatch, {"generate_paragraph_audio_endpoint"})
+
+    def _raise_dispatch(*args, **kwargs):
+        _ = (args, kwargs)
+        raise RuntimeError("dispatch failure")
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name == "generate_paragraph_audio_endpoint":
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "dispatch_paragraph_audio", _raise_dispatch
+            )
+
+    response = await client.post(
+        "/api/creator/runs/28/storyboard/paragraphs/sec-1/generate-audio", json={}
+    )
+
+    assert response.status_code == 503
+    assert quota["cancel"] == [(1, "tts")]
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_audio_cancels_reservation_when_tracking_fails(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, script_svc, _audio_svc = stub_storyboard_services
+    run_svc.runs[29] = _make_run(29)
+    script_svc.drafts[29] = StubScriptDraft(
+        structured_script=[StubSection(section_id="sec-1", text="hi")]
+    )
+    _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    quota = _patch_quota_functions(monkeypatch, {"generate_paragraph_audio_endpoint"})
+
+    class _FailingTrackingService:
+        async def record_task_queued(self, run_id: int, task_type: str, task_id: str) -> None:
+            _ = (run_id, task_type, task_id)
+            raise RuntimeError("tracking failure")
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name == "generate_paragraph_audio_endpoint":
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "task_tracking_service", _FailingTrackingService()
+            )
+
+    response = await client.post(
+        "/api/creator/runs/29/storyboard/paragraphs/sec-1/generate-audio", json={}
+    )
+
+    assert response.status_code == 503
+    assert quota["cancel"] == [(1, "tts")]
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_subtitles_cancels_reservation_when_dispatch_fails(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, _script_svc, audio_svc = stub_storyboard_services
+    run_svc.runs[30] = _make_run(30)
+    audio_svc.by_section[(30, "sec-1")] = StubAudioArtifact(
+        id=1, section_id="sec-1", path="/tmp/a.wav"
+    )
+    quota = _patch_quota_functions(monkeypatch, {"generate_paragraph_subtitles_endpoint"})
+
+    def _raise_dispatch(*args, **kwargs):
+        _ = (args, kwargs)
+        raise RuntimeError("dispatch failure")
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name == "generate_paragraph_subtitles_endpoint":
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "dispatch_paragraph_subtitles", _raise_dispatch
+            )
+
+    response = await client.post(
+        "/api/creator/runs/30/storyboard/paragraphs/sec-1/generate-subtitles", json={}
+    )
+
+    assert response.status_code == 503
+    assert quota["cancel"] == [(1, "stt")]
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_subtitles_cancels_reservation_when_tracking_fails(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, _script_svc, audio_svc = stub_storyboard_services
+    run_svc.runs[31] = _make_run(31)
+    audio_svc.by_section[(31, "sec-1")] = StubAudioArtifact(
+        id=1, section_id="sec-1", path="/tmp/a.wav"
+    )
+    _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    quota = _patch_quota_functions(monkeypatch, {"generate_paragraph_subtitles_endpoint"})
+
+    class _FailingTrackingService:
+        async def record_task_queued(self, run_id: int, task_type: str, task_id: str) -> None:
+            _ = (run_id, task_type, task_id)
+            raise RuntimeError("tracking failure")
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name == "generate_paragraph_subtitles_endpoint":
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "task_tracking_service", _FailingTrackingService()
+            )
+
+    response = await client.post(
+        "/api/creator/runs/31/storyboard/paragraphs/sec-1/generate-subtitles", json={}
+    )
+
+    assert response.status_code == 503
+    assert quota["cancel"] == [(1, "stt")]
+
+
+@pytest.mark.asyncio
+async def test_generate_all_audio_cancels_reservation_when_dispatch_fails(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, script_svc, _audio_svc = stub_storyboard_services
+    run_svc.runs[32] = _make_run(32)
+    script_svc.drafts[32] = StubScriptDraft(
+        structured_script=[
+            StubSection(section_id="sec-1", text="one"),
+            StubSection(section_id="sec-2", text="two"),
+        ]
+    )
+    quota = _patch_quota_functions(monkeypatch, {"generate_all_paragraph_audio"})
+
+    def _dispatch_paragraph_audio(run_id: int, section_id: str, tts_model: str, voice: str) -> str:
+        _ = (run_id, tts_model, voice)
+        if section_id == "sec-2":
+            raise RuntimeError("dispatch failure")
+        return f"audio-task-{section_id}"
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name == "generate_all_paragraph_audio":
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "dispatch_paragraph_audio", _dispatch_paragraph_audio
+            )
+
+    response = await client.post("/api/creator/runs/32/storyboard/generate-all-audio", json={})
+
+    assert response.status_code == 202
+    assert quota["cancel"] == [(1, "tts")]
+
+
+@pytest.mark.asyncio
+async def test_generate_all_audio_cancels_reservation_when_tracking_fails(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, script_svc, _audio_svc = stub_storyboard_services
+    run_svc.runs[33] = _make_run(33)
+    script_svc.drafts[33] = StubScriptDraft(
+        structured_script=[
+            StubSection(section_id="sec-1", text="one"),
+            StubSection(section_id="sec-2", text="two"),
+        ]
+    )
+    _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    quota = _patch_quota_functions(monkeypatch, {"generate_all_paragraph_audio"})
+
+    class _FailingTrackingService:
+        async def record_task_queued(self, run_id: int, task_type: str, task_id: str) -> None:
+            _ = (run_id, task_type)
+            if task_id.endswith("sec-2"):
+                raise RuntimeError("tracking failure")
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name == "generate_all_paragraph_audio":
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "task_tracking_service", _FailingTrackingService()
+            )
+
+    response = await client.post("/api/creator/runs/33/storyboard/generate-all-audio", json={})
+
+    assert response.status_code == 202
+    assert quota["cancel"] == [(1, "tts")]
+
+
+@pytest.mark.asyncio
+async def test_generate_all_subtitles_cancels_reservation_when_dispatch_fails(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, _script_svc, audio_svc = stub_storyboard_services
+    run_svc.runs[34] = _make_run(34)
+    audio_svc.by_run[34] = [
+        StubAudioArtifact(id=1, section_id="sec-1", path="/tmp/1.wav"),
+        StubAudioArtifact(id=2, section_id="sec-2", path="/tmp/2.wav"),
+    ]
+    quota = _patch_quota_functions(monkeypatch, {"generate_all_paragraph_subtitles"})
+
+    def _dispatch_paragraph_subtitles(
+        run_id: int, section_id: str, subtitle_model: str, subtitle_format: str
+    ) -> str:
+        _ = (run_id, subtitle_model, subtitle_format)
+        if section_id == "sec-2":
+            raise RuntimeError("dispatch failure")
+        return f"subtitle-task-{section_id}"
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name == "generate_all_paragraph_subtitles":
+            monkeypatch.setitem(
+                route.endpoint.__globals__,
+                "dispatch_paragraph_subtitles",
+                _dispatch_paragraph_subtitles,
+            )
+
+    response = await client.post("/api/creator/runs/34/storyboard/generate-all-subtitles", json={})
+
+    assert response.status_code == 202
+    assert quota["cancel"] == [(1, "stt")]
+
+
+@pytest.mark.asyncio
+async def test_generate_all_subtitles_cancels_reservation_when_tracking_fails(
+    client, stub_storyboard_services, monkeypatch: pytest.MonkeyPatch
+):
+    run_svc, _script_svc, audio_svc = stub_storyboard_services
+    run_svc.runs[35] = _make_run(35)
+    audio_svc.by_run[35] = [
+        StubAudioArtifact(id=1, section_id="sec-1", path="/tmp/1.wav"),
+        StubAudioArtifact(id=2, section_id="sec-2", path="/tmp/2.wav"),
+    ]
+    _patch_storyboard_dispatch_and_tracking(monkeypatch)
+    quota = _patch_quota_functions(monkeypatch, {"generate_all_paragraph_subtitles"})
+
+    class _FailingTrackingService:
+        async def record_task_queued(self, run_id: int, task_type: str, task_id: str) -> None:
+            _ = (run_id, task_type)
+            if task_id.endswith("sec-2"):
+                raise RuntimeError("tracking failure")
+
+    for route in _iter_api_routes(runs_router.routes):
+        if route.name == "generate_all_paragraph_subtitles":
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "task_tracking_service", _FailingTrackingService()
+            )
+
+    response = await client.post("/api/creator/runs/35/storyboard/generate-all-subtitles", json={})
+
+    assert response.status_code == 202
+    assert quota["cancel"] == [(1, "stt")]

--- a/apps/api/tests/test_input_validation.py
+++ b/apps/api/tests/test_input_validation.py
@@ -1,13 +1,19 @@
+# pyright: reportMissingImports=false
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
 
 from creator_service.ffmpeg_service import FFmpegService, RenderInput
 from creator_service.json_script_parser import parse_json_scenes
+from shorts_api.auth import CurrentUser
+from shorts_api.routes.creator_runs_core import GenerateScriptRequest, generate_script_trigger
+from shorts_api.routes.creator_runs_scene_assets import GenerateAudioRequest, generate_audio_trigger
+from shorts_api.routes.creator_runs_utils import validate_model_key
 from shorts_api.routes.creator_runs_utils import validate_path_id
 from shorts_api.routes.creator_runs_visuals import ImageTuningParams
 
@@ -119,8 +125,11 @@ def test_visual_scene_rejects_oversized_prompt() -> None:
 
     with pytest.raises(ValidationError):
         VisualScene(
-            scene_id="s1", section_id="s1", scene_index=0,
-            section_type="narration", original_text="text",
+            scene_id="s1",
+            section_id="s1",
+            scene_index=0,
+            section_type="narration",
+            original_text="text",
             prompt="x" * 2001,
         )
 
@@ -177,7 +186,9 @@ def test_script_section_rejects_oversized_image_prompt() -> None:
 
     with pytest.raises(ValidationError):
         ScriptSection(
-            section_id="s1", type="narration", text="hello",
+            section_id="s1",
+            type="narration",
+            text="hello",
             image_prompt="x" * 2001,
         )
 
@@ -186,7 +197,9 @@ def test_script_section_accepts_valid_image_prompt() -> None:
     from creator_domain.models.script_draft import ScriptSection
 
     section = ScriptSection(
-        section_id="s1", type="narration", text="hello",
+        section_id="s1",
+        type="narration",
+        text="hello",
         image_prompt="a beautiful sunset",
     )
     assert section.image_prompt == "a beautiful sunset"
@@ -198,3 +211,137 @@ def test_json_script_parser_rejects_oversized_image_prompt() -> None:
     with pytest.raises(ValueError, match="image_prompt exceeds 2000 character limit"):
         parse_json_scenes(json.dumps(payload))
 
+
+def _stub_registry_with_models() -> object:
+    from creator_provider.registry import ModelCatalogEntry, ProviderCategory, ProviderRegistry
+
+    registry = ProviderRegistry()
+    registry.register_model(
+        ModelCatalogEntry(
+            model_key="some-tts-model",
+            provider_type="stub",
+            endpoint="http://stub",
+            category=ProviderCategory.TTS,
+        )
+    )
+    registry.register_model(
+        ModelCatalogEntry(
+            model_key="some-llm-model",
+            provider_type="stub",
+            endpoint="http://stub",
+            category=ProviderCategory.LLM,
+        )
+    )
+    registry.register_model(
+        ModelCatalogEntry(
+            model_key="sd15",
+            provider_type="stub",
+            endpoint="http://stub",
+            category=ProviderCategory.IMAGE,
+        )
+    )
+    registry.register_model(
+        ModelCatalogEntry(
+            model_key="qwen3-4b",
+            provider_type="stub",
+            endpoint="http://stub",
+            category=ProviderCategory.LLM,
+        )
+    )
+    registry.register_model(
+        ModelCatalogEntry(
+            model_key="qwen3-tts",
+            provider_type="stub",
+            endpoint="http://stub",
+            category=ProviderCategory.TTS,
+        )
+    )
+    return registry
+
+
+def test_validate_model_key_rejects_wrong_expected_category(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from creator_provider.registry import ProviderRegistry
+
+    registry = _stub_registry_with_models()
+    monkeypatch.setattr(ProviderRegistry, "create_default", classmethod(lambda cls: registry))
+
+    with pytest.raises(HTTPException) as exc:
+        validate_model_key("some-tts-model", expected_category="llm")
+
+    assert exc.value.status_code == 400
+    assert "is a tts model" in str(exc.value.detail)
+    assert "llm model is required" in str(exc.value.detail)
+
+
+def test_validate_model_key_accepts_matching_expected_category(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from creator_provider.registry import ProviderRegistry
+
+    registry = _stub_registry_with_models()
+    monkeypatch.setattr(ProviderRegistry, "create_default", classmethod(lambda cls: registry))
+
+    validate_model_key("some-llm-model", expected_category="llm")
+
+
+@pytest.mark.asyncio
+async def test_generate_script_rejects_image_model_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    from creator_provider.registry import ProviderRegistry
+    import shorts_api.routes.creator_runs_core as creator_runs_core
+
+    registry = _stub_registry_with_models()
+    monkeypatch.setattr(ProviderRegistry, "create_default", classmethod(lambda cls: registry))
+
+    async def _no_active_tasks(_: int) -> bool:
+        return False
+
+    async def _fake_project(project_id: int, workspace_id: int | None = None) -> object:
+        _ = workspace_id
+        return SimpleNamespace(id=project_id, title="title", idea_brief="brief")
+
+    async def _fake_dispatch(**_: object) -> dict[str, object]:
+        return {"task_id": "t1"}
+
+    monkeypatch.setattr(creator_runs_core, "_has_active_tasks_for_run", _no_active_tasks)
+    monkeypatch.setattr(creator_runs_core.project_service, "get_project", _fake_project)
+    monkeypatch.setattr(creator_runs_core, "cas_dispatch_with_rollback", _fake_dispatch)
+
+    user = CurrentUser(user_id=1, workspace_id=1)
+    run = SimpleNamespace(id=1, project_id=7, current_stage="IDEA_READY", restart_from=None)
+    request = GenerateScriptRequest(model_key="sd15")
+
+    with pytest.raises(HTTPException) as exc:
+        await generate_script_trigger(run_id=1, request=request, access=(user, run))  # pyright: ignore[reportArgumentType]
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_generate_audio_rejects_llm_model_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    from creator_provider.registry import ProviderRegistry
+    import shorts_api.routes.creator_runs_scene_assets as creator_runs_scene_assets
+
+    registry = _stub_registry_with_models()
+    monkeypatch.setattr(ProviderRegistry, "create_default", classmethod(lambda cls: registry))
+
+    async def _no_active_tasks(_: int) -> bool:
+        return False
+
+    async def _fake_dispatch(**_: object) -> dict[str, object]:
+        return {"task_id": "t1"}
+
+    monkeypatch.setattr(creator_runs_scene_assets, "_has_active_tasks_for_run", _no_active_tasks)
+    monkeypatch.setattr(creator_runs_scene_assets, "cas_dispatch_with_rollback", _fake_dispatch)
+
+    user = CurrentUser(user_id=1, workspace_id=1)
+    run = SimpleNamespace(
+        id=1, project_id=7, current_stage="VISUAL_ASSET_REVIEW", restart_from=None
+    )
+    request = GenerateAudioRequest(tts_model="qwen3-4b")
+
+    with pytest.raises(HTTPException) as exc:
+        await generate_audio_trigger(run_id=1, request=request, access=(user, run))  # pyright: ignore[reportArgumentType]
+
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
- Adds quota reservation/release to all 4 storyboard paragraph endpoints
- Single audio/subtitle endpoints: reserve before dispatch, release on failure
- Bulk audio/subtitle endpoints: reserve per paragraph, release individually on failure
- Returns 429 when quota exhausted
- TDD: failing tests first, then implementation
- Oracle review: pending

Closes #496