### PR TITLE
fix: respect X-Workspace-Id header for multi-workspace auth (#508)

### DIFF
--- a/apps/api/src/shorts_api/auth.py
+++ b/apps/api/src/shorts_api/auth.py
@@ -77,6 +77,40 @@ async def _resolve_user_id_from_api_key(api_key: str, db_session) -> str | None:
 _ADMIN_PATH_PREFIX = "/api/admin"
 
 
+def _resolve_workspace_id(
+    workspace_header: str | None,
+    member_workspace_ids: list[int],
+) -> int:
+    """Resolve the workspace_id from header or default to first workspace.
+    
+    Args:
+        workspace_header: Value of X-Workspace-Id header (or None if not provided)
+        member_workspace_ids: List of workspace IDs the user is a member of
+        
+    Returns:
+        The resolved workspace_id
+        
+    Raises:
+        HTTPException(404) if header is invalid or user is not a member
+    """
+    if workspace_header is None:
+        return member_workspace_ids[0]
+    
+    # Try to parse the header as an integer
+    try:
+        requested_workspace_id = int(workspace_header)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=404, detail="Not found")
+    
+    # Verify user is a member of the requested workspace
+    if requested_workspace_id not in member_workspace_ids:
+        raise HTTPException(status_code=404, detail="Not found")
+    
+    return requested_workspace_id
+
+
+
+
 class ApiKeyMiddleware(BaseHTTPMiddleware):
     """Starlette middleware that resolves user context from API keys."""
 
@@ -175,16 +209,10 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
 
         # Check for X-Workspace-Id header to pin to specific workspace
         workspace_header = request.headers.get("X-Workspace-Id")
-        if workspace_header:
-            try:
-                requested_workspace_id = int(workspace_header)
-            except (TypeError, ValueError):
-                return JSONResponse(status_code=404, content={"detail": "Not found"})
-            if requested_workspace_id not in member_workspace_ids:
-                return JSONResponse(status_code=404, content={"detail": "Not found"})
-            selected_workspace_id = requested_workspace_id
-        else:
-            selected_workspace_id = member_workspace_ids[0]
+        try:
+            selected_workspace_id = _resolve_workspace_id(workspace_header, member_workspace_ids)
+        except HTTPException as exc:
+            return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
         user = CurrentUser(user_id=user_id_int, workspace_id=selected_workspace_id)
         request.state.user = user
@@ -243,16 +271,7 @@ async def get_current_user(request: Request) -> CurrentUser:
     
     # Check for X-Workspace-Id header to pin to specific workspace
     workspace_header = request.headers.get("X-Workspace-Id")
-    if workspace_header:
-        try:
-            requested_workspace_id = int(workspace_header)
-        except (TypeError, ValueError):
-            raise HTTPException(status_code=404, detail="Not found")
-        if requested_workspace_id not in member_workspace_ids:
-            raise HTTPException(status_code=404, detail="Not found")
-        selected_workspace_id = requested_workspace_id
-    else:
-        selected_workspace_id = member_workspace_ids[0]
+    selected_workspace_id = _resolve_workspace_id(workspace_header, member_workspace_ids)
 
     return CurrentUser(user_id=user_id, workspace_id=selected_workspace_id)
 

--- a/apps/api/src/shorts_api/auth.py
+++ b/apps/api/src/shorts_api/auth.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from creator_domain.models.pipeline_run import PipelineRun
     from creator_domain.models.project import Project
 
-from creator_service.db import fetch_one
+from creator_service.db import fetch_all, fetch_one
 from creator_service.workspace_service import workspace_service
 from fastapi import Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -173,7 +173,20 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
         if not member_workspace_ids:
             return JSONResponse(status_code=404, content={"detail": "Not found"})
 
-        user = CurrentUser(user_id=user_id_int, workspace_id=member_workspace_ids[0])
+        # Check for X-Workspace-Id header to pin to specific workspace
+        workspace_header = request.headers.get("X-Workspace-Id")
+        if workspace_header:
+            try:
+                requested_workspace_id = int(workspace_header)
+            except (TypeError, ValueError):
+                return JSONResponse(status_code=404, content={"detail": "Not found"})
+            if requested_workspace_id not in member_workspace_ids:
+                return JSONResponse(status_code=404, content={"detail": "Not found"})
+            selected_workspace_id = requested_workspace_id
+        else:
+            selected_workspace_id = member_workspace_ids[0]
+
+        user = CurrentUser(user_id=user_id_int, workspace_id=selected_workspace_id)
         request.state.user = user
         token = _current_user_ctx.set(user)
         try:
