### PR TITLE
fix(routes): prefer storage_key over absolute file_path for local downloads (#584)

### DIFF
--- a/apps/api/src/shorts_api/routes/creator_artifact_download.py
+++ b/apps/api/src/shorts_api/routes/creator_artifact_download.py
@@ -56,14 +56,34 @@ async def download_artifact(
     ):
         raise HTTPException(status_code=410, detail="Artifact has expired")
 
-    artifact_root = os.path.realpath(os.getenv("ARTIFACT_ROOT", "data/artifacts"))
-    artifact_path = artifact.get("file_path")
+    artifact_root_str = os.getenv("ARTIFACT_ROOT", "data/artifacts")
+    artifact_root = os.path.realpath(artifact_root_str)
+
+    # Prefer storage_key (always root-relative) over file_path (absolute since
+    # render_video.py stores `{_ARTIFACT_ROOT}/{run_id}/render/...`). Using
+    # file_path directly triggers the leading-component guard and returns 404 (#584).
+    artifact_path = artifact.get("storage_key") or artifact.get("file_path")
     if not isinstance(artifact_path, str) or not artifact_path:
         raise HTTPException(status_code=404, detail="Artifact not found")
 
-    normalized = artifact_path.replace("\\", "/")
-    path_components = normalized.split("/")
-    if any(component in {"", ".", ".."} for component in path_components):
+    # Legacy rows may still carry an absolute file_path; strip the artifact root
+    # so the remaining components are root-relative.
+    try:
+        rel_path = os.path.relpath(artifact_path, artifact_root_str)
+    except ValueError:
+        # Different drives on Windows — fall back to the raw value.
+        rel_path = artifact_path
+    if rel_path == ".." or rel_path.startswith("../") or rel_path.startswith(f"..{os.sep}"):
+        # file_path was not under ARTIFACT_ROOT; keep the original so the
+        # component guard + commonpath check below reject it safely.
+        rel_path = artifact_path
+        # file_path was not under ARTIFACT_ROOT; keep the original so the
+        # component guard + commonpath check below reject it safely.
+        rel_path = artifact_path
+
+    normalized = rel_path.replace("\\", "/")
+    path_components = [c for c in normalized.split("/") if c not in {"", "."}]
+    if any(component in {".."} for component in path_components):
         raise HTTPException(status_code=404, detail="Artifact not found")
 
     try:

--- a/apps/api/src/shorts_api/routes/creator_artifact_download.py
+++ b/apps/api/src/shorts_api/routes/creator_artifact_download.py
@@ -77,9 +77,6 @@ async def download_artifact(
         # file_path was not under ARTIFACT_ROOT; keep the original so the
         # component guard + commonpath check below reject it safely.
         rel_path = artifact_path
-        # file_path was not under ARTIFACT_ROOT; keep the original so the
-        # component guard + commonpath check below reject it safely.
-        rel_path = artifact_path
 
     normalized = rel_path.replace("\\", "/")
     path_components = [c for c in normalized.split("/") if c not in {"", "."}]

--- a/apps/api/tests/test_artifact_download.py
+++ b/apps/api/tests/test_artifact_download.py
@@ -152,6 +152,77 @@ async def test_download_artifact_nonexistent_returns_404(client, monkeypatch: py
 
 
 @pytest.mark.asyncio
+async def test_download_artifact_uses_storage_key_over_absolute_file_path(
+    client, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Worker-format artifact must download successfully (#584).
+
+    Workers store the absolute path in file_path and the root-relative
+    storage_key separately. The route must prefer storage_key; using
+    file_path directly triggers the leading-component guard and returns 404.
+    """
+    artifact_root = tmp_path
+    rel_key = "1/render/output.mp4"
+    target = artifact_root / rel_key
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"worker-format-video")
+
+    # Mirrors what render_video.py + PostgresRenderStorage persist:
+    #   file_path = absolute ({ARTIFACT_ROOT}/...)
+    #   storage_key = root-relative
+    stub = StubArtifactDownloadService(
+        {
+            "id": 910,
+            "run_id": 100,
+            "file_path": str(artifact_root / rel_key),
+            "storage_key": rel_key,
+            "storage_provider": "local",
+            "content_type": "video/mp4",
+        }
+    )
+
+    _patch_route_services(monkeypatch, stub)
+    monkeypatch.setenv("ARTIFACT_ROOT", str(artifact_root))
+
+    response = await client.get("/api/creator/runs/100/artifacts/910/download")
+
+    assert response.status_code == 200
+    assert response.content == b"worker-format-video"
+
+
+@pytest.mark.asyncio
+async def test_download_artifact_normalizes_legacy_absolute_file_path(
+    client, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Legacy rows without storage_key must still resolve via file_path (#584).
+
+    Some rows may predate storage_key. The route should strip a leading
+    ARTIFACT_ROOT prefix from file_path so those downloads keep working.
+    """
+    artifact_root = tmp_path
+    rel_key = "1/legacy/audio.wav"
+    target = artifact_root / rel_key
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"legacy-audio")
+
+    stub = StubArtifactDownloadService(
+        {
+            "id": 911,
+            "run_id": 100,
+            "file_path": str(artifact_root / rel_key),  # absolute, no storage_key
+            "storage_provider": "local",
+        }
+    )
+
+    _patch_route_services(monkeypatch, stub)
+    monkeypatch.setenv("ARTIFACT_ROOT", str(artifact_root))
+
+    response = await client.get("/api/creator/runs/100/artifacts/911/download")
+
+    assert response.status_code == 200
+    assert response.content == b"legacy-audio"
+
+@pytest.mark.asyncio
 async def test_old_artifact_endpoint_returns_404_for_missing_file(client):
     response = await client.get("/artifacts/1/100/audio.wav")
     assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Route now prefers `storage_key` (always root-relative) over `file_path` (absolute — `{ARTIFACT_ROOT}/{run_id}/render/output.mp4`). Reading `file_path` directly caused every local download to 404 because the leading-component guard rejected `.` (./data) and `""` (/data).
- Legacy rows without `storage_key`: `os.path.relpath(file_path, ARTIFACT_ROOT)` normalizes absolute paths to root-relative so those downloads keep working.
- The existing triple traversal defense (per-component `sanitize_path_component` + `realpath` + `commonpath` containment) is unchanged and remains the authoritative guard.
- Tightened the `startswith("..")` check to only catch real parent traversals (Oracle Minor feedback: the original was over-broad for `..foo`-style names).

Closes #584.

## TDD

- `test_download_artifact_uses_storage_key_over_absolute_file_path` — mirrors worker format (`file_path` absolute, `storage_key` root-relative). Fails `404 != 200` before fix.
- `test_download_artifact_normalizes_legacy_absolute_file_path` — legacy row with absolute `file_path` and no `storage_key`. Fails before fix.

## Verification

- Artifact suite (5 files): 23/23 pass.
- Full API suite: 574 passed, 5 pre-existing unrelated httpx errors (reproduce on `main`).
- Oracle review: **98/100** → Minor `startswith("..")` addressed in this commit.

## Why the bug wasn't caught

`test_artifact_download.py:130` stubbed the artifact with a root-relative `file_path` like `"1/999/audio.wav"` — a shape the real worker never produces. The unit test exercised the sanitize logic but never the worker → DB → download path. New tests close that gap.