### PR TITLE
fix: register SIGINT handler and chain previous signal handlers (#506)

### DIFF
--- a/apps/api/src/shorts_api/lifecycle.py
+++ b/apps/api/src/shorts_api/lifecycle.py
@@ -24,6 +24,7 @@ class ShutdownState:
 
 shutdown_state = ShutdownState()
 _previous_sigterm_handler: object | None = None
+_previous_sigint_handler: object | None = None
 
 
 def _parse_int_env(name: str, default: int) -> int:
@@ -118,17 +119,29 @@ def _handle_sigterm(_signum: int, _frame: object | None) -> None:
         prev(_signum, _frame)
 
 
+def _handle_sigint(_signum: int, _frame: object | None) -> None:
+    logger.info("SIGINT received; enabling graceful shutdown mode")
+    _mark_shutdown()
+    # Chain to previous handler so the server can exit gracefully
+    prev = _previous_sigint_handler
+    if callable(prev):
+        prev(_signum, _frame)
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
-    global _previous_sigterm_handler
+    global _previous_sigterm_handler, _previous_sigint_handler
     shutdown_state.is_shutting_down = False
     shutdown_state.inflight_requests = 0
     try:
         _previous_sigterm_handler = signal.getsignal(signal.SIGTERM)
         signal.signal(signal.SIGTERM, _handle_sigterm)
+        _previous_sigint_handler = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, _handle_sigint)
     except ValueError:
         _previous_sigterm_handler = None
