### PR TITLE
fix(worker): wire up Celery Beat + register retry task (#585)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,12 @@ jobs:
         run: cp .env.example .env
       - name: Validate docker-compose config
         run: docker compose config --quiet
+      - name: Verify celery beat service is defined
+        run: |
+          # Every beat_schedule entry needs a running beat process (#585).
+          docker compose config --services | grep -q '^beat$' \
+            || { echo 'ERROR: no beat service defined — scheduled tasks will never run'; exit 1; }
+        run: docker compose config --quiet
       - name: Verify API port not exposed on 0.0.0.0
         run: |
           # Ensure API, Postgres, and Redis are bound to 127.0.0.1 only
@@ -116,7 +122,7 @@ jobs:
         run: docker build --target runtime -f apps/worker-orchestrator/Dockerfile .
       - name: Smoke-test compose up
         run: |
-          docker compose up -d postgres redis api studio-web worker
+          docker compose up -d postgres redis api studio-web worker beat
           # Wait for API health endpoint
           timeout 60 bash -c 'until curl -sf http://localhost:8000/healthz; do sleep 2; done'
           # Verify API responds
@@ -127,6 +133,14 @@ jobs:
           curl -sf http://localhost:5174/
           # Verify worker container is running
           docker compose ps worker --format json | grep -q running
+          # Verify every beat_schedule task is registered on the worker (#585).
+          # Catches both missing include entries and NotRegistered at dispatch time.
+          for task in reconcile_stale_dispatches retry_failed_artifact_deletions; do
+            docker compose exec -T worker celery -A celery_app.celery_app inspect registered \
+              | grep -q "$task" \
+              || { echo "ERROR: beat task '$task' not registered on worker"; exit 1; }
+            echo "OK: $task registered"
+          done
           # --- Creator API smoke test ---
           # Run migrations
           docker compose exec -T api alembic upgrade head

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
           # Every beat_schedule entry needs a running beat process (#585).
           docker compose config --services | grep -q '^beat$' \
             || { echo 'ERROR: no beat service defined — scheduled tasks will never run'; exit 1; }
-        run: docker compose config --quiet
       - name: Verify API port not exposed on 0.0.0.0
         run: |
           # Ensure API, Postgres, and Redis are bound to 127.0.0.1 only

--- a/apps/worker-orchestrator/celery_app.py
+++ b/apps/worker-orchestrator/celery_app.py
@@ -109,6 +109,7 @@ celery_app = Celery(
         "tasks.generate_paragraph_audio",
         "tasks.generate_paragraph_subtitles",
         "tasks.reconcile_stale_dispatches",
+        "tasks.retry_failed_artifact_deletions",
     ],
 )
 celery_app.conf.task_default_queue = "creator"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,6 +22,17 @@ services:
       - ./packages/creator-provider/creator_provider:/usr/local/lib/python3.12/site-packages/creator_provider
       - ./packages/creator-domain/creator_domain:/usr/local/lib/python3.12/site-packages/creator_domain
 
+  # Mount source for live beat schedule reload during development.
+  beat:
+    build:
+      target: dev
+    volumes:
+      - ./apps/worker-orchestrator/tasks:/app/tasks
+      - ./apps/worker-orchestrator/celery_app.py:/app/celery_app.py
+      - ./packages/creator-service/creator_service:/usr/local/lib/python3.12/site-packages/creator_service
+      - ./packages/creator-provider/creator_provider:/usr/local/lib/python3.12/site-packages/creator_provider
+      - ./packages/creator-domain/creator_domain:/usr/local/lib/python3.12/site-packages/creator_domain
+
   # NOTE: This service is incompatible with docker-compose.local-server.yml.
   # The local-server override expects nginx on port 8080; this dev stage
   # runs Vite on 5173. Do not combine both overrides for studio-web.

--- a/docker-compose.scaled-workers.yml
+++ b/docker-compose.scaled-workers.yml
@@ -15,6 +15,22 @@ services:
   worker:
     profiles: ["disabled"]
 
+  # Beat scheduler must run as a single instance — independent of worker scaling.
+  beat:
+    build:
+      context: .
+      dockerfile: apps/worker-orchestrator/Dockerfile
+      target: runtime
+    command: ["celery", "-A", "celery_app.celery_app", "beat", "--loglevel=info"]
+    env_file:
+      - .env
+    environment:
+      PYTHONPATH: /app/src:/app
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
   worker-script:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,21 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # Celery Beat scheduler — required for any beat_schedule entry to actually fire.
+  # Without this, reconcile_stale_dispatches / retry_failed_artifact_deletions never run (#585).
+  beat:
+    build:
+      context: .
+      dockerfile: apps/worker-orchestrator/Dockerfile
+      target: runtime
+    command: ["celery", "-A", "celery_app.celery_app", "beat", "--loglevel=info"]
+    env_file:
+      - .env
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
   studio-web:
     build:
       context: .


### PR DESCRIPTION
## Summary

- Adds a dedicated `beat` service to `docker-compose.yml` (+ dev and scaled-workers overlays). Without it, every `beat_schedule` entry was dead code.
- Includes `tasks.retry_failed_artifact_deletions` in `celery_app.include` so the worker actually registers it (would have raised `NotRegistered`).
- CI now (1) asserts a `beat` service is defined, (2) starts it during the smoke, and (3) runs `celery -A celery_app.celery_app inspect registered` to verify every beat task is registered on the worker — catches both bugs in one check.

Closes #585.

## Verification

- `docker compose config --quiet` — valid for base, base+dev, base+scaled-workers.
- `docker compose config --services` lists `beat` in all three variants.
- `cd apps/worker-orchestrator && python -m pytest tests/` → 215 passed, 4 pre-existing failures (reproduce on `main`: `test_render_video.py` x3, `test_retry_config.py::test_task_retry_policies`), 1 pre-existing collection error (`test_task_message_validation.py`).

## Why a single-instance beat service (not `-B` on a worker)

Embedding beat in a worker via `-B` is fragile under `--scale` and with `docker-compose.scaled-workers.yml`'s per-queue workers — multiple beat instances would double-fire schedules. A dedicated single container is the Celery-recommended production setup.