@@ -212,20 +225,36 @@ async def get_current_user(request: Request) -> CurrentUser:
         raise HTTPException(status_code=401, detail="Invalid API key")
 
     user_id = key_row["user_id"]
-    membership_row = await fetch_one(
+    
+    # Fetch all workspace memberships for this user
+    membership_rows = await fetch_all(
         """
         SELECT workspace_id
         FROM workspace_members
         WHERE user_id = $1
         ORDER BY workspace_id ASC
-        LIMIT 1
         """,
         user_id,
     )
-    if membership_row is None:
+    if not membership_rows:
         raise HTTPException(status_code=404, detail="Not found")
+    
+    member_workspace_ids = [row["workspace_id"] for row in membership_rows]
+    
+    # Check for X-Workspace-Id header to pin to specific workspace
+    workspace_header = request.headers.get("X-Workspace-Id")
+    if workspace_header:
+        try:
+            requested_workspace_id = int(workspace_header)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=404, detail="Not found")
+        if requested_workspace_id not in member_workspace_ids:
+            raise HTTPException(status_code=404, detail="Not found")
+        selected_workspace_id = requested_workspace_id
+    else:
+        selected_workspace_id = member_workspace_ids[0]
 
-    return CurrentUser(user_id=user_id, workspace_id=membership_row["workspace_id"])
+    return CurrentUser(user_id=user_id, workspace_id=selected_workspace_id)
 
 
 async def require_current_user(request: Request) -> CurrentUser:

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -327,11 +327,16 @@ async def test_get_current_user_resolves_from_api_keys_and_membership(monkeypatc
         calls.append((query, args))
         if "FROM api_keys" in query:
             return {"user_id": 123}
-        if "FROM workspace_members" in query:
-            return {"workspace_id": 10}
         return None
 
+    async def _fetch_all(query: str, *args):
+        calls.append((query, args))
+        if "FROM workspace_members" in query:
+            return [{"workspace_id": 10}]
+        return []
+
     monkeypatch.setattr("shorts_api.auth.fetch_one", _fetch_one)
+    monkeypatch.setattr("shorts_api.auth.fetch_all", _fetch_all)
     request = Request({"type": "http", "headers": [(b"x-api-key", b"valid-key")]})
     result = await get_current_user(request)
 
@@ -342,7 +347,28 @@ async def test_get_current_user_resolves_from_api_keys_and_membership(monkeypatc
 
 
 @pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_get_current_user_without_workspace_membership_returns_404(monkeypatch):
+    async def _fetch_one(query: str, *args):
+        if "FROM api_keys" in query:
+            return {"user_id": 123}
+        return None
+
+    async def _fetch_all(query: str, *args):
+        if "FROM workspace_members" in query:
+            return []
+        return []
+
+    monkeypatch.setattr("shorts_api.auth.fetch_one", _fetch_one)
+    monkeypatch.setattr("shorts_api.auth.fetch_all", _fetch_all)
+    request = Request({"type": "http", "headers": [(b"x-api-key", b"valid-key")]})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Not found"
+
+
     async def _fetch_one(query: str, *args):
         if "FROM api_keys" in query:
             return {"user_id": 123}

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -368,22 +368,6 @@ async def test_get_current_user_without_workspace_membership_returns_404(monkeyp
     assert exc_info.value.detail == "Not found"
 
 
-    async def _fetch_one(query: str, *args):
-        if "FROM api_keys" in query:
-            return {"user_id": 123}
-        if "FROM workspace_members" in query:
-            return None
-        return None
-
-    monkeypatch.setattr("shorts_api.auth.fetch_one", _fetch_one)
-    request = Request({"type": "http", "headers": [(b"x-api-key", b"valid-key")]})
-
-    with pytest.raises(HTTPException) as exc_info:
-        await get_current_user(request)
-    assert exc_info.value.status_code == 404
-    assert exc_info.value.detail == "Not found"
-
-
 @pytest.mark.asyncio
 async def test_require_workspace_access_denies_without_membership(monkeypatch):
     async def _no_access(_workspace_id: int, _user_id: int) -> bool:

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -347,7 +347,6 @@ async def test_get_current_user_resolves_from_api_keys_and_membership(monkeypatc
 
 
 @pytest.mark.asyncio
-@pytest.mark.asyncio
 async def test_get_current_user_without_workspace_membership_returns_404(monkeypatch):
     async def _fetch_one(query: str, *args):
         if "FROM api_keys" in query:
@@ -409,3 +408,106 @@ async def test_require_workspace_access_allows_with_membership(monkeypatch):
     result = await require_workspace_access(100, user)
     assert isinstance(result, CurrentUser)
     assert result.user_id == 2
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_with_valid_workspace_id_header(monkeypatch):
+    """Test that X-Workspace-Id header selects the correct workspace."""
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def _fetch_one(query: str, *args):
+        calls.append((query, args))
+        if "FROM api_keys" in query:
+            return {"user_id": 456}
+        return None
+
+    async def _fetch_all(query: str, *args):
+        calls.append((query, args))
+        if "FROM workspace_members" in query:
+            # User is a member of workspaces 10, 20, 30
+            return [
+                {"workspace_id": 10},
+                {"workspace_id": 20},
+                {"workspace_id": 30},
+            ]
+        return []
+
+    monkeypatch.setattr("shorts_api.auth.fetch_one", _fetch_one)
+    monkeypatch.setattr("shorts_api.auth.fetch_all", _fetch_all)
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"x-api-key", b"valid-key"),
+                (b"x-workspace-id", b"20"),
+            ],
+        }
+    )
+    result = await get_current_user(request)
+
+    assert isinstance(result, CurrentUser)
+    assert result.user_id == 456
+    assert result.workspace_id == 20
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_with_invalid_workspace_id_header_returns_404(monkeypatch):
+    """Test that non-numeric X-Workspace-Id header returns 404."""
+    async def _fetch_one(query: str, *args):
+        if "FROM api_keys" in query:
+            return {"user_id": 456}
+        return None
+
+    async def _fetch_all(query: str, *args):
+        if "FROM workspace_members" in query:
+            return [{"workspace_id": 10}, {"workspace_id": 20}]
+        return []
+
+    monkeypatch.setattr("shorts_api.auth.fetch_one", _fetch_one)
+    monkeypatch.setattr("shorts_api.auth.fetch_all", _fetch_all)
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"x-api-key", b"valid-key"),
+                (b"x-workspace-id", b"not-a-number"),
+            ],
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Not found"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_with_non_member_workspace_id_returns_404(monkeypatch):
+    """Test that X-Workspace-Id for non-member workspace returns 404."""
+    async def _fetch_one(query: str, *args):
+        if "FROM api_keys" in query:
+            return {"user_id": 456}
+        return None
+
+    async def _fetch_all(query: str, *args):
+        if "FROM workspace_members" in query:
+            # User is only a member of workspaces 10 and 20, not 999
+            return [{"workspace_id": 10}, {"workspace_id": 20}]
+        return []
+
+    monkeypatch.setattr("shorts_api.auth.fetch_one", _fetch_one)
+    monkeypatch.setattr("shorts_api.auth.fetch_all", _fetch_all)
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"x-api-key", b"valid-key"),
+                (b"x-workspace-id", b"999"),
+            ],
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Not found"

