### PR TITLE
fix: atomic stage review with rollback on failure (#504)

### DIFF
--- a/.sisyphus/run-continuation/ses_1da689617ffe8Xac3Pf9Iz2qac.json
+++ b/.sisyphus/run-continuation/ses_1da689617ffe8Xac3Pf9Iz2qac.json
@@ -1,0 +1,11 @@
+{
+  "sessionID": "ses_1da689617ffe8Xac3Pf9Iz2qac",
+  "updatedAt": "2026-05-14T08:49:08.336Z",
+  "sources": {
+    "stop": {
+      "state": "stopped",
+      "reason": "continuation stopped",
+      "updatedAt": "2026-05-14T08:49:08.336Z"
+    }
+  }
+}

--- a/packages/creator-service/creator_service/stage_review_service.py
+++ b/packages/creator-service/creator_service/stage_review_service.py
@@ -139,15 +139,25 @@ class StageReviewService:
             )
 
         # 4. Record approval (only after CAS succeeds — no orphan reviews)
-        await self.storage.create_review(
-            {
-                "run_id": run_id,
-                "stage_name": stage_name,
-                "review_status": "approved",
-                "reviewer": reviewer,
-                "notes": notes,
-            }
-        )
+        try:
+            await self.storage.create_review(
+                {
+                    "run_id": run_id,
+                    "stage_name": stage_name,
+                    "review_status": "approved",
+                    "reviewer": reviewer,
+                    "notes": notes,
+                }
+            )
+        except Exception:
+            # Roll back stage on review insert failure.
+            await run_service.storage.conditional_update_run(
+                run_id,
+                {"current_stage": stage.value},
+                frozenset({target.value}),
+                workspace_id=workspace_id,
+            )
+            raise
 
         updated_run = await run_service.get_run(run_id, workspace_id=workspace_id)
         if updated_run is None:

--- a/packages/creator-service/creator_service/stage_review_service.py
+++ b/packages/creator-service/creator_service/stage_review_service.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
 from creator_domain.models import REVIEW_STAGES, RunStage, can_transition
+
+logger = logging.getLogger(__name__)
 
 
 class StageReviewStorageBackend(Protocol):
@@ -149,14 +152,27 @@ class StageReviewService:
                     "notes": notes,
                 }
             )
-        except Exception:
+        except Exception as exc:
             # Roll back stage on review insert failure.
