### PR TITLE
chore: polish batch — content-disposition, legacy nginx, docs, makefile (#588)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Celery Beat scheduler service (`beat`) in `docker-compose.yml` (+ dev and scaled-workers overlays) so scheduled tasks actually run (#585).
+- `retry_failed_artifact_deletions` and `sweep_expired_artifacts` registered in `celery_app.include` (#585, #587).
+- `ARTIFACT_RETENTION_DAYS` env var (default 90) + `sweep_expired_artifacts` beat task that marks expired artifacts for deletion (#587).
+- CI smoke: `celery inspect registered` verifies every beat task is registered on the worker (#585).
+- CI smoke: POST through nginx (port 5174) with the browser Origin header to catch CSRF regressions (#586).
+
+### Fixed
+
+- API key revocation silently bypassed — `_AsyncpgSessionAdapter` discarded the `revoked_at IS NULL` filter. Adapter removed; the resolver now runs the asyncpg query directly (#583).
+- Local artifact downloads always returned 404 — the route read `file_path` (absolute) instead of `storage_key` (root-relative). Legacy rows now normalized via `os.path.relpath` (#584).
+- nginx CSRF check rejected default compose port — `$host` doesn't include the port, switched to `$http_host` (#586).
+
+## [0.4.0] - 2026-07-23
+
+### Added
+
 - Mermaid architecture diagrams in README (system topology, pipeline flow, package dependencies)
 - CI pipeline with lint, test (coverage), Docker build, and smoke test
 - Community files: CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md
@@ -23,6 +39,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Authenticated artifact route replacing static file mounts
 - Paragraph-level generation with per-section skip/retry logic
 - Human-in-the-loop review gates at every pipeline stage
+- ADR-006 (API key auth) and ADR-007 (OAuth2/OIDC roadmap, Supabase primary)
+- `api_keys.name` and `api_keys.revoked_at` columns (migration 029)
+- Server-side `expires_at` default on `creator_artifacts` (migration 030)
+- Deletion retry metadata on `creator_artifacts` (`delete_requested_at`, `delete_failed_at`, `delete_retry_count`)
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	python3 -m pip install -r apps/api/requirements.txt -r apps/worker-orchestrator/requirements.txt
+	python3 -m pip install -c constraints.txt -r apps/api/requirements.txt -r apps/worker-orchestrator/requirements.txt
 	npm --prefix apps/studio-web install
 
 dev:

--- a/apps/api/src/shorts_api/routes/creator_artifact_download.py
+++ b/apps/api/src/shorts_api/routes/creator_artifact_download.py
@@ -97,5 +97,28 @@ async def download_artifact(
     if not os.path.isfile(resolved_path):
         raise HTTPException(status_code=404, detail="Artifact not found")
 
-    content_type = artifact.get("content_type") or artifact.get("mime_type")
-    return FileResponse(resolved_path, media_type=content_type)
+    raw_content_type = artifact.get("content_type") or artifact.get("mime_type")
+    # Defense in depth: only allow known artifact MIME types and force download.
+    # Prevents the API origin from ever rendering HTML/SVG as a document.
+    _ALLOWED_CONTENT_TYPES = frozenset({
+        "video/mp4",
+        "video/webm",
+        "audio/wav",
+        "audio/mpeg",
+        "audio/mp3",
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+        "text/vtt",
+        "application/x-subrip",
+        "application/octet-stream",
+    })
+    content_type = raw_content_type if raw_content_type in _ALLOWED_CONTENT_TYPES else "application/octet-stream"
+
+    artifact_id_str = str(artifact.get("id", artifact_id))
+    filename = safe_components[-1] if safe_components else f"artifact-{artifact_id_str}"
+    return FileResponse(
+        resolved_path,
+        media_type=content_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/apps/api/tests/test_artifact_download.py
+++ b/apps/api/tests/test_artifact_download.py
@@ -222,6 +222,66 @@ async def test_download_artifact_normalizes_legacy_absolute_file_path(
     assert response.status_code == 200
     assert response.content == b"legacy-audio"
 
+
+@pytest.mark.asyncio
+async def test_download_artifact_forces_attachment_disposition(
+    client, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Downloads must be served as attachments with a whitelisted MIME (#588)."""
+    artifact_rel_path = "1/100/audio.wav"
+    target_path = tmp_path / artifact_rel_path
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_bytes(b"test-audio")
+
+    stub = StubArtifactDownloadService(
+        {
+            "id": 920,
+            "run_id": 100,
+            "file_path": artifact_rel_path,
+            "storage_provider": "local",
+            "content_type": "audio/wav",
+        }
+    )
+
+    _patch_route_services(monkeypatch, stub)
+    monkeypatch.setenv("ARTIFACT_ROOT", str(tmp_path))
+
+    response = await client.get("/api/creator/runs/100/artifacts/920/download")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert response.headers["content-disposition"] == 'attachment; filename="audio.wav"'
+
+
+@pytest.mark.asyncio
+async def test_download_artifact_rejects_untrusted_content_type(
+    client, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Untrusted content_type falls back to application/octet-stream (#588)."""
+    artifact_rel_path = "1/100/evil.html"
+    target_path = tmp_path / artifact_rel_path
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_bytes(b"<script>x</script>")
+
+    stub = StubArtifactDownloadService(
+        {
+            "id": 921,
+            "run_id": 100,
+            "file_path": artifact_rel_path,
+            "storage_provider": "local",
+            "content_type": "text/html",
+        }
+    )
+
+    _patch_route_services(monkeypatch, stub)
+    monkeypatch.setenv("ARTIFACT_ROOT", str(tmp_path))
+
+    response = await client.get("/api/creator/runs/100/artifacts/921/download")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/octet-stream"
+    assert response.headers["content-disposition"].startswith("attachment;")
+
 @pytest.mark.asyncio
 async def test_old_artifact_endpoint_returns_404_for_missing_file(client):
     response = await client.get("/artifacts/1/100/audio.wav")

--- a/apps/studio-web/nginx.conf.template
+++ b/apps/studio-web/nginx.conf.template
@@ -35,14 +35,6 @@ server {
         proxy_set_header X-API-Key "${API_KEY}";
     }
 
-    # Proxy artifact requests to the backend
-    location /artifacts/ {
-        proxy_pass http://api:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-API-Key "${API_KEY}";
-    }
-
     # Proxy health/docs endpoints so frontend can use same-origin relative URLs
     location /health {
         proxy_pass http://api:8000;

--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -37,15 +37,15 @@ Operator-facing guide for deploying and verifying the short-form-studio system.
    | `OLLAMA_BASE_URL` | Yes | Default: `http://ollama:11434` |
    | `OLLAMA_DEFAULT_MODEL` | Yes | Default: `qwen3:4b` |
    | `STABLE_DIFFUSION_BASE_URL` | Yes | Default: `http://stable-diffusion:7860` |
-| `TTS_QWEN3_BASE_URL` | Yes | Default: `http://tts-qwen3:8100` |
-| `STT_WHISPER_BASE_URL` | Yes | Default: `http://stt-whisper:8200` |
+   | `TTS_QWEN3_BASE_URL` | Yes | Default: `http://tts-qwen3:8100` |
+   | `STT_WHISPER_BASE_URL` | Yes | Default: `http://stt-whisper:8200` |
    | `GPU_LOCK_KEY` | Yes | Default: `gpu:lock` |
    | `GPU_LOCK_TIMEOUT_SECONDS` | Yes | Default: `600` |
-| `OPENAI_API_KEY` | No | External LLM/Image/TTS provider |
-| `ANTHROPIC_API_KEY` | No | External LLM provider |
-| `GOOGLE_API_KEY` | No | External LLM/Image provider |
-| `STABILITY_API_KEY` | No | External image provider |
-| `ELEVENLABS_API_KEY` | No | External TTS fallback |
+   | `OPENAI_API_KEY` | No | External LLM/Image/TTS provider |
+   | `ANTHROPIC_API_KEY` | No | External LLM provider |
+   | `GOOGLE_API_KEY` | No | External LLM/Image provider |
+   | `STABILITY_API_KEY` | No | External image provider |
+   | `ELEVENLABS_API_KEY` | No | External TTS fallback |
 
 3. **Ensure AI model images exist** (pre-built locally; not shipped in this repo)
 
@@ -53,7 +53,7 @@ Operator-facing guide for deploying and verifying the short-form-studio system.
    docker images | grep short-form-studio
    # Expected:
    #   short-form-studio-stable-diffusion
-#   short-form-studio-tts-qwen3
+   #   short-form-studio-tts-qwen3
    #   short-form-studio-stt-whisper
    ```
 


### PR DESCRIPTION
## Summary

Six low-risk polish items from the review, batched to keep churn contained:

| Item | Change |
|---|---|
| **Content-Type whitelist + Content-Disposition: attachment** | Download route now forces a MIME whitelist and `attachment` disposition, so the API origin can never render HTML/SVG as a document. |
| **Legacy `/artifacts/` nginx location** | Removed — downloads go through `/api/creator/runs/{id}/artifacts/{id}/download`; the old location served nothing and only handed out the API key to a dead path. |
| **`make install` ignores constraints** | Now installs with `-c constraints.txt`, matching CI — local and CI resolve identical versions. |
| **`CHANGELOG.md` all `[Unreleased]`** | Split into `## [0.4.0] - 2026-07-23` with the released content; fresh `[Unreleased]` seeded with the P0/P1 fixes from #583–#587. |
| **`docs/CUTOVER.md` broken markdown** | Re-aligned the mixed-indent rows in the env-var table so it renders again (renaming-sweep casualty). |

## Deferred (follow-ups)

- **`uv.lock`** — generation requires workspace source declarations in each member `pyproject.toml` (`creator-service` → `creator-domain` etc.). Tracked as a separate task.
- **Commit author attribution** — maintainer call; no code change.

Closes #588.

## Verification

- Full API suite: 574 passed, 5 pre-existing httpx errors (reproduce on `main`).
- Artifact suite: 23/23 (includes 2 new Content-Disposition tests).
- `docker compose config --quiet` valid (nginx template change).
- `ruff check` — no new errors (pre-existing import-sort warning is unchanged).