-        logger.debug("Skipping SIGTERM handler registration outside main thread")
+        _previous_sigint_handler = None
+        logger.debug("Skipping signal handler registration outside main thread")
     if ENABLE_PROCESS_RESOURCE_GUARD:
         _apply_resource_limits()
         logger.info(
@@ -151,4 +164,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if _previous_sigterm_handler is not None:
         with contextlib.suppress(ValueError):
             signal.signal(signal.SIGTERM, _previous_sigterm_handler)
+    if _previous_sigint_handler is not None:
+        with contextlib.suppress(ValueError):
+            signal.signal(signal.SIGINT, _previous_sigint_handler)
     await close_pool()

--- a/apps/api/tests/test_resource_guard.py
+++ b/apps/api/tests/test_resource_guard.py
@@ -211,5 +211,15 @@ async def test_lifespan_restores_previous_sigterm_handler_after_exit(monkeypatch
     async with lifecycle_module.lifespan(app):
         pass
 
-    assert signal_calls[0] == (signal.SIGTERM, lifecycle_module._handle_sigterm)
-    assert signal_calls[-1] == (signal.SIGTERM, previous_handler)
+    # Should register SIGTERM and SIGINT handlers on startup
+    sigterm_setup_call = (signal.SIGTERM, lifecycle_module._handle_sigterm)
+    sigint_setup_call = (signal.SIGINT, lifecycle_module._handle_sigint)
+    
+    # Find setup calls (before restoration)
+    assert sigterm_setup_call in signal_calls
+    assert sigint_setup_call in signal_calls
+    
+    # Last two calls should be restoration of SIGTERM and SIGINT (in that order)
+    # SIGTERM is restored first, then SIGINT
+    assert signal_calls[-2] == (signal.SIGTERM, previous_handler)
+    assert signal_calls[-1] == (signal.SIGINT, previous_handler)

--- a/apps/api/tests/test_signal_handling.py
+++ b/apps/api/tests/test_signal_handling.py
@@ -1,0 +1,119 @@
+"""Test signal handling in API lifecycle."""
+
+import asyncio
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+
+from shorts_api import lifecycle
+
+
+@pytest.fixture(autouse=True)
+def reset_signal_handlers():
+    """Reset signal handler state before each test."""
+    lifecycle._previous_sigterm_handler = None
+    lifecycle._previous_sigint_handler = None
+    lifecycle.shutdown_state.is_shutting_down = False
+    yield
+    # Restore default handlers
+    lifecycle._previous_sigterm_handler = None
+    lifecycle._previous_sigint_handler = None
+    lifecycle.shutdown_state.is_shutting_down = False
+
+
+@pytest.mark.asyncio
+async def test_sigterm_handler_registered():
+    """Test that SIGTERM handler is registered during lifespan."""
+    app = FastAPI()
+
+    async with lifecycle.lifespan(app):
+        # During lifespan, the signal should be registered
+        handler = signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        # Restore original
+        signal.signal(signal.SIGTERM, handler)
+        assert handler == lifecycle._handle_sigterm
+
+
+@pytest.mark.asyncio
+async def test_sigint_handler_registered():
+    """Test that SIGINT handler is registered during lifespan."""
+    app = FastAPI()
+
+    async with lifecycle.lifespan(app):
+        # During lifespan, the signal should be registered
+        handler = signal.signal(signal.SIGINT, signal.SIG_DFL)
+        # Restore original
+        signal.signal(signal.SIGINT, handler)
+        assert handler == lifecycle._handle_sigint
+
+
+@pytest.mark.asyncio
+async def test_sigterm_chains_to_previous_handler():
+    """Test that SIGTERM handler chains to previous handler."""
+    previous_handler = MagicMock()
+    lifecycle._previous_sigterm_handler = previous_handler
+
+    # Simulate SIGTERM
+    lifecycle._handle_sigterm(signal.SIGTERM, None)
+
+    # Verify previous handler was called
+    previous_handler.assert_called_once()
+    assert previous_handler.call_args[0] == (signal.SIGTERM, None)
+    # Verify shutdown was marked
+    assert lifecycle.shutdown_state.is_shutting_down
+
+
+@pytest.mark.asyncio
+async def test_sigint_chains_to_previous_handler():
+    """Test that SIGINT handler chains to previous handler."""
+    previous_handler = MagicMock()
+    lifecycle._previous_sigint_handler = previous_handler
+
+    # Simulate SIGINT
+    lifecycle._handle_sigint(signal.SIGINT, None)
+
+    # Verify previous handler was called
+    previous_handler.assert_called_once()
+    assert previous_handler.call_args[0] == (signal.SIGINT, None)
+    # Verify shutdown was marked
+    assert lifecycle.shutdown_state.is_shutting_down
+
+
+@pytest.mark.asyncio
+async def test_signal_handlers_skip_registration_outside_main_thread():
+    """Test that signal handler registration is skipped outside main thread."""
+    app = FastAPI()
+
+    with patch("signal.signal", side_effect=ValueError("signal only works in main thread")):
+        async with lifecycle.lifespan(app):
+            # Should not raise, just log debug
+            pass
+        # Handlers should be None due to ValueError
+        assert lifecycle._previous_sigterm_handler is None
+        assert lifecycle._previous_sigint_handler is None
+
+
+@pytest.mark.asyncio
+async def test_previous_handlers_restored_on_shutdown():
+    """Test that previous handlers are restored after shutdown."""
+    app = FastAPI()
+    previous_sigterm = MagicMock()
+    previous_sigint = MagicMock()
+
+    with patch("signal.getsignal") as mock_getsignal:
+        with patch("signal.signal") as mock_signal:
+            # Mock getsignal to return our handlers
+            mock_getsignal.side_effect = lambda sig: (
+                previous_sigterm if sig == signal.SIGTERM else previous_sigint
+            )
+
+            async with lifecycle.lifespan(app):
+                pass
+
+            # Verify previous handlers were registered during cleanup
+            calls = mock_signal.call_args_list
+            # Should have registered both SIGTERM and SIGINT initially
+            assert any(call[0] == (signal.SIGTERM, lifecycle._handle_sigterm) for call in calls)
+            assert any(call[0] == (signal.SIGINT, lifecycle._handle_sigint) for call in calls)

--- a/apps/api/tests/test_signal_handling.py
+++ b/apps/api/tests/test_signal_handling.py
@@ -117,3 +117,8 @@ async def test_previous_handlers_restored_on_shutdown():
             # Should have registered both SIGTERM and SIGINT initially
             assert any(call[0] == (signal.SIGTERM, lifecycle._handle_sigterm) for call in calls)
             assert any(call[0] == (signal.SIGINT, lifecycle._handle_sigint) for call in calls)
+            # Verify restoration to distinct previous handlers
+            assert any(call[0] == (signal.SIGTERM, previous_sigterm) for call in calls), \
+                "SIGTERM not restored to its distinct previous handler"
+            assert any(call[0] == (signal.SIGINT, previous_sigint) for call in calls), \
+                "SIGINT not restored to its distinct previous handler"

--- a/apps/worker-orchestrator/celery_app.py
+++ b/apps/worker-orchestrator/celery_app.py
@@ -47,6 +47,8 @@ def _parse_int_env(name: str, default: int) -> int:
 
 MAX_MEMORY_MB = _parse_int_env("MAX_MEMORY_MB", 1024)
 _SHUTDOWN_REQUESTED = False
+_previous_sigterm_handler: object | None = None
+_previous_sigint_handler: object | None = None
 
 
 def _handle_sigterm(_signum: int, _frame: object | None) -> None:
@@ -55,6 +57,22 @@ def _handle_sigterm(_signum: int, _frame: object | None) -> None:
         return
     _SHUTDOWN_REQUESTED = True
     logging.getLogger(__name__).info("SIGTERM received; beginning Celery graceful shutdown")
+    # Chain to previous handler
+    prev = _previous_sigterm_handler
+    if callable(prev):
+        prev(_signum, _frame)
+
+
+def _handle_sigint(_signum: int, _frame: object | None) -> None:
+    global _SHUTDOWN_REQUESTED
+    if _SHUTDOWN_REQUESTED:
+        return
+    _SHUTDOWN_REQUESTED = True
+    logging.getLogger(__name__).info("SIGINT received; beginning Celery graceful shutdown")
+    # Chain to previous handler
+    prev = _previous_sigint_handler
+    if callable(prev):
+        prev(_signum, _frame)
 
 
 def is_shutting_down() -> bool:
@@ -112,9 +130,12 @@ celery_app.conf.update(
 
 validate_production_config(service_kind="worker")
 try:
+    _previous_sigterm_handler = signal.getsignal(signal.SIGTERM)
     signal.signal(signal.SIGTERM, _handle_sigterm)
+    _previous_sigint_handler = signal.getsignal(signal.SIGINT)
+    signal.signal(signal.SIGINT, _handle_sigint)
 except ValueError:
-    logging.getLogger(__name__).debug("Skipping SIGTERM handler: not in main thread")
+    logging.getLogger(__name__).debug("Skipping signal handler registration: not in main thread")
 
 
 @after_setup_logger.connect

--- a/apps/worker-orchestrator/tests/__init__.py
+++ b/apps/worker-orchestrator/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Worker orchestrator tests."""

--- a/apps/worker-orchestrator/tests/test_celery_app.py
+++ b/apps/worker-orchestrator/tests/test_celery_app.py
@@ -36,5 +36,5 @@ def test_sigterm_registration_skips_when_signal_raises_value_error() -> None:
         importlib.reload(celery_module)
 
     get_logger.return_value.debug.assert_called_once_with(
-        "Skipping SIGTERM handler: not in main thread"
+        "Skipping signal handler registration: not in main thread"
     )

--- a/apps/worker-orchestrator/tests/test_signal_handling.py
+++ b/apps/worker-orchestrator/tests/test_signal_handling.py
@@ -1,0 +1,121 @@
+"""Test signal handling in Celery app."""
+
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from celery_app import (
+    _handle_sigint,
+    _handle_sigterm,
+    _previous_sigint_handler,
+    _previous_sigterm_handler,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_shutdown_state():
+    """Reset shutdown state before each test."""
+    import celery_app
+
+    celery_app._SHUTDOWN_REQUESTED = False
+    yield
+    celery_app._SHUTDOWN_REQUESTED = False
+
+
+def test_sigterm_chains_to_previous_handler():
+    """Test that SIGTERM handler chains to previous handler."""
+    import celery_app
+
+    previous_handler = MagicMock()
+    celery_app._previous_sigterm_handler = previous_handler
+    celery_app._SHUTDOWN_REQUESTED = False
+
+    # Simulate SIGTERM
+    _handle_sigterm(signal.SIGTERM, None)
+
+    # Verify previous handler was called
+    previous_handler.assert_called_once()
+    assert previous_handler.call_args[0] == (signal.SIGTERM, None)
+    # Verify shutdown flag was set
+    assert celery_app._SHUTDOWN_REQUESTED
+
+
+def test_sigint_chains_to_previous_handler():
+    """Test that SIGINT handler chains to previous handler."""
+    import celery_app
+
+    previous_handler = MagicMock()
+    celery_app._previous_sigint_handler = previous_handler
+    celery_app._SHUTDOWN_REQUESTED = False
+
+    # Simulate SIGINT
+    _handle_sigint(signal.SIGINT, None)
+
+    # Verify previous handler was called
+    previous_handler.assert_called_once()
+    assert previous_handler.call_args[0] == (signal.SIGINT, None)
+    # Verify shutdown flag was set
+    assert celery_app._SHUTDOWN_REQUESTED
+
+
+def test_sigterm_skips_chaining_when_none():
+    """Test that SIGTERM handler doesn't crash if previous is None."""
+    import celery_app
+
+    celery_app._previous_sigterm_handler = None
+    celery_app._SHUTDOWN_REQUESTED = False
+
+    # Should not raise
+    _handle_sigterm(signal.SIGTERM, None)
+    assert celery_app._SHUTDOWN_REQUESTED
+
+
+def test_sigint_skips_chaining_when_none():
+    """Test that SIGINT handler doesn't crash if previous is None."""
+    import celery_app
+
+    celery_app._previous_sigint_handler = None
+    celery_app._SHUTDOWN_REQUESTED = False
+
+    # Should not raise
+    _handle_sigint(signal.SIGINT, None)
+    assert celery_app._SHUTDOWN_REQUESTED
+
+
+def test_sigterm_idempotent():
+    """Test that SIGTERM handler is idempotent."""
+    import celery_app
+
+    celery_app._previous_sigterm_handler = MagicMock()
+    celery_app._SHUTDOWN_REQUESTED = False
+
+    # First call
+    _handle_sigterm(signal.SIGTERM, None)
+    assert celery_app._SHUTDOWN_REQUESTED
+
+    # Reset the mock
+    celery_app._previous_sigterm_handler.reset_mock()
+
+    # Second call should not chain again
+    _handle_sigterm(signal.SIGTERM, None)
+    celery_app._previous_sigterm_handler.assert_not_called()
+
+
+def test_sigint_idempotent():
+    """Test that SIGINT handler is idempotent."""
+    import celery_app
+
+    celery_app._previous_sigint_handler = MagicMock()
+    celery_app._SHUTDOWN_REQUESTED = False
+
+    # First call
+    _handle_sigint(signal.SIGINT, None)
+    assert celery_app._SHUTDOWN_REQUESTED
+
+    # Reset the mock
+    celery_app._previous_sigint_handler.reset_mock()
+
+    # Second call should not chain again
+    _handle_sigint(signal.SIGINT, None)
+    celery_app._previous_sigint_handler.assert_not_called()


### PR DESCRIPTION
## Summary
- Registers SIGINT handler alongside SIGTERM in both API lifecycle and worker celery_app
- Stores and chains to previous signal handlers for both signals
- Adds 12 tests verifying handler registration, chaining, and idempotency

Closes #506