-            await run_service.storage.conditional_update_run(
+            rollback_ok, _ = await run_service.storage.conditional_update_run(
                 run_id,
                 {"current_stage": stage.value},
                 frozenset({target.value}),
                 workspace_id=workspace_id,
             )
+            if not rollback_ok:
+                logger.critical(
+                    "INCONSISTENCY: review insert failed AND rollback failed "
+                    "for run %s (stage %s -> %s). Manual intervention required.",
+                    run_id,
+                    stage.value,
+                    target.value,
+                )
+                raise RuntimeError(
+                    f"Stage rollback failed for run {run_id}: review insert failed "
+                    f"and stage could not be restored from {target.value} to {stage.value}. "
+                    f"Original error: {exc}"
+                ) from exc
             raise
 
         updated_run = await run_service.get_run(run_id, workspace_id=workspace_id)

--- a/packages/creator-service/tests/test_stage_review_service.py
+++ b/packages/creator-service/tests/test_stage_review_service.py
@@ -54,3 +54,68 @@ def test_approve_and_advance_rolls_back_stage_when_review_insert_fails() -> None
     latest = run(run_storage.get_run(run_id, workspace_id=1))
     assert latest is not None
     assert latest["current_stage"] == "SCRIPT_REVIEW"
+
+
+class _FailingReviewAndRollbackStorage(InMemoryStageReviewStorage):
+    """Review insert fails, and we rig the run storage so rollback CAS also fails."""
+
+    async def create_review(self, row: dict[str, object]) -> dict[str, object]:
+        raise RuntimeError("review insert failed")
+
+
+def test_approve_raises_inconsistency_when_rollback_also_fails() -> None:
+    """If review insert fails AND rollback CAS fails, a RuntimeError with
+    'Stage rollback failed' must be raised instead of the original error."""
+    run_storage = InMemoryRunStorage()
+    run_row = run(
+        run_storage.create_run(
+            {
+                "project_id": 1,
+                "workspace_id": 1,
+                "current_stage": "SCRIPT_REVIEW",
+                "status": "pending",
+            }
+        )
+    )
+    run_id = int(run_row["id"])
+
+    storage = _FailingReviewAndRollbackStorage()
+    service = StageReviewService(storage)
+    run_svc = _RunServiceStub(run_storage)
+
+    # First, do the approve which will:
+    # 1. CAS stage from SCRIPT_REVIEW -> VISUAL_PLAN_SETUP (succeeds)
+    # 2. create_review fails
+    # 3. rollback CAS expects current=VISUAL_PLAN_SETUP
+    # To make rollback fail, we simulate concurrent stage change by
+    # mutating the run after CAS but before rollback.
+    # Easier approach: just force the stage to something else before rollback.
+
+    # We need a more controlled approach. Let's override conditional_update_run
+    # on the run_storage to fail on the second call (the rollback).
+    original_cas = run_storage.conditional_update_run
+    call_count = 0
+
+    async def _cas_that_fails_on_second_call(
+        run_id, updates, expected_stages, workspace_id=None
+    ):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First call: the real stage advance
+            return await original_cas(run_id, updates, expected_stages, workspace_id=workspace_id)
+        # Second call: rollback — simulate concurrent modification
+        return False, {"current_stage": "SOMETHING_ELSE"}
+
+    run_storage.conditional_update_run = _cas_that_fails_on_second_call  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="Stage rollback failed"):
+        run(
+            service.approve_and_advance(
+                run_service=run_svc,
+                run_id=run_id,
+                stage_name="SCRIPT_REVIEW",
+                target_stage="VISUAL_PLAN_SETUP",
+                workspace_id=1,
+            )
+        )

--- a/packages/creator-service/tests/test_stage_review_service.py
+++ b/packages/creator-service/tests/test_stage_review_service.py
@@ -1,0 +1,56 @@
+import asyncio
+
+import pytest
+from creator_service.run_service import InMemoryRunStorage
+from creator_service.stage_review_service import InMemoryStageReviewStorage, StageReviewService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class _RunServiceStub:
+    def __init__(self, storage: InMemoryRunStorage) -> None:
+        self.storage = storage
+
+    async def get_run(self, run_id: int, workspace_id: int | None = None):
+        return await self.storage.get_run(run_id, workspace_id=workspace_id)
+
+
+class _FailingReviewStorage(InMemoryStageReviewStorage):
+    async def create_review(self, row: dict[str, object]) -> dict[str, object]:
+        raise RuntimeError("review insert failed")
+
+
+def test_approve_and_advance_rolls_back_stage_when_review_insert_fails() -> None:
+    run_storage = InMemoryRunStorage()
+    run_row = run(
+        run_storage.create_run(
+            {
+                "project_id": 1,
+                "workspace_id": 1,
+                "current_stage": "SCRIPT_REVIEW",
+                "status": "pending",
+            }
+        )
+    )
+    run_id = int(run_row["id"])
+
+    storage = _FailingReviewStorage()
+    service = StageReviewService(storage)
+    run_service = _RunServiceStub(run_storage)
+
+    with pytest.raises(RuntimeError, match="review insert failed"):
+        run(
+            service.approve_and_advance(
+                run_service=run_service,
+                run_id=run_id,
+                stage_name="SCRIPT_REVIEW",
+                target_stage="VISUAL_PLAN_SETUP",
+                workspace_id=1,
+            )
+        )
+
+    latest = run(run_storage.get_run(run_id, workspace_id=1))
+    assert latest is not None
+    assert latest["current_stage"] == "SCRIPT_REVIEW"


### PR DESCRIPTION
## Summary
- Wraps `approve_and_advance` in stage_review_service to rollback stage transition if review record insertion fails
- Adds regression test verifying rollback behavior

Closes #504