### PR TITLE
fix: move task revocation after service call success (#510)

### DIFF
--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -27,8 +27,6 @@ async def stop_run(
 ) -> dict[str, object]:
     user, run = access
 
-    await _revoke_active_tasks_for_run(run.id)
-
     try:
         updated = await run_service.stop_run(run_id, workspace_id=user.workspace_id)
     except ConflictError as exc:
@@ -38,6 +36,8 @@ async def stop_run(
         if "not found" in detail.lower():
             raise HTTPException(status_code=404, detail=detail) from exc
         raise HTTPException(status_code=400, detail=detail) from exc
+
+    await _revoke_active_tasks_for_run(run.id)
 
     return updated.model_dump(mode="json")
 
@@ -105,8 +105,6 @@ async def delete_run(
 ) -> dict[str, object]:
     user, run = access
 
-    await _revoke_active_tasks_for_run(run.id)
-
     try:
         deleted = await run_service.delete_run(run_id, workspace_id=user.workspace_id)
     except ValueError as exc:
@@ -114,6 +112,7 @@ async def delete_run(
     if not deleted:
         raise HTTPException(status_code=404, detail="Run not found")
 
+    await _revoke_active_tasks_for_run(run.id)
     await artifact_download_service.delete_artifacts_for_run(run_id)
 
     return {"deleted": True, "run_id": run_id}

--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -13,7 +13,9 @@ if TYPE_CHECKING:
 
 from shorts_api.routes.creator_runs_core import UpdateModelDefaultsRequest
 from shorts_api.routes.creator_runs_utils import (
+    _collect_active_celery_ids,
     _revoke_active_tasks_for_run,
+    _revoke_celery_ids,
     validate_model_defaults,
 )
 from shorts_api.auth import CurrentUser, require_run_access
@@ -105,6 +107,9 @@ async def delete_run(
 ) -> dict[str, object]:
     user, run = access
 
+    # Capture active task IDs BEFORE delete (CASCADE removes task rows)
+    celery_ids = await _collect_active_celery_ids(run.id)
+
     try:
         deleted = await run_service.delete_run(run_id, workspace_id=user.workspace_id)
     except ValueError as exc:
@@ -112,7 +117,7 @@ async def delete_run(
     if not deleted:
         raise HTTPException(status_code=404, detail="Run not found")
 
-    await _revoke_active_tasks_for_run(run.id)
+    await _revoke_celery_ids(celery_ids, run.id)
     await artifact_download_service.delete_artifacts_for_run(run_id)
 
     return {"deleted": True, "run_id": run_id}

--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -116,7 +116,10 @@ async def delete_run(
             run_id, {"status": "cancelled"}, workspace_id=user.workspace_id
         )
     except Exception:
-        pass  # Best-effort — run will be deleted shortly anyway
+        raise HTTPException(
+            status_code=503,
+            detail="Unable to mark run as cancelled before deletion; retry later",
+        ) from None
     collect_result = await _collect_active_celery_ids(run.id)
     if isinstance(collect_result, tuple):
         celery_ids, collect_reliable = collect_result

--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -107,7 +107,12 @@ async def delete_run(
 ) -> dict[str, object]:
     user, run = access
 
-    # Capture active task IDs BEFORE delete (CASCADE removes task rows)
+    # Stop run first to prevent new task dispatch, then collect active IDs
+    # before CASCADE removes task rows on delete.
+    try:
+        await run_service.stop_run(run_id, workspace_id=user.workspace_id)
+    except (ConflictError, ValueError):
+        pass  # Already stopped or in terminal state — safe to proceed
     celery_ids = await _collect_active_celery_ids(run.id)
 
     try:

--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -113,7 +113,12 @@ async def delete_run(
         await run_service.stop_run(run_id, workspace_id=user.workspace_id)
     except (ConflictError, ValueError):
         pass  # Already stopped or in terminal state — safe to proceed
-    celery_ids = await _collect_active_celery_ids(run.id)
+    collect_result = await _collect_active_celery_ids(run.id)
+    if isinstance(collect_result, tuple):
+        celery_ids, collect_reliable = collect_result
+    else:
+        celery_ids = collect_result
+        collect_reliable = True
 
     try:
         deleted = await run_service.delete_run(run_id, workspace_id=user.workspace_id)
@@ -122,7 +127,12 @@ async def delete_run(
     if not deleted:
         raise HTTPException(status_code=404, detail="Run not found")
 
-    await _revoke_celery_ids(celery_ids, run.id)
+    revoke_result = await _revoke_celery_ids(celery_ids, run.id)
+    revoke_reliable = bool(revoke_result) if revoke_result is not None else True
     await artifact_download_service.delete_artifacts_for_run(run_id)
 
-    return {"deleted": True, "run_id": run_id}
+    return {
+        "deleted": True,
+        "run_id": run_id,
+        "revoke_reliable": collect_reliable and revoke_reliable,
+    }

--- a/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_lifecycle.py
@@ -107,12 +107,16 @@ async def delete_run(
 ) -> dict[str, object]:
     user, run = access
 
-    # Stop run first to prevent new task dispatch, then collect active IDs
-    # before CASCADE removes task rows on delete.
+    # Mark run as cancelled to block any concurrent dispatch attempts.
+    # Unlike stop_run() which only works during generating stages, this
+    # works from any stage (including review stages where storyboard
+    # dispatch is allowed).
     try:
-        await run_service.stop_run(run_id, workspace_id=user.workspace_id)
-    except (ConflictError, ValueError):
-        pass  # Already stopped or in terminal state — safe to proceed
+        await run_service.storage.update_run(
+            run_id, {"status": "cancelled"}, workspace_id=user.workspace_id
+        )
+    except Exception:
+        pass  # Best-effort — run will be deleted shortly anyway
     collect_result = await _collect_active_celery_ids(run.id)
     if isinstance(collect_result, tuple):
         celery_ids, collect_reliable = collect_result

--- a/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
@@ -51,7 +51,14 @@ async def _get_fresh_run_for_dispatch(run_id: int, workspace_id: int) -> Pipelin
     try:
         return await run_service.get_run(run_id, workspace_id=workspace_id)
     except TypeError:
-        return await run_service.get_run(run_id)
+        try:
+            return await run_service.get_run(run_id)
+        except Exception:
+            logger.warning("Failed to re-read run %s for dispatch check (fallback)", run_id, exc_info=True)
+            return None
+    except Exception:
+        logger.warning("Failed to re-read run %s for dispatch check", run_id, exc_info=True)
+        return None
 
 
 class ParagraphAudioRequest(BaseModel):

--- a/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
@@ -225,6 +225,13 @@ async def generate_paragraph_audio_endpoint(
             ),
         )
 
+    if getattr(run, "status", None) == "cancelled":
+        raise HTTPException(
+            status_code=409,
+            detail="Run is cancelled; cannot dispatch new tasks",
+        )
+
+
     draft = await script_service.get_active_draft(run_id)
     if draft is None or not draft.structured_script:
         raise HTTPException(status_code=400, detail="No script available")
@@ -286,6 +293,13 @@ async def generate_paragraph_subtitles_endpoint(
             ),
         )
 
+    if getattr(run, "status", None) == "cancelled":
+        raise HTTPException(
+            status_code=409,
+            detail="Run is cancelled; cannot dispatch new tasks",
+        )
+
+
     audio = await audio_service.get_paragraph_audio(run_id, section_id)
     if audio is None:
         raise HTTPException(
@@ -337,6 +351,13 @@ async def generate_all_paragraph_audio(
                 "Pipeline must be past visual asset review."
             ),
         )
+
+    if getattr(run, "status", None) == "cancelled":
+        raise HTTPException(
+            status_code=409,
+            detail="Run is cancelled; cannot dispatch new tasks",
+        )
+
 
     draft = await script_service.get_active_draft(run_id)
     if draft is None or not draft.structured_script:
@@ -400,6 +421,13 @@ async def generate_all_paragraph_subtitles(
                 "Pipeline must be past visual asset review."
             ),
         )
+
+    if getattr(run, "status", None) == "cancelled":
+        raise HTTPException(
+            status_code=409,
+            detail="Run is cancelled; cannot dispatch new tasks",
+        )
+
 
     audio_artifacts = await audio_service.list_paragraph_audio(run_id)
     if not audio_artifacts:

--- a/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
@@ -282,6 +282,10 @@ async def generate_paragraph_audio_endpoint(
         try:
             celery_app = __import__("celery_app").celery_app
             celery_app.control.revoke(task_id, terminate=True)
+            try:
+                await task_tracking_service.mark_tasks_revoked([task_id])
+            except Exception:
+                logger.warning("Failed to mark task %s as revoked in tracking", task_id)
         except Exception:
             logger.warning("Failed to revoke untracked task %s for run %d", task_id, run_id)
         await cancel_workspace_quota_reservation(user.workspace_id, "tts")
@@ -297,6 +301,10 @@ async def generate_paragraph_audio_endpoint(
         try:
             celery_app = __import__("celery_app").celery_app
             celery_app.control.revoke(task_id, terminate=True)
+            try:
+                await task_tracking_service.mark_tasks_revoked([task_id])
+            except Exception:
+                logger.warning("Failed to mark task %s as revoked in tracking", task_id)
         except Exception:
             logger.warning(
                 "Failed to revoke task %s after concurrent cancel for run %d", task_id, run_id
@@ -378,6 +386,10 @@ async def generate_paragraph_subtitles_endpoint(
         try:
             celery_app = __import__("celery_app").celery_app
             celery_app.control.revoke(task_id, terminate=True)
+            try:
+                await task_tracking_service.mark_tasks_revoked([task_id])
+            except Exception:
+                logger.warning("Failed to mark task %s as revoked in tracking", task_id)
         except Exception:
             logger.warning("Failed to revoke untracked task %s for run %d", task_id, run_id)
         await cancel_workspace_quota_reservation(user.workspace_id, "stt")
@@ -393,6 +405,10 @@ async def generate_paragraph_subtitles_endpoint(
         try:
             celery_app = __import__("celery_app").celery_app
             celery_app.control.revoke(task_id, terminate=True)
+            try:
+                await task_tracking_service.mark_tasks_revoked([task_id])
+            except Exception:
+                logger.warning("Failed to mark task %s as revoked in tracking", task_id)
         except Exception:
             logger.warning(
                 "Failed to revoke task %s after concurrent cancel for run %d", task_id, run_id
@@ -482,6 +498,10 @@ async def generate_all_paragraph_audio(
             try:
                 celery_app = __import__("celery_app").celery_app
                 celery_app.control.revoke(tid, terminate=True)
+                try:
+                    await task_tracking_service.mark_tasks_revoked([tid])
+                except Exception:
+                    logger.warning("Failed to mark task %s as revoked in tracking", tid)
             except Exception:
                 logger.warning("Failed to revoke untracked task %s for run %d", tid, run_id)
             await cancel_workspace_quota_reservation(user.workspace_id, "tts")
@@ -498,6 +518,10 @@ async def generate_all_paragraph_audio(
             try:
                 celery_app = __import__("celery_app").celery_app
                 celery_app.control.revoke(tid, terminate=True)
+                try:
+                    await task_tracking_service.mark_tasks_revoked([tid])
+                except Exception:
+                    logger.warning("Failed to mark task %s as revoked in tracking", tid)
             except Exception:
                 logger.warning(
                     "Failed to revoke task %s after concurrent cancel for run %d", tid, run_id
@@ -602,6 +626,10 @@ async def generate_all_paragraph_subtitles(
             try:
                 celery_app = __import__("celery_app").celery_app
                 celery_app.control.revoke(tid, terminate=True)
+                try:
+                    await task_tracking_service.mark_tasks_revoked([tid])
+                except Exception:
+                    logger.warning("Failed to mark task %s as revoked in tracking", tid)
             except Exception:
                 logger.warning("Failed to revoke untracked task %s for run %d", tid, run_id)
             await cancel_workspace_quota_reservation(user.workspace_id, "stt")
@@ -620,6 +648,10 @@ async def generate_all_paragraph_subtitles(
             try:
                 celery_app = __import__("celery_app").celery_app
                 celery_app.control.revoke(tid, terminate=True)
+                try:
+                    await task_tracking_service.mark_tasks_revoked([tid])
+                except Exception:
+                    logger.warning("Failed to mark task %s as revoked in tracking", tid)
             except Exception:
                 logger.warning(
                     "Failed to revoke task %s after concurrent cancel for run %d", tid, run_id

--- a/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
@@ -289,6 +289,21 @@ async def generate_paragraph_audio_endpoint(
             status_code=503,
             detail="Failed to enqueue paragraph audio task",
         ) from None
+
+    # Post-dispatch: close TOCTOU window — if run was cancelled between
+    # pre-check and dispatch, revoke the just-dispatched task immediately.
+    post_run = await _get_fresh_run_for_dispatch(run_id, user.workspace_id)
+    if post_run is None or getattr(post_run, "status", None) == "cancelled":
+        try:
+            celery_app = __import__("celery_app").celery_app
+            celery_app.control.revoke(task_id, terminate=True)
+        except Exception:
+            logger.warning(
+                "Failed to revoke task %s after concurrent cancel for run %d", task_id, run_id
+            )
+        await cancel_workspace_quota_reservation(user.workspace_id, "tts")
+        raise HTTPException(status_code=409, detail="Run was cancelled during dispatch")
+
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -370,6 +385,21 @@ async def generate_paragraph_subtitles_endpoint(
             status_code=503,
             detail="Failed to enqueue paragraph subtitle task",
         ) from None
+
+    # Post-dispatch: close TOCTOU window — if run was cancelled between
+    # pre-check and dispatch, revoke the just-dispatched task immediately.
+    post_run = await _get_fresh_run_for_dispatch(run_id, user.workspace_id)
+    if post_run is None or getattr(post_run, "status", None) == "cancelled":
+        try:
+            celery_app = __import__("celery_app").celery_app
+            celery_app.control.revoke(task_id, terminate=True)
+        except Exception:
+            logger.warning(
+                "Failed to revoke task %s after concurrent cancel for run %d", task_id, run_id
+            )
+        await cancel_workspace_quota_reservation(user.workspace_id, "stt")
+        raise HTTPException(status_code=409, detail="Run was cancelled during dispatch")
+
     return {
         "task_id": task_id,
         "run_id": run_id,
@@ -448,7 +478,6 @@ async def generate_all_paragraph_audio(
 
         try:
             await task_tracking_service.record_task_queued(run_id, "generate_paragraph_audio", tid)
-            task_ids.append({"section_id": section.section_id, "task_id": tid})
         except Exception:
             try:
                 celery_app = __import__("celery_app").celery_app
@@ -462,6 +491,21 @@ async def generate_all_paragraph_audio(
             task_ids.append(
                 {"section_id": section.section_id, "task_id": "", "error": "dispatch_failed"}
             )
+            continue
+
+        post_run = await _get_fresh_run_for_dispatch(run_id, user.workspace_id)
+        if post_run is None or getattr(post_run, "status", None) == "cancelled":
+            try:
+                celery_app = __import__("celery_app").celery_app
+                celery_app.control.revoke(tid, terminate=True)
+            except Exception:
+                logger.warning(
+                    "Failed to revoke task %s after concurrent cancel for run %d", tid, run_id
+                )
+            await cancel_workspace_quota_reservation(user.workspace_id, "tts")
+            raise HTTPException(status_code=409, detail="Run was cancelled during dispatch")
+
+        task_ids.append({"section_id": section.section_id, "task_id": tid})
     failed_count = sum(1 for t in task_ids if "error" in t)
     return {
         "run_id": run_id,
@@ -554,7 +598,6 @@ async def generate_all_paragraph_subtitles(
             await task_tracking_service.record_task_queued(
                 run_id, "generate_paragraph_subtitles", tid
             )
-            task_ids.append({"section_id": audio.section_id, "task_id": tid})
         except Exception:
             try:
                 celery_app = __import__("celery_app").celery_app
@@ -570,6 +613,21 @@ async def generate_all_paragraph_subtitles(
             task_ids.append(
                 {"section_id": audio.section_id, "task_id": "", "error": "dispatch_failed"}
             )
+            continue
+
+        post_run = await _get_fresh_run_for_dispatch(run_id, user.workspace_id)
+        if post_run is None or getattr(post_run, "status", None) == "cancelled":
+            try:
+                celery_app = __import__("celery_app").celery_app
+                celery_app.control.revoke(tid, terminate=True)
+            except Exception:
+                logger.warning(
+                    "Failed to revoke task %s after concurrent cancel for run %d", tid, run_id
+                )
+            await cancel_workspace_quota_reservation(user.workspace_id, "stt")
+            raise HTTPException(status_code=409, detail="Run was cancelled during dispatch")
+
+        task_ids.append({"section_id": audio.section_id, "task_id": tid})
     failed_count = sum(1 for t in task_ids if "error" in t)
     return {
         "run_id": run_id,

--- a/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_storyboard.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Literal
 
 from creator_service.audio_service import audio_service
+from creator_service.run_service import run_service
 from creator_service.script_service import script_service
 from creator_service.subtitle_service import subtitle_service
 from creator_service.task_tracking_service import task_tracking_service
@@ -44,6 +45,13 @@ STORYBOARD_ALLOWED_STAGES = frozenset(
 )
 
 router = APIRouter(tags=["runs"])
+
+
+async def _get_fresh_run_for_dispatch(run_id: int, workspace_id: int) -> PipelineRun | Any | None:
+    try:
+        return await run_service.get_run(run_id, workspace_id=workspace_id)
+    except TypeError:
+        return await run_service.get_run(run_id)
 
 
 class ParagraphAudioRequest(BaseModel):
@@ -231,7 +239,6 @@ async def generate_paragraph_audio_endpoint(
             detail="Run is cancelled; cannot dispatch new tasks",
         )
 
-
     draft = await script_service.get_active_draft(run_id)
     if draft is None or not draft.structured_script:
         raise HTTPException(status_code=400, detail="No script available")
@@ -250,6 +257,11 @@ async def generate_paragraph_audio_endpoint(
     if not allowed:
         raise HTTPException(status_code=429, detail=reason)
 
+    fresh_run = await _get_fresh_run_for_dispatch(run_id, user.workspace_id)
+    if fresh_run is None or getattr(fresh_run, "status", None) == "cancelled":
+        await cancel_workspace_quota_reservation(user.workspace_id, "tts")
+        raise HTTPException(status_code=409, detail="Run was cancelled before dispatch")
+
     try:
         task_id = dispatch_paragraph_audio(
             run_id=run_id,
@@ -257,8 +269,21 @@ async def generate_paragraph_audio_endpoint(
             tts_model=effective.tts_model,
             voice=effective.voice,
         )
+    except Exception:
+        await cancel_workspace_quota_reservation(user.workspace_id, "tts")
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue paragraph audio task",
+        ) from None
+
+    try:
         await task_tracking_service.record_task_queued(run_id, "generate_paragraph_audio", task_id)
     except Exception:
+        try:
+            celery_app = __import__("celery_app").celery_app
+            celery_app.control.revoke(task_id, terminate=True)
+        except Exception:
+            logger.warning("Failed to revoke untracked task %s for run %d", task_id, run_id)
         await cancel_workspace_quota_reservation(user.workspace_id, "tts")
         raise HTTPException(
             status_code=503,
@@ -299,7 +324,6 @@ async def generate_paragraph_subtitles_endpoint(
             detail="Run is cancelled; cannot dispatch new tasks",
         )
 
-
     audio = await audio_service.get_paragraph_audio(run_id, section_id)
     if audio is None:
         raise HTTPException(
@@ -312,6 +336,11 @@ async def generate_paragraph_subtitles_endpoint(
     if not allowed:
         raise HTTPException(status_code=429, detail=reason)
 
+    fresh_run = await _get_fresh_run_for_dispatch(run_id, user.workspace_id)
+    if fresh_run is None or getattr(fresh_run, "status", None) == "cancelled":
+        await cancel_workspace_quota_reservation(user.workspace_id, "stt")
+        raise HTTPException(status_code=409, detail="Run was cancelled before dispatch")
+
     try:
         task_id = dispatch_paragraph_subtitles(
             run_id=run_id,
@@ -319,10 +348,23 @@ async def generate_paragraph_subtitles_endpoint(
             subtitle_model=effective.subtitle_model,
             subtitle_format=effective.subtitle_format,
         )
+    except Exception:
+        await cancel_workspace_quota_reservation(user.workspace_id, "stt")
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue paragraph subtitle task",
+        ) from None
+
+    try:
         await task_tracking_service.record_task_queued(
             run_id, "generate_paragraph_subtitles", task_id
         )
     except Exception:
+        try:
+            celery_app = __import__("celery_app").celery_app
+            celery_app.control.revoke(task_id, terminate=True)
+        except Exception:
+            logger.warning("Failed to revoke untracked task %s for run %d", task_id, run_id)
         await cancel_workspace_quota_reservation(user.workspace_id, "stt")
         raise HTTPException(
             status_code=503,
@@ -358,7 +400,6 @@ async def generate_all_paragraph_audio(
             detail="Run is cancelled; cannot dispatch new tasks",
         )
 
-
     draft = await script_service.get_active_draft(run_id)
     if draft is None or not draft.structured_script:
         raise HTTPException(status_code=400, detail="No script available")
@@ -379,6 +420,15 @@ async def generate_all_paragraph_audio(
         allowed, reason = await check_workspace_quota(user.workspace_id, operation_type="tts")
         if not allowed:
             raise HTTPException(status_code=429, detail=reason)
+
+        fresh_run = await _get_fresh_run_for_dispatch(run_id, user.workspace_id)
+        if fresh_run is None or getattr(fresh_run, "status", None) == "cancelled":
+            await cancel_workspace_quota_reservation(user.workspace_id, "tts")
+            task_ids.append(
+                {"section_id": section.section_id, "task_id": "", "error": "dispatch_failed"}
+            )
+            continue
+
         try:
             tid = dispatch_paragraph_audio(
                 run_id=run_id,
@@ -386,12 +436,28 @@ async def generate_all_paragraph_audio(
                 tts_model=effective.tts_model,
                 voice=effective.voice,
             )
-            await task_tracking_service.record_task_queued(run_id, "generate_paragraph_audio", tid)
-            task_ids.append({"section_id": section.section_id, "task_id": tid})
         except Exception:
             await cancel_workspace_quota_reservation(user.workspace_id, "tts")
             logger.exception(
                 "Failed to dispatch audio task for section %s of run %s", section.section_id, run_id
+            )
+            task_ids.append(
+                {"section_id": section.section_id, "task_id": "", "error": "dispatch_failed"}
+            )
+            continue
+
+        try:
+            await task_tracking_service.record_task_queued(run_id, "generate_paragraph_audio", tid)
+            task_ids.append({"section_id": section.section_id, "task_id": tid})
+        except Exception:
+            try:
+                celery_app = __import__("celery_app").celery_app
+                celery_app.control.revoke(tid, terminate=True)
+            except Exception:
+                logger.warning("Failed to revoke untracked task %s for run %d", tid, run_id)
+            await cancel_workspace_quota_reservation(user.workspace_id, "tts")
+            logger.exception(
+                "Failed to track audio task for section %s of run %s", section.section_id, run_id
             )
             task_ids.append(
                 {"section_id": section.section_id, "task_id": "", "error": "dispatch_failed"}
@@ -428,7 +494,6 @@ async def generate_all_paragraph_subtitles(
             detail="Run is cancelled; cannot dispatch new tasks",
         )
 
-
     audio_artifacts = await audio_service.list_paragraph_audio(run_id)
     if not audio_artifacts:
         raise HTTPException(
@@ -457,6 +522,15 @@ async def generate_all_paragraph_subtitles(
         allowed, reason = await check_workspace_quota(user.workspace_id, operation_type="stt")
         if not allowed:
             raise HTTPException(status_code=429, detail=reason)
+
+        fresh_run = await _get_fresh_run_for_dispatch(run_id, user.workspace_id)
+        if fresh_run is None or getattr(fresh_run, "status", None) == "cancelled":
+            await cancel_workspace_quota_reservation(user.workspace_id, "stt")
+            task_ids.append(
+                {"section_id": audio.section_id, "task_id": "", "error": "dispatch_failed"}
+            )
+            continue
+
         try:
             tid = dispatch_paragraph_subtitles(
                 run_id=run_id,
@@ -464,14 +538,32 @@ async def generate_all_paragraph_subtitles(
                 subtitle_model=effective.subtitle_model,
                 subtitle_format=effective.subtitle_format,
             )
+        except Exception:
+            await cancel_workspace_quota_reservation(user.workspace_id, "stt")
+            logger.exception(
+                "Failed to dispatch subtitle task for section %s of run %s",
+                audio.section_id,
+                run_id,
+            )
+            task_ids.append(
+                {"section_id": audio.section_id, "task_id": "", "error": "dispatch_failed"}
+            )
+            continue
+
+        try:
             await task_tracking_service.record_task_queued(
                 run_id, "generate_paragraph_subtitles", tid
             )
             task_ids.append({"section_id": audio.section_id, "task_id": tid})
         except Exception:
+            try:
+                celery_app = __import__("celery_app").celery_app
+                celery_app.control.revoke(tid, terminate=True)
+            except Exception:
+                logger.warning("Failed to revoke untracked task %s for run %d", tid, run_id)
             await cancel_workspace_quota_reservation(user.workspace_id, "stt")
             logger.exception(
-                "Failed to dispatch subtitle task for section %s of run %s",
+                "Failed to track subtitle task for section %s of run %s",
                 audio.section_id,
                 run_id,
             )

--- a/apps/api/src/shorts_api/routes/creator_runs_utils.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_utils.py
@@ -148,3 +148,41 @@ def validate_path_id(value: str, name: str = "id") -> str:
             detail=f"Invalid {name}: must be 1-128 alphanumeric chars, hyphens, or underscores",
         )
     return value
+
+
+async def _collect_active_celery_ids(run_id: int) -> list[str]:
+    """Capture active Celery task IDs for a run before deletion.
+
+    Must be called BEFORE deleting the run, since CASCADE will remove
+    task tracking rows.
+    """
+    try:
+        tracking_service = import_module(
+            "creator_service.task_tracking_service"
+        ).task_tracking_service
+        return await tracking_service.get_active_celery_ids(run_id)
+    except Exception:
+        logger.warning("Failed to collect active task IDs for run %d", run_id, exc_info=True)
+        return []
+
+
+async def _revoke_celery_ids(celery_ids: list[str], run_id: int) -> None:
+    """Revoke pre-captured Celery task IDs and mark them revoked."""
+    if not celery_ids:
+        return
+    try:
+        celery_app = __import__("celery_app").celery_app
+        tracking_service = import_module(
+            "creator_service.task_tracking_service"
+        ).task_tracking_service
+        revoked: list[str] = []
+        for tid in celery_ids:
+            try:
+                celery_app.control.revoke(tid, terminate=True)
+                revoked.append(tid)
+            except Exception:
+                logger.warning("Failed to revoke celery task %s for run %d", tid, run_id, exc_info=True)
+        if revoked:
+            await tracking_service.mark_tasks_revoked(revoked)
+    except Exception:
+        logger.warning("Failed to revoke captured tasks for run %d", run_id, exc_info=True)

--- a/apps/api/src/shorts_api/routes/creator_runs_utils.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_utils.py
@@ -107,7 +107,7 @@ def validate_model_defaults(model_defaults: Mapping[str, str] | None) -> None:
 
 async def _revoke_active_tasks_for_run(run_id: int) -> None:
     """Collect and revoke active tasks for a run (use when run still exists)."""
-    celery_ids = await _collect_active_celery_ids(run_id)
+    celery_ids, _ = await _collect_active_celery_ids(run_id)
     await _revoke_celery_ids(celery_ids, run_id)
 
 
@@ -131,7 +131,7 @@ def validate_path_id(value: str, name: str = "id") -> str:
     return value
 
 
-async def _collect_active_celery_ids(run_id: int) -> list[str]:
+async def _collect_active_celery_ids(run_id: int) -> tuple[list[str], bool]:
     """Capture active Celery task IDs for a run before deletion.
 
     Must be called BEFORE deleting the run, since CASCADE will remove
@@ -141,29 +141,36 @@ async def _collect_active_celery_ids(run_id: int) -> list[str]:
         tracking_service = import_module(
             "creator_service.task_tracking_service"
         ).task_tracking_service
-        return await tracking_service.get_active_celery_ids(run_id)
+        ids = await tracking_service.get_active_celery_ids(run_id)
+        return ids, True
     except Exception:
         logger.warning("Failed to collect active task IDs for run %d", run_id, exc_info=True)
-        return []
+        return [], False
 
 
-async def _revoke_celery_ids(celery_ids: list[str], run_id: int) -> None:
+async def _revoke_celery_ids(celery_ids: list[str], run_id: int) -> bool:
     """Revoke pre-captured Celery task IDs and mark them revoked."""
     if not celery_ids:
-        return
+        return True
     try:
         celery_app = __import__("celery_app").celery_app
         tracking_service = import_module(
             "creator_service.task_tracking_service"
         ).task_tracking_service
         revoked: list[str] = []
+        all_ok = True
         for tid in celery_ids:
             try:
                 celery_app.control.revoke(tid, terminate=True)
                 revoked.append(tid)
             except Exception:
-                logger.warning("Failed to revoke celery task %s for run %d", tid, run_id, exc_info=True)
+                all_ok = False
+                logger.warning(
+                    "Failed to revoke celery task %s for run %d", tid, run_id, exc_info=True
+                )
         if revoked:
             await tracking_service.mark_tasks_revoked(revoked)
+        return all_ok
     except Exception:
         logger.warning("Failed to revoke captured tasks for run %d", run_id, exc_info=True)
+        return False

--- a/apps/api/src/shorts_api/routes/creator_runs_utils.py
+++ b/apps/api/src/shorts_api/routes/creator_runs_utils.py
@@ -106,28 +106,9 @@ def validate_model_defaults(model_defaults: Mapping[str, str] | None) -> None:
 
 
 async def _revoke_active_tasks_for_run(run_id: int) -> None:
-    try:
-        celery_app = __import__("celery_app").celery_app
-        tracking_service = import_module(
-            "creator_service.task_tracking_service"
-        ).task_tracking_service
-        celery_ids = await tracking_service.revoke_active_tasks(run_id)
-        revoked_ids: list[str] = []
-        for tid in celery_ids:
-            try:
-                celery_app.control.revoke(tid, terminate=True)
-                revoked_ids.append(tid)
-            except Exception:
-                logger.warning(
-                    "Failed to revoke celery task %s for run %d",
-                    tid,
-                    run_id,
-                    exc_info=True,
-                )
-        if revoked_ids:
-            await tracking_service.mark_tasks_revoked(revoked_ids)
-    except Exception:
-        logger.warning("Failed to revoke active tasks for run %d", run_id, exc_info=True)
+    """Collect and revoke active tasks for a run (use when run still exists)."""
+    celery_ids = await _collect_active_celery_ids(run_id)
+    await _revoke_celery_ids(celery_ids, run_id)
 
 
 async def _has_active_tasks_for_run(run_id: int) -> bool:

--- a/apps/api/tests/test_creator_runs_utils_revoke.py
+++ b/apps/api/tests/test_creator_runs_utils_revoke.py
@@ -12,6 +12,9 @@ class _TrackingServiceStub:
     def __init__(self) -> None:
         self.marked: list[str] = []
 
+    async def get_active_celery_ids(self, _run_id: int) -> list[str]:
+        return ["ok-1", "fail-1", "ok-2"]
+
     async def revoke_active_tasks(self, _run_id: int) -> list[str]:
         return ["ok-1", "fail-1", "ok-2"]
 

--- a/apps/api/tests/test_creator_runs_utils_revoke.py
+++ b/apps/api/tests/test_creator_runs_utils_revoke.py
@@ -22,6 +22,20 @@ class _TrackingServiceStub:
         self.marked.extend(celery_ids)
 
 
+class _TrackingServiceSingleStub:
+    def __init__(self, ids: list[str] | Exception) -> None:
+        self._ids = ids
+        self.marked: list[str] = []
+
+    async def get_active_celery_ids(self, _run_id: int) -> list[str]:
+        if isinstance(self._ids, Exception):
+            raise self._ids
+        return self._ids
+
+    async def mark_tasks_revoked(self, celery_ids: list[str]) -> None:
+        self.marked.extend(celery_ids)
+
+
 class _ControlStub:
     def __init__(self) -> None:
         self.calls: list[str] = []
@@ -58,3 +72,81 @@ async def test_revoke_active_tasks_marks_only_successful_broker_revokes(
 
     assert control.calls == ["ok-1", "fail-1", "ok-2"]
     assert tracking.marked == ["ok-1", "ok-2"]
+
+
+@pytest.mark.asyncio
+async def test_collect_active_celery_ids_returns_tuple_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracking = _TrackingServiceSingleStub(["id-1"])
+    monkeypatch.setattr(
+        creator_runs_utils,
+        "import_module",
+        lambda _name: SimpleNamespace(task_tracking_service=tracking),
+    )
+    result = await creator_runs_utils._collect_active_celery_ids(1)
+    assert result == (["id-1"], True)
+
+
+@pytest.mark.asyncio
+async def test_collect_active_celery_ids_returns_tuple_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracking = _TrackingServiceSingleStub(RuntimeError("db down"))
+    monkeypatch.setattr(
+        creator_runs_utils,
+        "import_module",
+        lambda _name: SimpleNamespace(task_tracking_service=tracking),
+    )
+    result = await creator_runs_utils._collect_active_celery_ids(1)
+    assert result == ([], False)
+
+
+@pytest.mark.asyncio
+async def test_revoke_celery_ids_returns_true_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracking = _TrackingServiceSingleStub(["id-1", "id-2"])
+    control = _ControlStub()
+    celery_app = SimpleNamespace(control=control)
+
+    monkeypatch.setattr(
+        creator_runs_utils,
+        "import_module",
+        lambda _name: SimpleNamespace(task_tracking_service=tracking),
+    )
+    original_import = builtins.__import__
+
+    def _import(name: str, *args, **kwargs):
+        if name == "celery_app":
+            return SimpleNamespace(celery_app=celery_app)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+    result = await creator_runs_utils._revoke_celery_ids(["id-1", "id-2"], 1)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_celery_ids_returns_false_on_partial_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracking = _TrackingServiceSingleStub(["ok-1", "fail-1", "ok-2"])
+    control = _ControlStub()
+    celery_app = SimpleNamespace(control=control)
+
+    monkeypatch.setattr(
+        creator_runs_utils,
+        "import_module",
+        lambda _name: SimpleNamespace(task_tracking_service=tracking),
+    )
+    original_import = builtins.__import__
+
+    def _import(name: str, *args, **kwargs):
+        if name == "celery_app":
+            return SimpleNamespace(celery_app=celery_app)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+    result = await creator_runs_utils._revoke_celery_ids(["ok-1", "fail-1", "ok-2"], 1)
+    assert result is False

--- a/apps/api/tests/test_lifecycle.py
+++ b/apps/api/tests/test_lifecycle.py
@@ -154,6 +154,25 @@ class StubRevokeTasks:
         self.calls.append(run_id)
 
 
+class StubCollectCeleryIds:
+    """Stub for _collect_active_celery_ids — returns empty list by default."""
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    async def __call__(self, run_id: int) -> list[str]:
+        self.calls.append(run_id)
+        return []
+
+
+class StubRevokeCeleryIds:
+    """Stub for _revoke_celery_ids — tracks calls."""
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], int]] = []
+
+    async def __call__(self, celery_ids: list[str], run_id: int) -> None:
+        self.calls.append((celery_ids, run_id))
+
+
 class StubArtifactLifecycleService:
     def __init__(self) -> None:
         self.delete_artifacts_for_run_calls: list[int] = []
@@ -191,6 +210,12 @@ def stub_lifecycle_services(
             monkeypatch.setitem(route.endpoint.__globals__, "run_service", run_svc)
             monkeypatch.setitem(
                 route.endpoint.__globals__, "_revoke_active_tasks_for_run", revoke_tasks
+            )
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "_collect_active_celery_ids", StubCollectCeleryIds()
+            )
+            monkeypatch.setitem(
+                route.endpoint.__globals__, "_revoke_celery_ids", StubRevokeCeleryIds()
             )
             monkeypatch.setitem(
                 route.endpoint.__globals__, "artifact_download_service", artifact_lifecycle_svc
@@ -461,7 +486,8 @@ async def test_delete_run_success_with_artifact_cleanup(client, stub_lifecycle_s
 
     assert response.status_code == 200
     assert response.json() == {"deleted": True, "run_id": 17}
-    assert revoke_tasks.calls == [17]
+    # delete_run now uses _collect_active_celery_ids + _revoke_celery_ids (not _revoke_active_tasks_for_run)
+    assert revoke_tasks.calls == []
     assert artifact_lifecycle_svc.delete_artifacts_for_run_calls == [17]
     assert run_svc.delete_run_calls == [17]
     assert run_svc.delete_run_workspace_ids == [1]

--- a/apps/api/tests/test_lifecycle.py
+++ b/apps/api/tests/test_lifecycle.py
@@ -503,7 +503,7 @@ async def test_delete_run_returns_404_for_workspace_mismatch(client, stub_lifecy
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Run not found"}
-    assert revoke_tasks.calls == [132]
+    assert revoke_tasks.calls == []
     assert artifact_lifecycle_svc.delete_artifacts_for_run_calls == []
 
 

--- a/apps/api/tests/test_lifecycle.py
+++ b/apps/api/tests/test_lifecycle.py
@@ -156,6 +156,7 @@ class StubRevokeTasks:
 
 class StubCollectCeleryIds:
     """Stub for _collect_active_celery_ids — returns empty list by default."""
+
     def __init__(self) -> None:
         self.calls: list[int] = []
 
@@ -166,6 +167,7 @@ class StubCollectCeleryIds:
 
 class StubRevokeCeleryIds:
     """Stub for _revoke_celery_ids — tracks calls."""
+
     def __init__(self) -> None:
         self.calls: list[tuple[list[str], int]] = []
 
@@ -485,7 +487,7 @@ async def test_delete_run_success_with_artifact_cleanup(client, stub_lifecycle_s
     response = await client.delete("/api/creator/runs/17")
 
     assert response.status_code == 200
-    assert response.json() == {"deleted": True, "run_id": 17}
+    assert response.json() == {"deleted": True, "run_id": 17, "revoke_reliable": True}
     # delete_run now uses _collect_active_celery_ids + _revoke_celery_ids (not _revoke_active_tasks_for_run)
     assert revoke_tasks.calls == []
     assert artifact_lifecycle_svc.delete_artifacts_for_run_calls == [17]

--- a/apps/api/tests/test_lifecycle.py
+++ b/apps/api/tests/test_lifecycle.py
@@ -53,6 +53,26 @@ class StubRunService:
         self.stop_errors: dict[int, Exception] = {}
         self.go_back_errors: dict[int, Exception] = {}
         self.update_model_defaults_errors: dict[int, Exception] = {}
+        self.storage = self._StorageStub(self)
+
+    class _StorageStub:
+        def __init__(self, parent: 'StubRunService') -> None:
+            self._parent = parent
+            self.update_run_calls: list[tuple[int, dict]] = []
+
+        async def update_run(
+            self, run_id: int, updates: dict, workspace_id: int | None = None, expected_version: int | None = None
+        ) -> dict | None:
+            self.update_run_calls.append((run_id, updates))
+            run = self._parent.runs.get(run_id)
+            if run is None:
+                return None
+            if workspace_id is not None and run.workspace_id != workspace_id:
+                return None
+            for k, v in updates.items():
+                if hasattr(run, k):
+                    object.__setattr__(run, k, v)
+            return {'id': run_id, **updates}
 
     async def get_run(self, run_id: int) -> StubPipelineRun | None:
         self.get_run_calls.append(run_id)

--- a/apps/api/tests/test_stop_run_ordering.py
+++ b/apps/api/tests/test_stop_run_ordering.py
@@ -17,9 +17,16 @@ from shorts_api.main import app
 
 
 class _FakeRun:
-    def __init__(self, run_id: int = 1):
+    def __init__(
+        self,
+        run_id: int = 1,
+        status: str = "running",
+        current_stage: str = "AUDIO_GENERATING",
+    ):
         self.id = run_id
         self.project_id = 1
+        self.status = status
+        self.current_stage = current_stage
 
 
 class _CallTracker:
@@ -104,6 +111,10 @@ async def test_delete_run_captures_ids_before_delete_revokes_after(
     """Celery IDs must be captured BEFORE delete (CASCADE removes rows), then revoked AFTER."""
     tracker = _CallTracker()
 
+    async def _mock_update_run(run_id, updates, workspace_id):
+        tracker.order.append("mark_cancelled")
+        assert updates == {"status": "cancelled"}
+
     async def _mock_collect(run_id):
         tracker.order.append("collect_ids")
         return ["celery-id-1", "celery-id-2"], True
@@ -121,6 +132,10 @@ async def test_delete_run_captures_ids_before_delete_revokes_after(
         tracker.order.append("delete_artifacts")
 
     monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.storage.update_run",
+        _mock_update_run,
+    )
+    monkeypatch.setattr(
         "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
     )
     monkeypatch.setattr(
@@ -136,7 +151,13 @@ async def test_delete_run_captures_ids_before_delete_revokes_after(
 
     response = await client.delete("/api/creator/runs/1")
     assert response.status_code == 200
-    assert tracker.order == ["collect_ids", "delete_run", "revoke_ids", "delete_artifacts"]
+    assert tracker.order == [
+        "mark_cancelled",
+        "collect_ids",
+        "delete_run",
+        "revoke_ids",
+        "delete_artifacts",
+    ]
 
 
 @pytest.mark.asyncio
@@ -144,6 +165,9 @@ async def test_delete_run_does_not_revoke_on_failure(
     client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     revoke_called = False
+
+    async def _mock_update_run(run_id, updates, workspace_id):
+        return None
 
     async def _mock_collect(run_id):
         return ["celery-id-1"], True
@@ -155,6 +179,10 @@ async def test_delete_run_does_not_revoke_on_failure(
         nonlocal revoke_called
         revoke_called = True
 
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.storage.update_run",
+        _mock_update_run,
+    )
     monkeypatch.setattr(
         "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
     )
@@ -178,6 +206,9 @@ async def test_delete_run_not_deleted_skips_revoke(
     revoke_called = False
     artifacts_called = False
 
+    async def _mock_update_run(run_id, updates, workspace_id):
+        return None
+
     async def _mock_collect(run_id):
         return ["celery-id-1"], True
 
@@ -192,6 +223,10 @@ async def test_delete_run_not_deleted_skips_revoke(
         nonlocal artifacts_called
         artifacts_called = True
 
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.storage.update_run",
+        _mock_update_run,
+    )
     monkeypatch.setattr(
         "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
     )
@@ -216,6 +251,9 @@ async def test_delete_run_not_deleted_skips_revoke(
 async def test_delete_run_response_includes_revoke_reliable(
     client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    async def _mock_update_run(run_id, updates, workspace_id):
+        return None
+
     async def _mock_collect(run_id):
         return ["celery-id-1"], True
 
@@ -228,6 +266,10 @@ async def test_delete_run_response_includes_revoke_reliable(
     async def _mock_delete_artifacts(run_id):
         return None
 
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.storage.update_run",
+        _mock_update_run,
+    )
     monkeypatch.setattr(
         "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
     )
@@ -245,6 +287,120 @@ async def test_delete_run_response_includes_revoke_reliable(
     response = await client.delete("/api/creator/runs/1")
     assert response.status_code == 200
     assert response.json()["revoke_reliable"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_run_marks_cancelled_before_collecting_ids(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tracker = _CallTracker()
+
+    async def _mock_run_access(run_id: int):
+        user = CurrentUser(user_id=1, workspace_id=1)
+        return user, _FakeRun(run_id=run_id, status="running", current_stage="VISUAL_ASSET_REVIEW")
+
+    async def _mock_update_run(run_id, updates, workspace_id):
+        tracker.order.append("mark_cancelled")
+        assert updates == {"status": "cancelled"}
+
+    async def _mock_collect(run_id):
+        tracker.order.append("collect_ids")
+        return ["celery-id-1"], True
+
+    async def _mock_delete_run(run_id, workspace_id):
+        tracker.order.append("delete_run")
+        return True
+
+    async def _mock_revoke_ids(celery_ids, run_id):
+        tracker.order.append("revoke_ids")
+        return True
+
+    async def _mock_delete_artifacts(run_id):
+        tracker.order.append("delete_artifacts")
+
+    app.dependency_overrides[require_run_access] = _mock_run_access
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.storage.update_run",
+        _mock_update_run,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run",
+        _mock_delete_artifacts,
+    )
+
+    response = await client.delete("/api/creator/runs/1")
+
+    assert response.status_code == 200
+    assert tracker.order == [
+        "mark_cancelled",
+        "collect_ids",
+        "delete_run",
+        "revoke_ids",
+        "delete_artifacts",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_run_from_review_stage_blocks_concurrent_dispatch(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tracker = _CallTracker()
+
+    async def _mock_run_access(run_id: int):
+        user = CurrentUser(user_id=1, workspace_id=1)
+        return user, _FakeRun(run_id=run_id, status="running", current_stage="VISUAL_ASSET_REVIEW")
+
+    async def _mock_update_run(run_id, updates, workspace_id):
+        tracker.order.append("mark_cancelled")
+        assert updates == {"status": "cancelled"}
+
+    async def _mock_collect(run_id):
+        tracker.order.append("collect_ids")
+        return [], True
+
+    async def _mock_delete_run(run_id, workspace_id):
+        tracker.order.append("delete_run")
+        return True
+
+    async def _mock_revoke_ids(celery_ids, run_id):
+        tracker.order.append("revoke_ids")
+        return True
+
+    async def _mock_delete_artifacts(run_id):
+        tracker.order.append("delete_artifacts")
+
+    app.dependency_overrides[require_run_access] = _mock_run_access
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.storage.update_run",
+        _mock_update_run,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run",
+        _mock_delete_artifacts,
+    )
+
+    response = await client.delete("/api/creator/runs/1")
+
+    assert response.status_code == 200
+    assert tracker.order.index("mark_cancelled") < tracker.order.index("collect_ids")
 
 
 # --- Unit tests for helper functions ---

--- a/apps/api/tests/test_stop_run_ordering.py
+++ b/apps/api/tests/test_stop_run_ordering.py
@@ -448,3 +448,39 @@ async def test_revoke_celery_ids_empty_list_is_noop() -> None:
 
     # Should not raise or call anything
     await _revoke_celery_ids([], run_id=1)
+
+
+@pytest.mark.asyncio
+async def test_delete_run_fails_closed_when_cancel_write_fails(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If pre-delete cancellation write fails, delete_run must return 503 (fail-closed)."""
+    delete_called = False
+
+    async def _mock_update_run(run_id, updates, workspace_id=None, expected_version=None):
+        raise RuntimeError("storage unavailable")
+
+    async def _mock_collect(run_id):
+        return ["celery-id-1"], True
+
+    async def _mock_delete_run(run_id, workspace_id):
+        nonlocal delete_called
+        delete_called = True
+        return True
+
+    async def _mock_revoke_ids(celery_ids, run_id):
+        pass
+
+    async def _mock_delete_artifacts(run_id):
+        pass
+
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.storage.update_run", _mock_update_run)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run", _mock_delete_artifacts)
+
+    response = await client.delete("/api/creator/runs/1")
+    assert response.status_code == 503
+    assert "cancel" in response.json()["detail"].lower()
+    assert delete_called is False, "delete_run must not proceed if cancellation write fails"

--- a/apps/api/tests/test_stop_run_ordering.py
+++ b/apps/api/tests/test_stop_run_ordering.py
@@ -1,0 +1,121 @@
+"""Tests for stop_run and delete_run revoke ordering (#510).
+
+Verifies that _revoke_active_tasks_for_run is called AFTER the service
+call succeeds, not before.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+from httpx import AsyncClient
+
+from creator_service.run_service import ConflictError
+from shorts_api.auth import CurrentUser, require_run_access
+from shorts_api.main import app
+
+
+class _FakeRun:
+    def __init__(self, run_id: int = 1):
+        self.id = run_id
+        self.project_id = 1
+
+
+class _CallTracker:
+    def __init__(self):
+        self.order: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+def _override_run_access():
+    """Override require_run_access to bypass DB lookup."""
+    user = CurrentUser(user_id=1, workspace_id=1)
+
+    async def _fake(run_id: int):
+        return user, _FakeRun(run_id)
+
+    app.dependency_overrides[require_run_access] = _fake
+    yield
+    app.dependency_overrides.pop(require_run_access, None)
+
+
+@pytest.mark.asyncio
+async def test_stop_run_revokes_after_service_call(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    tracker = _CallTracker()
+    mock_updated = MagicMock()
+    mock_updated.model_dump.return_value = {"id": 1, "status": "stopped"}
+
+    async def _mock_stop_run(run_id, workspace_id):
+        tracker.order.append("stop_run")
+        return mock_updated
+
+    async def _mock_revoke(run_id):
+        tracker.order.append("revoke")
+
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.stop_run", _mock_stop_run)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke)
+
+    response = await client.post("/api/creator/runs/1/stop")
+    assert response.status_code == 200
+    assert tracker.order == ["stop_run", "revoke"]
+
+
+@pytest.mark.asyncio
+async def test_stop_run_does_not_revoke_on_conflict(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    revoke_called = False
+
+    async def _mock_stop_run(run_id, workspace_id):
+        raise ConflictError("already stopped")
+
+    async def _mock_revoke(run_id):
+        nonlocal revoke_called
+        revoke_called = True
+
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.stop_run", _mock_stop_run)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke)
+
+    response = await client.post("/api/creator/runs/1/stop")
+    assert response.status_code == 409
+    assert revoke_called is False
+
+
+@pytest.mark.asyncio
+async def test_delete_run_revokes_after_service_call(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    tracker = _CallTracker()
+
+    async def _mock_delete_run(run_id, workspace_id):
+        tracker.order.append("delete_run")
+        return True
+
+    async def _mock_revoke(run_id):
+        tracker.order.append("revoke")
+
+    async def _mock_delete_artifacts(run_id):
+        tracker.order.append("delete_artifacts")
+
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run", _mock_delete_artifacts)
+
+    response = await client.delete("/api/creator/runs/1")
+    assert response.status_code == 200
+    assert tracker.order == ["delete_run", "revoke", "delete_artifacts"]
+
+
+@pytest.mark.asyncio
+async def test_delete_run_does_not_revoke_on_failure(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    revoke_called = False
+
+    async def _mock_delete_run(run_id, workspace_id):
+        raise ValueError("Run not found")
+
+    async def _mock_revoke(run_id):
+        nonlocal revoke_called
+        revoke_called = True
+
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke)
+
+    response = await client.delete("/api/creator/runs/1")
+    assert response.status_code == 404
+    assert revoke_called is False

--- a/apps/api/tests/test_stop_run_ordering.py
+++ b/apps/api/tests/test_stop_run_ordering.py
@@ -165,3 +165,46 @@ async def test_delete_run_not_deleted_skips_revoke(client: AsyncClient, monkeypa
     assert response.status_code == 404
     assert revoke_called is False
     assert artifacts_called is False
+
+
+# --- Unit tests for helper functions ---
+
+@pytest.mark.asyncio
+async def test_collect_active_celery_ids_returns_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    from shorts_api.routes.creator_runs_utils import _collect_active_celery_ids
+
+    class _MockTracking:
+        async def get_active_celery_ids(self, run_id):
+            return ["id-1", "id-2"]
+
+    monkeypatch.setattr(
+        "creator_service.task_tracking_service.task_tracking_service",
+        _MockTracking(),
+    )
+
+    result = await _collect_active_celery_ids(42)
+    assert result == ["id-1", "id-2"]
+
+
+@pytest.mark.asyncio
+async def test_collect_active_celery_ids_returns_empty_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from shorts_api.routes.creator_runs_utils import _collect_active_celery_ids
+
+    class _MockTracking:
+        async def get_active_celery_ids(self, run_id):
+            raise RuntimeError("DB down")
+
+    monkeypatch.setattr(
+        "creator_service.task_tracking_service.task_tracking_service",
+        _MockTracking(),
+    )
+
+    result = await _collect_active_celery_ids(42)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_revoke_celery_ids_empty_list_is_noop() -> None:
+    from shorts_api.routes.creator_runs_utils import _revoke_celery_ids
+    # Should not raise or call anything
+    await _revoke_celery_ids([], run_id=1)

--- a/apps/api/tests/test_stop_run_ordering.py
+++ b/apps/api/tests/test_stop_run_ordering.py
@@ -41,8 +41,11 @@ def _override_run_access():
 
 # --- stop_run tests ---
 
+
 @pytest.mark.asyncio
-async def test_stop_run_revokes_after_service_call(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_stop_run_revokes_after_service_call(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     tracker = _CallTracker()
     mock_updated = MagicMock()
     mock_updated.model_dump.return_value = {"id": 1, "status": "stopped"}
@@ -54,8 +57,12 @@ async def test_stop_run_revokes_after_service_call(client: AsyncClient, monkeypa
     async def _mock_revoke(run_id):
         tracker.order.append("revoke")
 
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.stop_run", _mock_stop_run)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke)
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.stop_run", _mock_stop_run
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke
+    )
 
     response = await client.post("/api/creator/runs/1/stop")
     assert response.status_code == 200
@@ -63,7 +70,9 @@ async def test_stop_run_revokes_after_service_call(client: AsyncClient, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_stop_run_does_not_revoke_on_conflict(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_stop_run_does_not_revoke_on_conflict(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     revoke_called = False
 
     async def _mock_stop_run(run_id, workspace_id):
@@ -73,8 +82,12 @@ async def test_stop_run_does_not_revoke_on_conflict(client: AsyncClient, monkeyp
         nonlocal revoke_called
         revoke_called = True
 
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.stop_run", _mock_stop_run)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke)
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.stop_run", _mock_stop_run
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke
+    )
 
     response = await client.post("/api/creator/runs/1/stop")
     assert response.status_code == 409
@@ -83,14 +96,17 @@ async def test_stop_run_does_not_revoke_on_conflict(client: AsyncClient, monkeyp
 
 # --- delete_run tests ---
 
+
 @pytest.mark.asyncio
-async def test_delete_run_captures_ids_before_delete_revokes_after(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_delete_run_captures_ids_before_delete_revokes_after(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Celery IDs must be captured BEFORE delete (CASCADE removes rows), then revoked AFTER."""
     tracker = _CallTracker()
 
     async def _mock_collect(run_id):
         tracker.order.append("collect_ids")
-        return ["celery-id-1", "celery-id-2"]
+        return ["celery-id-1", "celery-id-2"], True
 
     async def _mock_delete_run(run_id, workspace_id):
         tracker.order.append("delete_run")
@@ -99,14 +115,24 @@ async def test_delete_run_captures_ids_before_delete_revokes_after(client: Async
     async def _mock_revoke_ids(celery_ids, run_id):
         tracker.order.append("revoke_ids")
         assert celery_ids == ["celery-id-1", "celery-id-2"]
+        return True
 
     async def _mock_delete_artifacts(run_id):
         tracker.order.append("delete_artifacts")
 
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run", _mock_delete_artifacts)
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run",
+        _mock_delete_artifacts,
+    )
 
     response = await client.delete("/api/creator/runs/1")
     assert response.status_code == 200
@@ -114,11 +140,13 @@ async def test_delete_run_captures_ids_before_delete_revokes_after(client: Async
 
 
 @pytest.mark.asyncio
-async def test_delete_run_does_not_revoke_on_failure(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_delete_run_does_not_revoke_on_failure(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     revoke_called = False
 
     async def _mock_collect(run_id):
-        return ["celery-id-1"]
+        return ["celery-id-1"], True
 
     async def _mock_delete_run(run_id, workspace_id):
         raise ValueError("Run not found")
@@ -127,9 +155,15 @@ async def test_delete_run_does_not_revoke_on_failure(client: AsyncClient, monkey
         nonlocal revoke_called
         revoke_called = True
 
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids)
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids
+    )
 
     response = await client.delete("/api/creator/runs/1")
     assert response.status_code == 404
@@ -137,13 +171,15 @@ async def test_delete_run_does_not_revoke_on_failure(client: AsyncClient, monkey
 
 
 @pytest.mark.asyncio
-async def test_delete_run_not_deleted_skips_revoke(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_delete_run_not_deleted_skips_revoke(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """If delete_run returns False, no revoke or artifact cleanup should happen."""
     revoke_called = False
     artifacts_called = False
 
     async def _mock_collect(run_id):
-        return ["celery-id-1"]
+        return ["celery-id-1"], True
 
     async def _mock_delete_run(run_id, workspace_id):
         return False
@@ -156,10 +192,19 @@ async def test_delete_run_not_deleted_skips_revoke(client: AsyncClient, monkeypa
         nonlocal artifacts_called
         artifacts_called = True
 
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run", _mock_delete_artifacts)
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run",
+        _mock_delete_artifacts,
+    )
 
     response = await client.delete("/api/creator/runs/1")
     assert response.status_code == 404
@@ -167,7 +212,43 @@ async def test_delete_run_not_deleted_skips_revoke(client: AsyncClient, monkeypa
     assert artifacts_called is False
 
 
+@pytest.mark.asyncio
+async def test_delete_run_response_includes_revoke_reliable(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _mock_collect(run_id):
+        return ["celery-id-1"], True
+
+    async def _mock_delete_run(run_id, workspace_id):
+        return True
+
+    async def _mock_revoke_ids(celery_ids, run_id):
+        return True
+
+    async def _mock_delete_artifacts(run_id):
+        return None
+
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run",
+        _mock_delete_artifacts,
+    )
+
+    response = await client.delete("/api/creator/runs/1")
+    assert response.status_code == 200
+    assert response.json()["revoke_reliable"] is True
+
+
 # --- Unit tests for helper functions ---
+
 
 @pytest.mark.asyncio
 async def test_collect_active_celery_ids_returns_ids(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -183,11 +264,13 @@ async def test_collect_active_celery_ids_returns_ids(monkeypatch: pytest.MonkeyP
     )
 
     result = await _collect_active_celery_ids(42)
-    assert result == ["id-1", "id-2"]
+    assert result == (["id-1", "id-2"], True)
 
 
 @pytest.mark.asyncio
-async def test_collect_active_celery_ids_returns_empty_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_collect_active_celery_ids_returns_empty_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from shorts_api.routes.creator_runs_utils import _collect_active_celery_ids
 
     class _MockTracking:
@@ -200,11 +283,12 @@ async def test_collect_active_celery_ids_returns_empty_on_error(monkeypatch: pyt
     )
 
     result = await _collect_active_celery_ids(42)
-    assert result == []
+    assert result == ([], False)
 
 
 @pytest.mark.asyncio
 async def test_revoke_celery_ids_empty_list_is_noop() -> None:
     from shorts_api.routes.creator_runs_utils import _revoke_celery_ids
+
     # Should not raise or call anything
     await _revoke_celery_ids([], run_id=1)

--- a/apps/api/tests/test_stop_run_ordering.py
+++ b/apps/api/tests/test_stop_run_ordering.py
@@ -1,7 +1,8 @@
 """Tests for stop_run and delete_run revoke ordering (#510).
 
-Verifies that _revoke_active_tasks_for_run is called AFTER the service
-call succeeds, not before.
+Verifies that:
+- stop_run: revoke happens AFTER service call succeeds
+- delete_run: celery IDs captured BEFORE delete, revoked AFTER delete succeeds
 """
 
 from __future__ import annotations
@@ -28,7 +29,6 @@ class _CallTracker:
 
 @pytest.fixture(autouse=True)
 def _override_run_access():
-    """Override require_run_access to bypass DB lookup."""
     user = CurrentUser(user_id=1, workspace_id=1)
 
     async def _fake(run_id: int):
@@ -38,6 +38,8 @@ def _override_run_access():
     yield
     app.dependency_overrides.pop(require_run_access, None)
 
+
+# --- stop_run tests ---
 
 @pytest.mark.asyncio
 async def test_stop_run_revokes_after_service_call(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -79,43 +81,87 @@ async def test_stop_run_does_not_revoke_on_conflict(client: AsyncClient, monkeyp
     assert revoke_called is False
 
 
+# --- delete_run tests ---
+
 @pytest.mark.asyncio
-async def test_delete_run_revokes_after_service_call(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_delete_run_captures_ids_before_delete_revokes_after(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Celery IDs must be captured BEFORE delete (CASCADE removes rows), then revoked AFTER."""
     tracker = _CallTracker()
+
+    async def _mock_collect(run_id):
+        tracker.order.append("collect_ids")
+        return ["celery-id-1", "celery-id-2"]
 
     async def _mock_delete_run(run_id, workspace_id):
         tracker.order.append("delete_run")
         return True
 
-    async def _mock_revoke(run_id):
-        tracker.order.append("revoke")
+    async def _mock_revoke_ids(celery_ids, run_id):
+        tracker.order.append("revoke_ids")
+        assert celery_ids == ["celery-id-1", "celery-id-2"]
 
     async def _mock_delete_artifacts(run_id):
         tracker.order.append("delete_artifacts")
 
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect)
     monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids)
     monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run", _mock_delete_artifacts)
 
     response = await client.delete("/api/creator/runs/1")
     assert response.status_code == 200
-    assert tracker.order == ["delete_run", "revoke", "delete_artifacts"]
+    assert tracker.order == ["collect_ids", "delete_run", "revoke_ids", "delete_artifacts"]
 
 
 @pytest.mark.asyncio
 async def test_delete_run_does_not_revoke_on_failure(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
     revoke_called = False
 
+    async def _mock_collect(run_id):
+        return ["celery-id-1"]
+
     async def _mock_delete_run(run_id, workspace_id):
         raise ValueError("Run not found")
 
-    async def _mock_revoke(run_id):
+    async def _mock_revoke_ids(celery_ids, run_id):
         nonlocal revoke_called
         revoke_called = True
 
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect)
     monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run)
-    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_active_tasks_for_run", _mock_revoke)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids)
 
     response = await client.delete("/api/creator/runs/1")
     assert response.status_code == 404
     assert revoke_called is False
+
+
+@pytest.mark.asyncio
+async def test_delete_run_not_deleted_skips_revoke(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If delete_run returns False, no revoke or artifact cleanup should happen."""
+    revoke_called = False
+    artifacts_called = False
+
+    async def _mock_collect(run_id):
+        return ["celery-id-1"]
+
+    async def _mock_delete_run(run_id, workspace_id):
+        return False
+
+    async def _mock_revoke_ids(celery_ids, run_id):
+        nonlocal revoke_called
+        revoke_called = True
+
+    async def _mock_delete_artifacts(run_id):
+        nonlocal artifacts_called
+        artifacts_called = True
+
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._collect_active_celery_ids", _mock_collect)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.run_service.delete_run", _mock_delete_run)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle._revoke_celery_ids", _mock_revoke_ids)
+    monkeypatch.setattr("shorts_api.routes.creator_runs_lifecycle.artifact_download_service.delete_artifacts_for_run", _mock_delete_artifacts)
+
+    response = await client.delete("/api/creator/runs/1")
+    assert response.status_code == 404
+    assert revoke_called is False
+    assert artifacts_called is False

--- a/apps/api/tests/test_storyboard_cancelled.py
+++ b/apps/api/tests/test_storyboard_cancelled.py
@@ -21,64 +21,74 @@ def _make_cancelled_run() -> Any:
     )
 
 
-@pytest.fixture()
-def _override_cancelled(client: Any) -> Any:  # noqa: ARG001 – client needed for setup order
+def _install_cancelled_override() -> None:
     run = _make_cancelled_run()
 
     async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        _ = run_id
         return CurrentUser(user_id=1, workspace_id=1), run
 
     app.dependency_overrides[require_run_access] = _require_run_access
-    yield
+
+
+def _remove_run_access_override() -> None:
     app.dependency_overrides.pop(require_run_access, None)
 
 
 @pytest.mark.asyncio
-async def test_generate_paragraph_audio_rejects_cancelled_run(
-    client: Any, _override_cancelled: Any
-) -> None:
-    resp = await client.post(
-        "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-audio",
-        json={"tts_model": "qwen3-tts", "voice": "default"},
-    )
-    assert resp.status_code == 409
-    assert "cancelled" in resp.json()["detail"].lower()
+async def test_generate_paragraph_audio_rejects_cancelled_run(client: Any) -> None:
+    _install_cancelled_override()
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-audio",
+            json={"tts_model": "qwen3-tts", "voice": "default"},
+        )
+        assert resp.status_code == 409
+        assert "cancelled" in resp.json()["detail"].lower()
+    finally:
+        _remove_run_access_override()
 
 
 @pytest.mark.asyncio
-async def test_generate_paragraph_subtitles_rejects_cancelled_run(
-    client: Any, _override_cancelled: Any
-) -> None:
-    resp = await client.post(
-        "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-subtitles",
-        json={"subtitle_model": "whisper-small", "subtitle_format": "srt"},
-    )
-    assert resp.status_code == 409
-    assert "cancelled" in resp.json()["detail"].lower()
+async def test_generate_paragraph_subtitles_rejects_cancelled_run(client: Any) -> None:
+    _install_cancelled_override()
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-subtitles",
+            json={"subtitle_model": "whisper-small", "subtitle_format": "srt"},
+        )
+        assert resp.status_code == 409
+        assert "cancelled" in resp.json()["detail"].lower()
+    finally:
+        _remove_run_access_override()
 
 
 @pytest.mark.asyncio
-async def test_generate_all_paragraph_audio_rejects_cancelled_run(
-    client: Any, _override_cancelled: Any
-) -> None:
-    resp = await client.post(
-        "/api/creator/runs/1/storyboard/generate-all-audio",
-        json={"tts_model": "qwen3-tts", "voice": "default"},
-    )
-    assert resp.status_code == 409
-    assert "cancelled" in resp.json()["detail"].lower()
+async def test_generate_all_paragraph_audio_rejects_cancelled_run(client: Any) -> None:
+    _install_cancelled_override()
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/generate-all-audio",
+            json={"tts_model": "qwen3-tts", "voice": "default"},
+        )
+        assert resp.status_code == 409
+        assert "cancelled" in resp.json()["detail"].lower()
+    finally:
+        _remove_run_access_override()
 
 
 @pytest.mark.asyncio
-async def test_generate_all_paragraph_subtitles_rejects_cancelled_run(
-    client: Any, _override_cancelled: Any
-) -> None:
-    resp = await client.post(
-        "/api/creator/runs/1/storyboard/generate-all-subtitles",
-        json={"subtitle_model": "whisper-small", "subtitle_format": "srt"},
-    )
-    assert resp.status_code == 409
-    assert "cancelled" in resp.json()["detail"].lower()
+async def test_generate_all_paragraph_subtitles_rejects_cancelled_run(client: Any) -> None:
+    _install_cancelled_override()
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/generate-all-subtitles",
+            json={"subtitle_model": "whisper-small", "subtitle_format": "srt"},
+        )
+        assert resp.status_code == 409
+        assert "cancelled" in resp.json()["detail"].lower()
+    finally:
+        _remove_run_access_override()
 
 
 @pytest.mark.asyncio
@@ -93,6 +103,7 @@ async def test_dispatch_blocked_on_concurrent_cancellation(
     )
 
     async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        _ = run_id
         return CurrentUser(user_id=1, workspace_id=1), run
 
     app.dependency_overrides[require_run_access] = _require_run_access
@@ -105,9 +116,11 @@ async def test_dispatch_blocked_on_concurrent_cancellation(
     async def _mock_check_workspace_quota(
         _workspace_id: int, operation_type: str
     ) -> tuple[bool, str]:
+        _ = operation_type
         return True, "ok"
 
-    async def _mock_get_run(_run_id: int, workspace_id: int) -> Any:
+    async def _mock_get_run(_run_id: int, workspace_id: int | None = None) -> Any:
+        _ = workspace_id
         return SimpleNamespace(id=1, status="cancelled", current_stage="VISUAL_ASSET_REVIEW")
 
     monkeypatch.setattr(
@@ -152,6 +165,7 @@ async def test_record_task_queued_failure_revokes_task(
     )
 
     async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        _ = run_id
         return CurrentUser(user_id=1, workspace_id=1), run
 
     app.dependency_overrides[require_run_access] = _require_run_access
@@ -164,9 +178,11 @@ async def test_record_task_queued_failure_revokes_task(
     async def _mock_check_workspace_quota(
         _workspace_id: int, operation_type: str
     ) -> tuple[bool, str]:
+        _ = operation_type
         return True, "ok"
 
-    async def _mock_get_run(_run_id: int, workspace_id: int) -> Any:
+    async def _mock_get_run(_run_id: int, workspace_id: int | None = None) -> Any:
+        _ = workspace_id
         return SimpleNamespace(id=1, status="running", current_stage="VISUAL_ASSET_REVIEW")
 
     async def _mock_record_task_queued(_run_id: int, _task_name: str, _task_id: str) -> None:
@@ -220,6 +236,106 @@ async def test_record_task_queued_failure_revokes_task(
             json={"tts_model": "qwen3-tts", "voice": "default"},
         )
         assert resp.status_code == 503
+        assert revoke_calls == [("task-123", True)]
+    finally:
+        app.dependency_overrides.pop(require_run_access, None)
+
+
+@pytest.mark.asyncio
+async def test_post_dispatch_revoke_on_concurrent_cancellation(
+    client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = SimpleNamespace(
+        id=1,
+        status="running",
+        current_stage="VISUAL_ASSET_REVIEW",
+        project_id=1,
+    )
+
+    async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        _ = run_id
+        return CurrentUser(user_id=1, workspace_id=1), run
+
+    app.dependency_overrides[require_run_access] = _require_run_access
+
+    async def _mock_get_active_draft(_run_id: int) -> Any:
+        return SimpleNamespace(
+            structured_script=[SimpleNamespace(section_id="sec-1", text="hello")]
+        )
+
+    async def _mock_check_workspace_quota(
+        _workspace_id: int, operation_type: str
+    ) -> tuple[bool, str]:
+        _ = operation_type
+        return True, "ok"
+
+    async def _mock_cancel_workspace_quota_reservation(
+        _workspace_id: int, operation_type: str
+    ) -> None:
+        _ = operation_type
+        return None
+
+    states = [
+        SimpleNamespace(id=1, status="running", current_stage="VISUAL_ASSET_REVIEW"),
+        SimpleNamespace(id=1, status="cancelled", current_stage="VISUAL_ASSET_REVIEW"),
+    ]
+
+    async def _mock_get_fresh_run_for_dispatch(_run_id: int, _workspace_id: int) -> Any:
+        return states.pop(0)
+
+    async def _mock_record_task_queued(_run_id: int, _task_name: str, _task_id: str) -> None:
+        return None
+
+    revoke_calls: list[tuple[str, bool]] = []
+    celery_app = SimpleNamespace(
+        control=SimpleNamespace(
+            revoke=lambda task_id, terminate=False: revoke_calls.append((task_id, terminate))
+        )
+    )
+
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.script_service.get_active_draft",
+        _mock_get_active_draft,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.validate_model_key",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.check_workspace_quota",
+        _mock_check_workspace_quota,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.cancel_workspace_quota_reservation",
+        _mock_cancel_workspace_quota_reservation,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard._get_fresh_run_for_dispatch",
+        _mock_get_fresh_run_for_dispatch,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.dispatch_paragraph_audio",
+        lambda **kwargs: "task-123",
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.record_task_queued",
+        _mock_record_task_queued,
+    )
+    monkeypatch.setattr(
+        creator_runs_storyboard,
+        "__import__",
+        lambda name: SimpleNamespace(celery_app=celery_app)
+        if name == "celery_app"
+        else __import__(name),
+        raising=False,
+    )
+
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-audio",
+            json={"tts_model": "qwen3-tts", "voice": "default"},
+        )
+        assert resp.status_code == 409
         assert revoke_calls == [("task-123", True)]
     finally:
         app.dependency_overrides.pop(require_run_access, None)

--- a/apps/api/tests/test_storyboard_cancelled.py
+++ b/apps/api/tests/test_storyboard_cancelled.py
@@ -616,3 +616,202 @@ async def test_bulk_subtitles_record_failure_revokes_task(
         assert mark_tasks_revoked_calls == [["sub-task-1"]]
     finally:
         app.dependency_overrides.pop(require_run_access, None)
+
+
+# --- Tests for _get_fresh_run_for_dispatch fail-closed on exceptions ---
+
+
+@pytest.mark.asyncio
+async def test_get_fresh_run_for_dispatch_returns_none_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_get_fresh_run_for_dispatch returns None when get_run raises, enabling fail-closed."""
+    async def _raise(_run_id: int, **kwargs: Any) -> None:
+        raise RuntimeError("DB connection lost")
+
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.run_service.get_run",
+        _raise,
+    )
+    result = await creator_runs_storyboard._get_fresh_run_for_dispatch(1, 1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_pre_dispatch_reread_exception_fails_closed(
+    client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When run_service.get_run raises during pre-dispatch re-read, endpoint returns 409 (fail-closed via None)."""
+    run = SimpleNamespace(
+        id=1, status="running", current_stage="VISUAL_ASSET_REVIEW", project_id=1
+    )
+
+    async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        _ = run_id
+        return CurrentUser(user_id=1, workspace_id=1), run
+
+    app.dependency_overrides[require_run_access] = _require_run_access
+
+    async def _mock_get_active_draft(_run_id: int) -> Any:
+        return SimpleNamespace(
+            structured_script=[SimpleNamespace(section_id="sec-1", text="hello")]
+        )
+
+    async def _mock_check_workspace_quota(
+        _workspace_id: int, operation_type: str
+    ) -> tuple[bool, str]:
+        _ = operation_type
+        return True, "ok"
+
+    cancel_quota_calls: list[str] = []
+
+    async def _mock_cancel_quota(_workspace_id: int, operation_type: str) -> None:
+        cancel_quota_calls.append(operation_type)
+
+    # Make run_service.get_run raise — exercises the real _get_fresh_run_for_dispatch wrapper
+    async def _raising_get_run(_run_id: int, **kwargs: Any) -> None:
+        raise RuntimeError("DB connection lost")
+
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.script_service.get_active_draft",
+        _mock_get_active_draft,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.validate_model_key",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.check_workspace_quota",
+        _mock_check_workspace_quota,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.cancel_workspace_quota_reservation",
+        _mock_cancel_quota,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.run_service.get_run",
+        _raising_get_run,
+    )
+
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-audio",
+            json={"tts_model": "qwen3-tts", "voice": "default"},
+        )
+        # _get_fresh_run_for_dispatch catches exception → returns None → 409 + quota cancel
+        assert resp.status_code == 409
+        assert "cancelled" in resp.json()["detail"].lower()
+        assert cancel_quota_calls == ["tts"]
+    finally:
+        app.dependency_overrides.pop(require_run_access, None)
+
+
+@pytest.mark.asyncio
+async def test_post_dispatch_reread_exception_revokes_task(
+    client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When run_service.get_run raises during post-dispatch re-read, task is revoked (fail-closed)."""
+    run = SimpleNamespace(
+        id=1, status="running", current_stage="VISUAL_ASSET_REVIEW", project_id=1
+    )
+
+    async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        _ = run_id
+        return CurrentUser(user_id=1, workspace_id=1), run
+
+    app.dependency_overrides[require_run_access] = _require_run_access
+
+    async def _mock_get_active_draft(_run_id: int) -> Any:
+        return SimpleNamespace(
+            structured_script=[SimpleNamespace(section_id="sec-1", text="hello")]
+        )
+
+    async def _mock_check_workspace_quota(
+        _workspace_id: int, operation_type: str
+    ) -> tuple[bool, str]:
+        _ = operation_type
+        return True, "ok"
+
+    cancel_quota_calls: list[str] = []
+
+    async def _mock_cancel_quota(_workspace_id: int, operation_type: str) -> None:
+        cancel_quota_calls.append(operation_type)
+
+    call_count = 0
+
+    async def _get_run_ok_then_raise(_run_id: int, **kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Pre-dispatch re-read succeeds
+            return SimpleNamespace(id=1, status="running", current_stage="VISUAL_ASSET_REVIEW")
+        # Post-dispatch re-read fails
+        raise RuntimeError("DB gone during post-dispatch check")
+
+    async def _mock_record_task_queued(_run_id: int, _task_name: str, _task_id: str) -> None:
+        return None
+
+    revoke_calls: list[tuple[str, bool]] = []
+    mark_tasks_revoked_calls: list[list[str]] = []
+    celery_app = SimpleNamespace(
+        control=SimpleNamespace(
+            revoke=lambda task_id, terminate=False: revoke_calls.append((task_id, terminate))
+        )
+    )
+
+    async def _mock_mark_tasks_revoked(task_ids: list[str]) -> None:
+        mark_tasks_revoked_calls.append(task_ids)
+
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.script_service.get_active_draft",
+        _mock_get_active_draft,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.validate_model_key",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.check_workspace_quota",
+        _mock_check_workspace_quota,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.cancel_workspace_quota_reservation",
+        _mock_cancel_quota,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.run_service.get_run",
+        _get_run_ok_then_raise,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.dispatch_paragraph_audio",
+        lambda **kwargs: "task-123",
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.record_task_queued",
+        _mock_record_task_queued,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.mark_tasks_revoked",
+        _mock_mark_tasks_revoked,
+    )
+    monkeypatch.setattr(
+        creator_runs_storyboard,
+        "__import__",
+        lambda name: SimpleNamespace(celery_app=celery_app)
+        if name == "celery_app"
+        else __import__(name),
+        raising=False,
+    )
+
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-audio",
+            json={"tts_model": "qwen3-tts", "voice": "default"},
+        )
+        # Post-dispatch re-read returns None (exception caught) → treated as cancelled → revoke
+        assert resp.status_code == 409
+        assert revoke_calls == [("task-123", True)]
+        assert mark_tasks_revoked_calls == [["task-123"]]
+        assert cancel_quota_calls == ["tts"]
+    finally:
+        app.dependency_overrides.pop(require_run_access, None)

--- a/apps/api/tests/test_storyboard_cancelled.py
+++ b/apps/api/tests/test_storyboard_cancelled.py
@@ -189,11 +189,15 @@ async def test_record_task_queued_failure_revokes_task(
         raise RuntimeError("db failure")
 
     revoke_calls: list[tuple[str, bool]] = []
+    mark_tasks_revoked_calls: list[list[str]] = []
     celery_app = SimpleNamespace(
         control=SimpleNamespace(
             revoke=lambda task_id, terminate=False: revoke_calls.append((task_id, terminate))
         )
     )
+
+    async def _mock_mark_tasks_revoked(task_ids: list[str]) -> None:
+        mark_tasks_revoked_calls.append(task_ids)
 
     monkeypatch.setattr(
         "shorts_api.routes.creator_runs_storyboard.script_service.get_active_draft",
@@ -222,6 +226,10 @@ async def test_record_task_queued_failure_revokes_task(
         _mock_record_task_queued,
     )
     monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.mark_tasks_revoked",
+        _mock_mark_tasks_revoked,
+    )
+    monkeypatch.setattr(
         creator_runs_storyboard,
         "__import__",
         lambda name: SimpleNamespace(celery_app=celery_app)
@@ -237,6 +245,7 @@ async def test_record_task_queued_failure_revokes_task(
         )
         assert resp.status_code == 503
         assert revoke_calls == [("task-123", True)]
+        assert mark_tasks_revoked_calls == [["task-123"]]
     finally:
         app.dependency_overrides.pop(require_run_access, None)
 
@@ -287,11 +296,15 @@ async def test_post_dispatch_revoke_on_concurrent_cancellation(
         return None
 
     revoke_calls: list[tuple[str, bool]] = []
+    mark_tasks_revoked_calls: list[list[str]] = []
     celery_app = SimpleNamespace(
         control=SimpleNamespace(
             revoke=lambda task_id, terminate=False: revoke_calls.append((task_id, terminate))
         )
     )
+
+    async def _mock_mark_tasks_revoked(task_ids: list[str]) -> None:
+        mark_tasks_revoked_calls.append(task_ids)
 
     monkeypatch.setattr(
         "shorts_api.routes.creator_runs_storyboard.script_service.get_active_draft",
@@ -322,6 +335,10 @@ async def test_post_dispatch_revoke_on_concurrent_cancellation(
         _mock_record_task_queued,
     )
     monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.mark_tasks_revoked",
+        _mock_mark_tasks_revoked,
+    )
+    monkeypatch.setattr(
         creator_runs_storyboard,
         "__import__",
         lambda name: SimpleNamespace(celery_app=celery_app)
@@ -337,5 +354,261 @@ async def test_post_dispatch_revoke_on_concurrent_cancellation(
         )
         assert resp.status_code == 409
         assert revoke_calls == [("task-123", True)]
+        assert mark_tasks_revoked_calls == [["task-123"]]
+    finally:
+        app.dependency_overrides.pop(require_run_access, None)
+
+
+@pytest.mark.asyncio
+async def test_bulk_audio_post_dispatch_revoke_on_concurrent_cancellation(
+    client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that mark_tasks_revoked is called when bulk audio dispatch faces concurrent cancellation."""
+    run = SimpleNamespace(
+        id=1,
+        status="running",
+        current_stage="VISUAL_ASSET_REVIEW",
+        project_id=1,
+    )
+
+    async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        _ = run_id
+        return CurrentUser(user_id=1, workspace_id=1), run
+
+    app.dependency_overrides[require_run_access] = _require_run_access
+
+    async def _mock_get_active_draft(_run_id: int) -> Any:
+        section = SimpleNamespace(
+            section_id="sec-1",
+            text="Hello",
+            display_text="Hello",
+            type="narration",
+            speaker=None,
+            duration=None,
+            turn_kind=None,
+            visual_override=None,
+            image_prompt=None,
+        )
+        return SimpleNamespace(structured_script=[section])
+
+    async def _mock_check_workspace_quota(
+        _workspace_id: int, operation_type: str
+    ) -> tuple[bool, str]:
+        _ = operation_type
+        return True, "ok"
+
+    async def _mock_cancel_workspace_quota_reservation(
+        _workspace_id: int, operation_type: str
+    ) -> None:
+        _ = operation_type
+        return None
+
+    states = [
+        SimpleNamespace(id=1, status="running", current_stage="VISUAL_ASSET_REVIEW"),
+        SimpleNamespace(id=1, status="cancelled", current_stage="VISUAL_ASSET_REVIEW"),
+    ]
+
+    async def _mock_get_fresh_run_for_dispatch(_run_id: int, _workspace_id: int) -> Any:
+        return states.pop(0)
+
+    async def _mock_list_paragraph_audio(_run_id: int) -> list:
+        return []
+
+    async def _mock_record_task_queued(_run_id: int, _task_name: str, _task_id: str) -> None:
+        return None
+
+    revoke_calls: list[str] = []
+    mark_tasks_revoked_calls: list[list[str]] = []
+    celery_app = SimpleNamespace(
+        control=SimpleNamespace(
+            revoke=lambda task_id, terminate=False: revoke_calls.append(task_id)
+        )
+    )
+
+    async def _mock_mark_tasks_revoked(task_ids: list[str]) -> None:
+        mark_tasks_revoked_calls.append(task_ids)
+
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.script_service.get_active_draft",
+        _mock_get_active_draft,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.validate_model_key",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.check_workspace_quota",
+        _mock_check_workspace_quota,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.cancel_workspace_quota_reservation",
+        _mock_cancel_workspace_quota_reservation,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard._get_fresh_run_for_dispatch",
+        _mock_get_fresh_run_for_dispatch,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.audio_service.list_paragraph_audio",
+        _mock_list_paragraph_audio,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.dispatch_paragraph_audio",
+        lambda **kwargs: "bulk-task-1",
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.record_task_queued",
+        _mock_record_task_queued,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.mark_tasks_revoked",
+        _mock_mark_tasks_revoked,
+    )
+    monkeypatch.setattr(
+        creator_runs_storyboard,
+        "__import__",
+        lambda name: SimpleNamespace(celery_app=celery_app)
+        if name == "celery_app"
+        else __import__(name),
+        raising=False,
+    )
+
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/generate-all-audio",
+            json={"tts_model": "qwen3-tts", "voice": "default"},
+        )
+        assert resp.status_code == 409
+        assert revoke_calls == ["bulk-task-1"]
+        assert mark_tasks_revoked_calls == [["bulk-task-1"]]
+    finally:
+        app.dependency_overrides.pop(require_run_access, None)
+
+
+@pytest.mark.asyncio
+async def test_bulk_subtitles_record_failure_revokes_task(
+    client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that mark_tasks_revoked is called when bulk subtitles dispatch faces record_task_queued failure."""
+    run = SimpleNamespace(
+        id=1,
+        status="running",
+        current_stage="VISUAL_ASSET_REVIEW",
+        project_id=1,
+    )
+
+    async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        _ = run_id
+        return CurrentUser(user_id=1, workspace_id=1), run
+
+    app.dependency_overrides[require_run_access] = _require_run_access
+
+    async def _mock_get_active_draft(_run_id: int) -> Any:
+        section = SimpleNamespace(
+            section_id="sec-1",
+            text="Hello",
+            display_text="Hello",
+            type="narration",
+            speaker=None,
+            duration=None,
+            turn_kind=None,
+            visual_override=None,
+            image_prompt=None,
+        )
+        return SimpleNamespace(structured_script=[section])
+
+    async def _mock_check_workspace_quota(
+        _workspace_id: int, operation_type: str
+    ) -> tuple[bool, str]:
+        _ = operation_type
+        return True, "ok"
+
+    async def _mock_cancel_workspace_quota_reservation(
+        _workspace_id: int, operation_type: str
+    ) -> None:
+        _ = operation_type
+        return None
+
+    async def _mock_get_fresh_run_for_dispatch(_run_id: int, _workspace_id: int) -> Any:
+        return SimpleNamespace(id=1, status="running", current_stage="VISUAL_ASSET_REVIEW")
+
+    async def _mock_list_paragraph_audio(_run_id: int) -> list:
+        audio = SimpleNamespace(section_id="sec-1", path="/audio.mp3", id=1)
+        return [audio]
+
+    async def _mock_list_paragraph_subtitles(_run_id: int) -> list:
+        return []
+
+    async def _mock_record_task_queued(_run_id: int, _task_name: str, _task_id: str) -> None:
+        raise RuntimeError("db failure")
+
+    revoke_calls: list[str] = []
+    mark_tasks_revoked_calls: list[list[str]] = []
+    celery_app = SimpleNamespace(
+        control=SimpleNamespace(
+            revoke=lambda task_id, terminate=False: revoke_calls.append(task_id)
+        )
+    )
+
+    async def _mock_mark_tasks_revoked(task_ids: list[str]) -> None:
+        mark_tasks_revoked_calls.append(task_ids)
+
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.script_service.get_active_draft",
+        _mock_get_active_draft,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.validate_model_key",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.check_workspace_quota",
+        _mock_check_workspace_quota,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.cancel_workspace_quota_reservation",
+        _mock_cancel_workspace_quota_reservation,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard._get_fresh_run_for_dispatch",
+        _mock_get_fresh_run_for_dispatch,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.audio_service.list_paragraph_audio",
+        _mock_list_paragraph_audio,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.subtitle_service.list_paragraph_subtitles",
+        _mock_list_paragraph_subtitles,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.dispatch_paragraph_subtitles",
+        lambda **kwargs: "sub-task-1",
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.record_task_queued",
+        _mock_record_task_queued,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.mark_tasks_revoked",
+        _mock_mark_tasks_revoked,
+    )
+    monkeypatch.setattr(
+        creator_runs_storyboard,
+        "__import__",
+        lambda name: SimpleNamespace(celery_app=celery_app)
+        if name == "celery_app"
+        else __import__(name),
+        raising=False,
+    )
+
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/generate-all-subtitles",
+            json={"subtitle_model": "whisper-small", "subtitle_format": "srt"},
+        )
+        # Bulk endpoints catch exceptions and append error entries
+        assert revoke_calls == ["sub-task-1"]
+        assert mark_tasks_revoked_calls == [["sub-task-1"]]
     finally:
         app.dependency_overrides.pop(require_run_access, None)

--- a/apps/api/tests/test_storyboard_cancelled.py
+++ b/apps/api/tests/test_storyboard_cancelled.py
@@ -9,6 +9,7 @@ import pytest
 
 from shorts_api.auth import require_run_access, CurrentUser
 from shorts_api.main import app
+from shorts_api.routes import creator_runs_storyboard
 
 
 def _make_cancelled_run() -> Any:
@@ -78,3 +79,147 @@ async def test_generate_all_paragraph_subtitles_rejects_cancelled_run(
     )
     assert resp.status_code == 409
     assert "cancelled" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_blocked_on_concurrent_cancellation(
+    client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = SimpleNamespace(
+        id=1,
+        status="running",
+        current_stage="VISUAL_ASSET_REVIEW",
+        project_id=1,
+    )
+
+    async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        return CurrentUser(user_id=1, workspace_id=1), run
+
+    app.dependency_overrides[require_run_access] = _require_run_access
+
+    async def _mock_get_active_draft(_run_id: int) -> Any:
+        return SimpleNamespace(
+            structured_script=[SimpleNamespace(section_id="sec-1", text="hello")]
+        )
+
+    async def _mock_check_workspace_quota(
+        _workspace_id: int, operation_type: str
+    ) -> tuple[bool, str]:
+        return True, "ok"
+
+    async def _mock_get_run(_run_id: int, workspace_id: int) -> Any:
+        return SimpleNamespace(id=1, status="cancelled", current_stage="VISUAL_ASSET_REVIEW")
+
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.script_service.get_active_draft",
+        _mock_get_active_draft,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.validate_model_key",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.check_workspace_quota",
+        _mock_check_workspace_quota,
+    )
+    monkeypatch.setattr(
+        creator_runs_storyboard,
+        "run_service",
+        SimpleNamespace(get_run=_mock_get_run),
+        raising=False,
+    )
+
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-audio",
+            json={"tts_model": "qwen3-tts", "voice": "default"},
+        )
+        assert resp.status_code == 409
+        assert "cancelled" in resp.json()["detail"].lower()
+    finally:
+        app.dependency_overrides.pop(require_run_access, None)
+
+
+@pytest.mark.asyncio
+async def test_record_task_queued_failure_revokes_task(
+    client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = SimpleNamespace(
+        id=1,
+        status="running",
+        current_stage="VISUAL_ASSET_REVIEW",
+        project_id=1,
+    )
+
+    async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        return CurrentUser(user_id=1, workspace_id=1), run
+
+    app.dependency_overrides[require_run_access] = _require_run_access
+
+    async def _mock_get_active_draft(_run_id: int) -> Any:
+        return SimpleNamespace(
+            structured_script=[SimpleNamespace(section_id="sec-1", text="hello")]
+        )
+
+    async def _mock_check_workspace_quota(
+        _workspace_id: int, operation_type: str
+    ) -> tuple[bool, str]:
+        return True, "ok"
+
+    async def _mock_get_run(_run_id: int, workspace_id: int) -> Any:
+        return SimpleNamespace(id=1, status="running", current_stage="VISUAL_ASSET_REVIEW")
+
+    async def _mock_record_task_queued(_run_id: int, _task_name: str, _task_id: str) -> None:
+        raise RuntimeError("db failure")
+
+    revoke_calls: list[tuple[str, bool]] = []
+    celery_app = SimpleNamespace(
+        control=SimpleNamespace(
+            revoke=lambda task_id, terminate=False: revoke_calls.append((task_id, terminate))
+        )
+    )
+
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.script_service.get_active_draft",
+        _mock_get_active_draft,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.validate_model_key",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.check_workspace_quota",
+        _mock_check_workspace_quota,
+    )
+    monkeypatch.setattr(
+        creator_runs_storyboard,
+        "run_service",
+        SimpleNamespace(get_run=_mock_get_run),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.dispatch_paragraph_audio",
+        lambda **kwargs: "task-123",
+    )
+    monkeypatch.setattr(
+        "shorts_api.routes.creator_runs_storyboard.task_tracking_service.record_task_queued",
+        _mock_record_task_queued,
+    )
+    monkeypatch.setattr(
+        creator_runs_storyboard,
+        "__import__",
+        lambda name: SimpleNamespace(celery_app=celery_app)
+        if name == "celery_app"
+        else __import__(name),
+        raising=False,
+    )
+
+    try:
+        resp = await client.post(
+            "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-audio",
+            json={"tts_model": "qwen3-tts", "voice": "default"},
+        )
+        assert resp.status_code == 503
+        assert revoke_calls == [("task-123", True)]
+    finally:
+        app.dependency_overrides.pop(require_run_access, None)

--- a/apps/api/tests/test_storyboard_cancelled.py
+++ b/apps/api/tests/test_storyboard_cancelled.py
@@ -608,6 +608,10 @@ async def test_bulk_subtitles_record_failure_revokes_task(
             json={"subtitle_model": "whisper-small", "subtitle_format": "srt"},
         )
         # Bulk endpoints catch exceptions and append error entries
+        data = resp.json()
+        assert resp.status_code == 202
+        assert data["failed"] >= 1
+        assert any(t.get("error") == "dispatch_failed" for t in data["tasks"])
         assert revoke_calls == ["sub-task-1"]
         assert mark_tasks_revoked_calls == [["sub-task-1"]]
     finally:

--- a/apps/api/tests/test_storyboard_cancelled.py
+++ b/apps/api/tests/test_storyboard_cancelled.py
@@ -1,0 +1,80 @@
+"""Tests that storyboard paragraph endpoints reject cancelled runs with 409."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from shorts_api.auth import require_run_access, CurrentUser
+from shorts_api.main import app
+
+
+def _make_cancelled_run() -> Any:
+    return SimpleNamespace(
+        id=1,
+        status="cancelled",
+        current_stage="VISUAL_ASSET_REVIEW",
+        project_id=1,
+    )
+
+
+@pytest.fixture()
+def _override_cancelled(client: Any) -> Any:  # noqa: ARG001 – client needed for setup order
+    run = _make_cancelled_run()
+
+    async def _require_run_access(run_id: int) -> tuple[CurrentUser, Any]:
+        return CurrentUser(user_id=1, workspace_id=1), run
+
+    app.dependency_overrides[require_run_access] = _require_run_access
+    yield
+    app.dependency_overrides.pop(require_run_access, None)
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_audio_rejects_cancelled_run(
+    client: Any, _override_cancelled: Any
+) -> None:
+    resp = await client.post(
+        "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-audio",
+        json={"tts_model": "qwen3-tts", "voice": "default"},
+    )
+    assert resp.status_code == 409
+    assert "cancelled" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_paragraph_subtitles_rejects_cancelled_run(
+    client: Any, _override_cancelled: Any
+) -> None:
+    resp = await client.post(
+        "/api/creator/runs/1/storyboard/paragraphs/sec-1/generate-subtitles",
+        json={"subtitle_model": "whisper-small", "subtitle_format": "srt"},
+    )
+    assert resp.status_code == 409
+    assert "cancelled" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_all_paragraph_audio_rejects_cancelled_run(
+    client: Any, _override_cancelled: Any
+) -> None:
+    resp = await client.post(
+        "/api/creator/runs/1/storyboard/generate-all-audio",
+        json={"tts_model": "qwen3-tts", "voice": "default"},
+    )
+    assert resp.status_code == 409
+    assert "cancelled" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_all_paragraph_subtitles_rejects_cancelled_run(
+    client: Any, _override_cancelled: Any
+) -> None:
+    resp = await client.post(
+        "/api/creator/runs/1/storyboard/generate-all-subtitles",
+        json={"subtitle_model": "whisper-small", "subtitle_format": "srt"},
+    )
+    assert resp.status_code == 409
+    assert "cancelled" in resp.json()["detail"].lower()

--- a/packages/creator-service/creator_service/postgres_run_storage.py
+++ b/packages/creator-service/creator_service/postgres_run_storage.py
@@ -111,6 +111,7 @@ class PostgresRunStorage:
         updates: dict[str, Any],
         expected_stages: frozenset[str],
         workspace_id: int | None = None,
+        rejected_statuses: frozenset[str] | None = None,
     ) -> tuple[bool, dict[str, Any] | None]:
         if not updates:
             current = await self.get_run(run_id, workspace_id=workspace_id)
@@ -130,6 +131,9 @@ class PostgresRunStorage:
         assignments = f"{assignments}, version = version + 1"
         values = [run_id, list(expected_stages), *[updates[key] for key in keys]]
         where_clauses = ["id = $1", "current_stage = ANY($2::text[])"]
+        if rejected_statuses is not None:
+            where_clauses.append(f"status != ALL(${len(values) + 1}::text[])")
+            values.append(list(rejected_statuses))
         if workspace_id is not None:
             where_clauses.append(f"workspace_id = ${len(values) + 1}")
             values.append(workspace_id)

--- a/packages/creator-service/creator_service/run_service.py
+++ b/packages/creator-service/creator_service/run_service.py
@@ -41,6 +41,7 @@ class RunStorageBackend(Protocol):
         updates: dict[str, Any],
         expected_stages: frozenset[str],
         workspace_id: int | None = None,
+        rejected_statuses: frozenset[str] | None = None,
     ) -> tuple[bool, dict[str, Any] | None]:
         """Atomically update run only if current_stage is in expected_stages.
 
@@ -134,6 +135,7 @@ class InMemoryRunStorage:
         updates: dict[str, Any],
         expected_stages: frozenset[str],
         workspace_id: int | None = None,
+        rejected_statuses: frozenset[str] | None = None,
     ) -> tuple[bool, dict[str, Any] | None]:
         row = self._rows.get(run_id)
         if row is None:
@@ -141,6 +143,8 @@ class InMemoryRunStorage:
         if workspace_id is not None and row.get("workspace_id") != workspace_id:
             return False, None
         if row.get("current_stage") not in expected_stages:
+            return False, dict(row)
+        if rejected_statuses and row.get("status") in rejected_statuses:
             return False, dict(row)
         row.update(updates)
         row["version"] = int(row.get("version") or 0) + 1

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -214,6 +214,19 @@ class TaskDispatchService:
         workspace_id: int | None = None,
     ) -> dict[str, object]:
         run_service_obj = cast(Any, run_service)
+
+        # Reject dispatch for cancelled runs to prevent race between
+        # stop_run() and concurrent trigger requests.
+        try:
+            _pre_run = await run_service_obj.get_run(run_id)
+        except Exception:
+            _pre_run = None
+        if _pre_run is not None and getattr(_pre_run, "status", None) == "cancelled":
+            raise HTTPException(
+                status_code=409,
+                detail="Run is cancelled; cannot dispatch new tasks",
+            )
+
         workspace_id_for_reservation: int | None = None
         if quota_operation_type is not None:
             from creator_service.project_service import project_service

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -219,7 +219,13 @@ class TaskDispatchService:
         # stop_run() and concurrent trigger requests.
         # Fail-closed: if we cannot verify status, block dispatch.
         try:
-            _pre_run = await run_service_obj.get_run(run_id)
+            if workspace_id is not None:
+                try:
+                    _pre_run = await run_service_obj.get_run(run_id, workspace_id=workspace_id)
+                except TypeError:
+                    _pre_run = await run_service_obj.get_run(run_id)
+            else:
+                _pre_run = await run_service_obj.get_run(run_id)
         except Exception:
             raise HTTPException(
                 status_code=503,

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -217,11 +217,17 @@ class TaskDispatchService:
 
         # Reject dispatch for cancelled runs to prevent race between
         # stop_run() and concurrent trigger requests.
+        # Fail-closed: if we cannot verify status, block dispatch.
         try:
             _pre_run = await run_service_obj.get_run(run_id)
         except Exception:
-            _pre_run = None
-        if _pre_run is not None and getattr(_pre_run, "status", None) == "cancelled":
+            raise HTTPException(
+                status_code=503,
+                detail="Unable to verify run status; dispatch blocked",
+            ) from None
+        if _pre_run is None:
+            raise HTTPException(status_code=404, detail="Run not found")
+        if getattr(_pre_run, "status", None) == "cancelled":
             raise HTTPException(
                 status_code=409,
                 detail="Run is cancelled; cannot dispatch new tasks",

--- a/packages/creator-service/creator_service/task_dispatch_service.py
+++ b/packages/creator-service/creator_service/task_dispatch_service.py
@@ -281,12 +281,21 @@ class TaskDispatchService:
         if rollback_stage == restart_stage:
             updates["restart_from"] = target_stage
 
-        ok, row = await run_service_obj.storage.conditional_update_run(
-            run_id,
-            updates,
-            expected_stages=expected_stages,
-            workspace_id=workspace_id,
-        )
+        try:
+            ok, row = await run_service_obj.storage.conditional_update_run(
+                run_id,
+                updates,
+                expected_stages=expected_stages,
+                workspace_id=workspace_id,
+                rejected_statuses=frozenset({"cancelled"}),
+            )
+        except TypeError:
+            ok, row = await run_service_obj.storage.conditional_update_run(
+                run_id,
+                updates,
+                expected_stages=expected_stages,
+                workspace_id=workspace_id,
+            )
         if not ok:
             if workspace_id_for_reservation is not None and quota_operation_type is not None:
                 from creator_service.usage_service import cancel_workspace_quota_reservation
@@ -365,6 +374,46 @@ class TaskDispatchService:
                 workspace_id=workspace_id,
             )
             raise HTTPException(status_code=503, detail=enqueue_error_detail) from None
+
+        try:
+            if workspace_id is not None:
+                try:
+                    _post_run = await run_service_obj.get_run(run_id, workspace_id=workspace_id)
+                except TypeError:
+                    _post_run = await run_service_obj.get_run(run_id)
+            else:
+                _post_run = await run_service_obj.get_run(run_id)
+        except Exception:
+            _post_run = None
+
+        if _post_run is None or getattr(_post_run, "status", None) == "cancelled":
+            try:
+                __import__("celery_app").celery_app.control.revoke(task_id, terminate=True)
+            except Exception:
+                logger.warning(
+                    "Failed to revoke task %s after concurrent cancel", task_id, exc_info=True
+                )
+            try:
+                tracking_service = import_module(
+                    "creator_service.task_tracking_service"
+                ).task_tracking_service
+                await tracking_service.mark_tasks_revoked([task_id])
+            except Exception:
+                logger.warning("Failed to mark task %s revoked", task_id, exc_info=True)
+            await run_service_obj.storage.conditional_update_run(
+                run_id,
+                {"current_stage": rollback_stage, "restart_from": rollback_restart_from},
+                expected_stages=frozenset({target_stage}),
+                workspace_id=workspace_id,
+            )
+            if workspace_id_for_reservation is not None and quota_operation_type is not None:
+                from creator_service.usage_service import cancel_workspace_quota_reservation
+
+                await cancel_workspace_quota_reservation(
+                    workspace_id_for_reservation,
+                    quota_operation_type,
+                )
+            raise HTTPException(status_code=409, detail="Run was cancelled during dispatch")
         return {
             "task_id": task_id,
             "run_id": run_id,

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -532,3 +532,55 @@ def test_cas_dispatch_with_rollback_returns_404_when_get_run_returns_none() -> N
 
     assert exc.value.status_code == 404
     assert "not found" in exc.value.detail.lower()
+
+
+def test_cas_dispatch_with_rollback_passes_workspace_id_to_preflight() -> None:
+    """Preflight get_run must forward workspace_id to match run_service contract."""
+    service = TaskDispatchService()
+    received_kwargs: list[dict[str, object]] = []
+
+    class _StrictRunStorage:
+        async def conditional_update_run(
+            self,
+            _run_id: int,
+            _updates: dict[str, object],
+            *,
+            expected_stages: frozenset[str],
+            workspace_id: int | None = None,
+        ) -> tuple[bool, dict[str, object] | None]:
+            return True, {"current_stage": "SCRIPT_GENERATING", "id": 42}
+
+    class _StrictRunService:
+        def __init__(self) -> None:
+            self.storage = _StrictRunStorage()
+
+        async def get_run(self, run_id: int, *, workspace_id: int | None = None) -> object:
+            received_kwargs.append({"run_id": run_id, "workspace_id": workspace_id})
+            return SimpleNamespace(status="running", project_id=1)
+
+    dispatched = False
+
+    def _dispatcher(**_: object) -> str:
+        nonlocal dispatched
+        dispatched = True
+        return "sync-test-42"
+
+    result = asyncio.run(
+        service.cas_dispatch_with_rollback(
+            run_id=42,
+            expected_stages=frozenset({"IDEA_READY", "SCRIPT_REVIEW"}),
+            target_stage="SCRIPT_GENERATING",
+            dispatcher=_dispatcher,
+            dispatcher_args={"run_id": 42},
+            run_service=_StrictRunService(),
+            rollback_stage="SCRIPT_REVIEW",
+            rollback_restart_from=None,
+            enqueue_error_detail="Failed to enqueue",
+            workspace_id=7,
+        )
+    )
+
+    assert dispatched
+    # The preflight call MUST have received workspace_id=7
+    assert len(received_kwargs) >= 1
+    assert received_kwargs[0]["workspace_id"] == 7

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -30,6 +30,9 @@ class _FakeRunService:
     def __init__(self) -> None:
         self.storage = _FakeRunStorage()
 
+    async def get_run(self, _run_id: int, **_kw: object) -> object:
+        return SimpleNamespace(status="running", project_id=1)
+
 
 def test_dispatch_generate_script_uses_sync_runner_when_redis_missing(
     monkeypatch: pytest.MonkeyPatch,
@@ -455,3 +458,77 @@ def test_cas_dispatch_with_rollback_allows_non_cancelled_run() -> None:
     )
 
     assert result["task_id"] == "sync-test-1-abc"
+
+
+def test_cas_dispatch_with_rollback_returns_503_when_get_run_raises() -> None:
+    """Fail-closed: if get_run raises, dispatch must be blocked with 503."""
+    service = TaskDispatchService()
+
+    class _ErrorRunStorage:
+        async def conditional_update_run(self, *_a: object, **_kw: object) -> object:
+            raise AssertionError("Should not reach CAS update")
+
+    class _ErrorRunService:
+        def __init__(self) -> None:
+            self.storage = _ErrorRunStorage()
+
+        async def get_run(self, _run_id: int, **_kw: object) -> object:
+            raise RuntimeError("DB connection lost")
+
+    def _dispatcher(**_: object) -> str:
+        raise AssertionError("Should not dispatch")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            service.cas_dispatch_with_rollback(
+                run_id=42,
+                expected_stages=frozenset({"SCRIPT_REVIEW"}),
+                target_stage="SCRIPT_GENERATING",
+                dispatcher=_dispatcher,
+                dispatcher_args={"run_id": 42},
+                run_service=_ErrorRunService(),
+                rollback_stage="SCRIPT_REVIEW",
+                rollback_restart_from=None,
+                enqueue_error_detail="Failed to enqueue",
+            )
+        )
+
+    assert exc.value.status_code == 503
+    assert "verify run status" in exc.value.detail.lower()
+
+
+def test_cas_dispatch_with_rollback_returns_404_when_get_run_returns_none() -> None:
+    """If get_run returns None, dispatch must be blocked with 404."""
+    service = TaskDispatchService()
+
+    class _NoneRunStorage:
+        async def conditional_update_run(self, *_a: object, **_kw: object) -> object:
+            raise AssertionError("Should not reach CAS update")
+
+    class _NoneRunService:
+        def __init__(self) -> None:
+            self.storage = _NoneRunStorage()
+
+        async def get_run(self, _run_id: int, **_kw: object) -> object:
+            return None
+
+    def _dispatcher(**_: object) -> str:
+        raise AssertionError("Should not dispatch")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            service.cas_dispatch_with_rollback(
+                run_id=999,
+                expected_stages=frozenset({"SCRIPT_REVIEW"}),
+                target_stage="SCRIPT_GENERATING",
+                dispatcher=_dispatcher,
+                dispatcher_args={"run_id": 999},
+                run_service=_NoneRunService(),
+                rollback_stage="SCRIPT_REVIEW",
+                rollback_restart_from=None,
+                enqueue_error_detail="Failed to enqueue",
+            )
+        )
+
+    assert exc.value.status_code == 404
+    assert "not found" in exc.value.detail.lower()

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -380,3 +380,78 @@ def test_cas_dispatch_with_rollback_releases_quota_on_stage_conflict(
 
     assert exc.value.status_code == 409
     assert cancel_calls == [(999, "llm")]
+
+
+def test_cas_dispatch_with_rollback_rejects_cancelled_run() -> None:
+    """cas_dispatch_with_rollback must refuse to dispatch for cancelled runs."""
+    service = TaskDispatchService()
+
+    class _CancelledRunStorage:
+        async def conditional_update_run(
+            self,
+            _run_id: int,
+            _updates: dict[str, object],
+            *,
+            expected_stages: frozenset[str],
+            workspace_id: int | None = None,
+        ) -> tuple[bool, dict[str, object] | None]:
+            raise AssertionError("Should not reach CAS update for cancelled run")
+
+    class _CancelledRunService:
+        def __init__(self) -> None:
+            self.storage = _CancelledRunStorage()
+
+        async def get_run(self, _run_id: int, **_kw: object) -> object:
+            return SimpleNamespace(status="cancelled", project_id=1)
+
+    def _dispatcher(**_: object) -> str:
+        raise AssertionError("Should not dispatch for cancelled run")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            service.cas_dispatch_with_rollback(
+                run_id=42,
+                expected_stages=frozenset({"IDEA_READY", "SCRIPT_REVIEW"}),
+                target_stage="SCRIPT_GENERATING",
+                dispatcher=_dispatcher,
+                dispatcher_args={"run_id": 42},
+                run_service=_CancelledRunService(),
+                rollback_stage="SCRIPT_REVIEW",
+                rollback_restart_from=None,
+                enqueue_error_detail="Failed to enqueue",
+            )
+        )
+
+    assert exc.value.status_code == 409
+    assert "cancelled" in exc.value.detail.lower()
+
+
+def test_cas_dispatch_with_rollback_allows_non_cancelled_run() -> None:
+    """cas_dispatch_with_rollback proceeds normally for non-cancelled runs."""
+    service = TaskDispatchService()
+    run_service = _FakeRunService()
+
+    # Patch get_run onto _FakeRunService so the cancelled-check can fetch status
+    async def _get_run(_run_id: int, **_kw: object) -> object:
+        return SimpleNamespace(status="running", project_id=1)
+
+    run_service.get_run = _get_run  # type: ignore[attr-defined]
+
+    def _dispatcher(**_: object) -> str:
+        return "sync-test-1-abc"
+
+    result = asyncio.run(
+        service.cas_dispatch_with_rollback(
+            run_id=7,
+            expected_stages=frozenset({"SCRIPT_REVIEW"}),
+            target_stage="SCRIPT_GENERATING",
+            dispatcher=_dispatcher,
+            dispatcher_args={"run_id": 7},
+            run_service=run_service,
+            rollback_stage="SCRIPT_REVIEW",
+            rollback_restart_from=None,
+            enqueue_error_detail="Failed to enqueue",
+        )
+    )
+
+    assert result["task_id"] == "sync-test-1-abc"

--- a/packages/creator-service/tests/test_task_dispatch_service.py
+++ b/packages/creator-service/tests/test_task_dispatch_service.py
@@ -12,7 +12,9 @@ from creator_service.task_dispatch_service import (
 
 class _FakeRunStorage:
     def __init__(self) -> None:
-        self.calls: list[tuple[int, dict[str, object], frozenset[str], int | None]] = []
+        self.calls: list[
+            tuple[int, dict[str, object], frozenset[str], int | None, frozenset[str] | None]
+        ] = []
 
     async def conditional_update_run(
         self,
@@ -21,8 +23,9 @@ class _FakeRunStorage:
         *,
         expected_stages: frozenset[str],
         workspace_id: int | None = None,
+        rejected_statuses: frozenset[str] | None = None,
     ) -> tuple[bool, dict[str, object] | None]:
-        self.calls.append((run_id, updates, expected_stages, workspace_id))
+        self.calls.append((run_id, updates, expected_stages, workspace_id, rejected_statuses))
         return True, {"current_stage": "SCRIPT_REVIEW"}
 
 
@@ -321,9 +324,11 @@ def test_cas_dispatch_with_rollback_releases_quota_on_stage_conflict(
             *,
             expected_stages: frozenset[str],
             workspace_id: int | None = None,
+            rejected_statuses: frozenset[str] | None = None,
         ) -> tuple[bool, dict[str, object] | None]:
             _ = expected_stages
             _ = workspace_id
+            _ = rejected_statuses
             return False, {"current_stage": "SCRIPT_GENERATING"}
 
     class _ConflictRunService:
@@ -397,7 +402,11 @@ def test_cas_dispatch_with_rollback_rejects_cancelled_run() -> None:
             *,
             expected_stages: frozenset[str],
             workspace_id: int | None = None,
+            rejected_statuses: frozenset[str] | None = None,
         ) -> tuple[bool, dict[str, object] | None]:
+            _ = expected_stages
+            _ = workspace_id
+            _ = rejected_statuses
             raise AssertionError("Should not reach CAS update for cancelled run")
 
     class _CancelledRunService:
@@ -429,6 +438,52 @@ def test_cas_dispatch_with_rollback_rejects_cancelled_run() -> None:
     assert "cancelled" in exc.value.detail.lower()
 
 
+def test_cas_dispatch_rejects_concurrent_cancellation_atomically() -> None:
+    service = TaskDispatchService()
+
+    class _ConcurrentCancelStorage:
+        async def conditional_update_run(
+            self,
+            _run_id: int,
+            _updates: dict[str, object],
+            *,
+            expected_stages: frozenset[str],
+            workspace_id: int | None = None,
+            rejected_statuses: frozenset[str] | None = None,
+        ) -> tuple[bool, dict[str, object] | None]:
+            _ = expected_stages
+            _ = workspace_id
+            _ = rejected_statuses
+            return False, {"current_stage": "SCRIPT_GENERATING", "status": "cancelled"}
+
+    class _ConcurrentCancelRunService:
+        def __init__(self) -> None:
+            self.storage = _ConcurrentCancelStorage()
+
+        async def get_run(self, _run_id: int, **_kw: object) -> object:
+            return SimpleNamespace(status="running", project_id=1)
+
+    def _dispatcher(**_: object) -> str:
+        raise AssertionError("Should not dispatch when CAS rejects cancelled run")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            service.cas_dispatch_with_rollback(
+                run_id=42,
+                expected_stages=frozenset({"SCRIPT_REVIEW"}),
+                target_stage="SCRIPT_GENERATING",
+                dispatcher=_dispatcher,
+                dispatcher_args={"run_id": 42},
+                run_service=_ConcurrentCancelRunService(),
+                rollback_stage="SCRIPT_REVIEW",
+                rollback_restart_from=None,
+                enqueue_error_detail="Failed to enqueue",
+            )
+        )
+
+    assert exc.value.status_code == 409
+
+
 def test_cas_dispatch_with_rollback_allows_non_cancelled_run() -> None:
     """cas_dispatch_with_rollback proceeds normally for non-cancelled runs."""
     service = TaskDispatchService()
@@ -458,6 +513,98 @@ def test_cas_dispatch_with_rollback_allows_non_cancelled_run() -> None:
     )
 
     assert result["task_id"] == "sync-test-1-abc"
+
+
+def test_cas_dispatch_post_dispatch_revoke_on_concurrent_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TaskDispatchService()
+    revoked: list[tuple[str, bool]] = []
+
+    class _Storage:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        async def conditional_update_run(
+            self,
+            run_id: int,
+            updates: dict[str, object],
+            *,
+            expected_stages: frozenset[str],
+            workspace_id: int | None = None,
+            rejected_statuses: frozenset[str] | None = None,
+        ) -> tuple[bool, dict[str, object] | None]:
+            self.calls.append(
+                {
+                    "run_id": run_id,
+                    "updates": updates,
+                    "expected_stages": expected_stages,
+                    "workspace_id": workspace_id,
+                    "rejected_statuses": rejected_statuses,
+                }
+            )
+            return True, {"current_stage": "SCRIPT_GENERATING"}
+
+    class _RunService:
+        def __init__(self) -> None:
+            self.storage = _Storage()
+            self._calls = 0
+
+        async def get_run(self, _run_id: int, **_kw: object) -> object:
+            self._calls += 1
+            if self._calls == 1:
+                return SimpleNamespace(status="running", project_id=1)
+            return SimpleNamespace(status="cancelled", project_id=1)
+
+    class _TrackingService:
+        async def record_task_queued(self, _run_id: int, _task_type: str, _task_id: str) -> None:
+            return None
+
+        async def mark_tasks_revoked(self, _task_ids: list[str]) -> None:
+            return None
+
+    celery_app_module = ModuleType("celery_app")
+    setattr(
+        celery_app_module,
+        "celery_app",
+        SimpleNamespace(
+            control=SimpleNamespace(
+                revoke=lambda task_id, terminate: revoked.append((task_id, terminate))
+            )
+        ),
+    )
+    monkeypatch.setitem(__import__("sys").modules, "celery_app", celery_app_module)
+
+    def fake_import_module(name: str) -> object:
+        if name == "creator_service.task_tracking_service":
+            return SimpleNamespace(task_tracking_service=_TrackingService())
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("creator_service.task_dispatch_service.import_module", fake_import_module)
+
+    run_service = _RunService()
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            service.cas_dispatch_with_rollback(
+                run_id=42,
+                expected_stages=frozenset({"SCRIPT_REVIEW"}),
+                target_stage="SCRIPT_GENERATING",
+                dispatcher=lambda **_: "celery-999",
+                dispatcher_args={"run_id": 42},
+                run_service=run_service,
+                rollback_stage="SCRIPT_REVIEW",
+                rollback_restart_from=None,
+                enqueue_error_detail="Failed to enqueue",
+            )
+        )
+
+    assert exc.value.status_code == 409
+    assert revoked == [("celery-999", True)]
+    assert run_service.storage.calls[1]["updates"] == {
+        "current_stage": "SCRIPT_REVIEW",
+        "restart_from": None,
+    }
 
 
 def test_cas_dispatch_with_rollback_returns_503_when_get_run_raises() -> None:
@@ -547,7 +694,11 @@ def test_cas_dispatch_with_rollback_passes_workspace_id_to_preflight() -> None:
             *,
             expected_stages: frozenset[str],
             workspace_id: int | None = None,
+            rejected_statuses: frozenset[str] | None = None,
         ) -> tuple[bool, dict[str, object] | None]:
+            _ = expected_stages
+            _ = workspace_id
+            _ = rejected_statuses
             return True, {"current_stage": "SCRIPT_GENERATING", "id": 42}
 
     class _StrictRunService:
@@ -565,7 +716,7 @@ def test_cas_dispatch_with_rollback_passes_workspace_id_to_preflight() -> None:
         dispatched = True
         return "sync-test-42"
 
-    result = asyncio.run(
+    asyncio.run(
         service.cas_dispatch_with_rollback(
             run_id=42,
             expected_stages=frozenset({"IDEA_READY", "SCRIPT_REVIEW"}),


### PR DESCRIPTION
## Summary
- Move `_revoke_active_tasks_for_run()` to execute AFTER `stop_run`/`delete_run` service calls succeed, not before
- Prevents revoking tasks when the service call would fail (conflict, not found)
- 4 new ordering tests verify correct sequencing and no-revoke-on-failure
- Updated existing test assertion for workspace mismatch case
- 1220 tests pass