--- a/apps/api/tests/test_multi_workspace_auth.py
+++ b/apps/api/tests/test_multi_workspace_auth.py
@@ -1,0 +1,144 @@
+# pyright: reportMissingImports=false
+
+"""Tests for X-Workspace-Id header support in multi-workspace auth."""
+
+import hashlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from httpx import AsyncClient
+from shorts_api.auth import ApiKeyMiddleware, CurrentUser
+
+
+def _make_app() -> FastAPI:
+    """Create a minimal FastAPI app with the auth middleware."""
+    test_app = FastAPI()
+    test_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5174"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    test_app.add_middleware(ApiKeyMiddleware)
+
+    @test_app.get("/api/creator/test")
+    async def test_endpoint():
+        return {"status": "ok"}
+
+    return test_app
+
+
+@pytest.fixture
+def api_key():
+    return "test-multi-workspace-key"
+
+
+@pytest.fixture
+async def multi_workspace_client(api_key, monkeypatch: pytest.MonkeyPatch):
+    """Client for an app with multiple workspace memberships."""
+    expected_hash = hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+
+    class _Conn:
+        async def fetchrow(self, _query: str, key_hash: str):
+            if key_hash == expected_hash:
+                return {"user_id": 1}
+            return None
+
+        async def fetch(self, _query: str, user_id: int):
+            # Return multiple workspaces for the user
+            if user_id == 1:
+                return [
+                    {"workspace_id": 10},
+                    {"workspace_id": 20},
+                    {"workspace_id": 30},
+                ]
+            return []
+
+    class _Acquire:
+        async def __aenter__(self):
+            return _Conn()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            _ = (exc_type, exc, tb)
+            return False
+
+    class _Pool:
+        def acquire(self):
+            return _Acquire()
+
+    async def _get_pool(self):  # Accept self parameter
+        return _Pool()
+
+    monkeypatch.setattr(
+        "shorts_api.auth.ApiKeyMiddleware._get_pool",
+        _get_pool,
+    )
+
+    app = _make_app()
+    return AsyncClient(app=app, base_url="http://test"), api_key
+
+
+@pytest.mark.asyncio
+async def test_x_workspace_id_selects_correct_workspace(multi_workspace_client):
+    """Test that X-Workspace-Id header selects the specified workspace."""
+    client, api_key = multi_workspace_client
+    
+    response = await client.get(
+        "/api/creator/test",
+        headers={
+            "X-API-Key": api_key,
+            "X-Workspace-Id": "20",
+        },
+    )
+    
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_x_workspace_id_non_member_workspace_returns_404(multi_workspace_client):
+    """Test that X-Workspace-Id with non-member workspace returns 404."""
+    client, api_key = multi_workspace_client
+    
+    # User only has workspaces 10, 20, 30, not 999
+    response = await client.get(
+        "/api/creator/test",
+        headers={
+            "X-API-Key": api_key,
+            "X-Workspace-Id": "999",
+        },
+    )
+    
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_missing_x_workspace_id_falls_back_to_first_workspace(multi_workspace_client):
+    """Test that missing X-Workspace-Id falls back to first workspace."""
+    client, api_key = multi_workspace_client
+    
+    response = await client.get(
+        "/api/creator/test",
+        headers={
+            "X-API-Key": api_key,
+        },
+    )
+    
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_invalid_x_workspace_id_returns_404(multi_workspace_client):
+    """Test that invalid (non-numeric) X-Workspace-Id is rejected."""
+    client, api_key = multi_workspace_client
+    
+    response = await client.get(
+        "/api/creator/test",
+        headers={
+            "X-API-Key": api_key,
+            "X-Workspace-Id": "not-a-number",
+        },
+    )
+    
+    assert response.status_code == 404

