### PR TITLE
fix(auth): revoke API keys via direct asyncpg query (#583)

### DIFF
--- a/apps/api/src/shorts_api/auth.py
+++ b/apps/api/src/shorts_api/auth.py
@@ -18,7 +18,6 @@ from creator_service.db import fetch_all, fetch_one
 from creator_service.workspace_service import workspace_service
 from fastapi import Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
-from sqlalchemy import text
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
@@ -59,33 +58,22 @@ def _extract_api_key(request: Request) -> str | None:
     return None
 
 
-class _FetchOneResult:
-    def __init__(self, row: tuple[object, ...] | None) -> None:
-        self._row = row
+async def _resolve_user_id_from_api_key(api_key: str, connection) -> str | None:
+    """Resolve a user_id from an API key, rejecting revoked keys.
 
-    def fetchone(self) -> tuple[object, ...] | None:
-        return self._row
-
-
-class _AsyncpgSessionAdapter:
-    def __init__(self, connection) -> None:
-        self._connection = connection
-
-    async def execute(self, query, params: dict[str, object]):
-        row = await self._connection.fetchrow("SELECT user_id FROM api_keys WHERE key_hash = $1", params["h"])
-        if row is None:
-            return _FetchOneResult(None)
-        return _FetchOneResult((row.get("user_id"),))
-
-
-async def _resolve_user_id_from_api_key(api_key: str, db_session) -> str | None:
+    Runs the asyncpg query directly against ``connection`` so the
+    ``revoked_at IS NULL`` filter cannot be silently dropped (the bug fixed
+    in #583 — the previous _AsyncpgSessionAdapter discarded the query and ran
+    its own filter-less SQL).
+    """
     key_hash = hashlib.sha256(api_key.encode()).hexdigest()
-    result = await db_session.execute(
-        text("SELECT user_id FROM api_keys WHERE key_hash = :h AND revoked_at IS NULL"),
-        {"h": key_hash},
+    row = await connection.fetchrow(
+        "SELECT user_id FROM api_keys WHERE key_hash = $1 AND revoked_at IS NULL",
+        key_hash,
     )
-    row = result.fetchone()
-    return row[0] if row else None
+    if row is None:
+        return None
+    return row["user_id"]
 
 
 _ADMIN_PATH_PREFIX = "/api/admin"
@@ -207,9 +195,7 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
             return JSONResponse(status_code=503, content={"detail": "Service unavailable"})
 
         async with pool.acquire() as connection:
-            user_id = await _resolve_user_id_from_api_key(
-                provided, _AsyncpgSessionAdapter(connection)
-            )
+            user_id = await _resolve_user_id_from_api_key(provided, connection)
         if user_id is None:
             return JSONResponse(
                 status_code=401,

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -3,6 +3,7 @@
 """Tests for API key authentication middleware."""
 
 import hashlib
+from datetime import datetime, timezone
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -296,6 +297,60 @@ async def test_middleware_without_workspace_membership_returns_404(api_key, monk
         assert response.status_code == 404
         assert response.json() == {"detail": "Not found"}
 
+
+@pytest.mark.asyncio
+async def test_revoked_api_key_returns_401(api_key, monkeypatch: pytest.MonkeyPatch):
+    """A revoked key (revoked_at set in the DB) must NOT authenticate.
+
+    Reproduces #583: the middleware adapter discarded the ``revoked_at IS NULL``
+    filter from the SQL, so revoked keys kept authenticating. The stub below
+    faithfully models a real asyncpg connection — it applies the WHERE clause
+    as written, so a query that omits the filter returns the row (the bug),
+    while a query that includes ``revoked_at IS NULL`` excludes the revoked row.
+    """
+    expected_hash = hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+    revoked_at = datetime.now(timezone.utc)
+
+    class _Conn:
+        # Models the real api_keys row: key exists but revoked_at is set.
+        async def fetchrow(self, query: str, key_hash: str):
+            if key_hash != expected_hash:
+                return None
+            # Real DB applies the WHERE clause verbatim.
+            if "revoked_at IS NULL" in query:
+                return None  # revoked row is filtered out
+            # Query without the filter still returns the row — this is the bug.
+            return {"user_id": 1, "revoked_at": revoked_at}
+
+        async def fetch(self, _query: str, user_id: int):
+            if user_id == 1:
+                return [{"workspace_id": 1}]
+            return []
+
+    class _Acquire:
+        async def __aenter__(self):
+            return _Conn()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            _ = (exc_type, exc, tb)
+            return False
+
+    class _Pool:
+        def acquire(self):
+            return _Acquire()
+
+    async def _get_pool_stub(self):
+        _ = self
+        return _Pool()
+
+    monkeypatch.setattr("shorts_api.auth.ApiKeyMiddleware._get_pool", _get_pool_stub)
+
+    app = _make_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/creator/data", headers={"X-API-Key": api_key})
+        assert response.status_code == 401
+        assert response.json() == {"detail": "API key is not associated with any user"}
 
 @pytest.mark.asyncio
 async def test_get_current_user_without_api_key_returns_401():


### PR DESCRIPTION
## Summary

- Removes the `_AsyncpgSessionAdapter` whose `execute()` method discarded the `query` argument and ran its own hardcoded SQL without the `revoked_at IS NULL` filter.
- `_resolve_user_id_from_api_key` now takes a raw asyncpg connection and runs the query inline with the security predicate.
- Adds a TDD regression test (`test_revoked_api_key_returns_401`) that reproduces the bypass with a faithful DB stub.

Closes #583.

## Verification

- `cd apps/api && python3 -m pytest tests/ -v` → 573 passed (5 pre-existing unrelated httpx errors in `test_multi_workspace_auth.py`, reproduce on `main`).
- New test `test_revoked_api_key_returns_401`: fails before fix (`assert 200 == 401`), passes after.
- basedpyright: clean on `auth.py`.
- Oracle review: **100/100** (no Critical/Major/Minor findings).

## Notes

The adapter indirection was itself the footgun — a layer that silently overrode the security-critical SQL. Removing it (rather than patching its query string) is the structural fix recommended in the review.