### PR TITLE
fix(nginx): use $http_host in CSRF check so port is included (#586)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,4 +151,17 @@ jobs:
             -d '{"style_preset":"default"}' \
             http://localhost:8000/api/creator/projects/$PROJECT_ID/runs
           echo "Creator API smoke test passed"
+          # --- nginx CSRF smoke test (#586) ---
+          # POST through nginx (port 5174) with the real browser Origin header.
+          # Before the fix, $host didn't include the port, so the CSRF check
+          # rejected every write with 403.
+          NGINX_POST_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+            -H "Origin: http://127.0.0.1:5174" \
+            -H "X-API-Key: $API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{"title":"Nginx CSRF Smoke","source_type":"idea","idea_brief":"nginx"}' \
+            http://localhost:5174/api/creator/projects)
+          [ "$NGINX_POST_CODE" = "200" ] || [ "$NGINX_POST_CODE" = "201" ] \
+            || { echo "Expected 2xx for nginx-proxied POST with valid Origin, got $NGINX_POST_CODE"; exit 1; }
+          echo "nginx CSRF smoke passed ($NGINX_POST_CODE)"
           docker compose down

--- a/apps/studio-web/nginx.conf.template
+++ b/apps/studio-web/nginx.conf.template
@@ -16,7 +16,7 @@ server {
     # Proxy API requests to the backend
     location /api/ {
         set $csrf_check 0;
-        if ($http_origin = "$scheme://$host") {
+        if ($http_origin = "$scheme://$http_host") {
             set $csrf_check 1;
         }
         if ($request_method !~ ^(GET|HEAD|OPTIONS)$) {


### PR DESCRIPTION
## Summary

- `nginx.conf.template`: `\$host` → `\$http_host`. nginx's `\$host` omits the port, so on the default `127.0.0.1:5174` compose mapping the browser Origin (`http://127.0.0.1:5174`) never matched `\$scheme://\$host` (`http://127.0.0.1`) — every POST/PATCH/DELETE returned 403 and users couldn't even create a project from the UI.
- CI: added a POST through nginx (port 5174) with the real browser Origin header. Before the fix this would have returned 403; the existing curl-based smoke only exercised GETs so it missed the regression.

Closes #586.

## Verification

- `docker compose config --quiet` still passes (template already used envsubst; only the comparison expression changed).
- The smoke step runs against the `studio-web` container the CI already starts, so no new service is required.