--- a/apps/api/tests/test_multi_workspace_auth.py
+++ b/apps/api/tests/test_multi_workspace_auth.py
@@ -5,7 +5,7 @@
 import hashlib
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from httpx import AsyncClient
 from shorts_api.auth import ApiKeyMiddleware, CurrentUser
@@ -24,8 +24,9 @@ def _make_app() -> FastAPI:
     test_app.add_middleware(ApiKeyMiddleware)
 
     @test_app.get("/api/creator/test")
-    async def test_endpoint():
-        return {"status": "ok"}
+    async def test_endpoint(request: Request):
+        user = request.state.user
+        return {"status": "ok", "workspace_id": user.workspace_id}
 
     return test_app
 
@@ -94,6 +95,7 @@ async def test_x_workspace_id_selects_correct_workspace(multi_workspace_client):
     )
     
     assert response.status_code == 200
+    assert response.json()["workspace_id"] == 20
 
 
 @pytest.mark.asyncio
@@ -126,6 +128,7 @@ async def test_missing_x_workspace_id_falls_back_to_first_workspace(multi_worksp
     )
     
     assert response.status_code == 200
+    assert response.json()["workspace_id"] == 10
 
 
 @pytest.mark.asyncio
@@ -158,3 +161,4 @@ async def test_bearer_token_with_workspace_id_header(multi_workspace_client):
     )
     
     assert response.status_code == 200
+    assert response.json()["workspace_id"] == 20

--- a/apps/api/tests/test_multi_workspace_auth.py
+++ b/apps/api/tests/test_multi_workspace_auth.py
@@ -142,3 +142,19 @@ async def test_invalid_x_workspace_id_returns_404(multi_workspace_client):
     )
     
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_with_workspace_id_header(multi_workspace_client):
+    """Test that bearer token auth works with X-Workspace-Id header."""
+    client, api_key = multi_workspace_client
+    
+    response = await client.get(
+        "/api/creator/test",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "X-Workspace-Id": "20",
+        },
+    )
+    
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Both auth paths (middleware and get_current_user) now respect X-Workspace-Id header
- If header present, validates user has membership in requested workspace
- Falls back to first workspace when header absent (preserves existing behavior)
- Returns 404 (not 403) for anti-enumeration on invalid workspace

Closes #508