### PR TITLE
fix(sweep): parse asyncpg status string correctly (#596)

### DIFF
--- a/packages/creator-service/creator_service/artifact_download_service.py
+++ b/packages/creator-service/creator_service/artifact_download_service.py
@@ -160,8 +160,8 @@ class ArtifactDownloadService:
             ")",
             batch_size,
         )
-        # asyncpg CommandComplete returns a status string like 'UPDATE N'.
-        status = getattr(result, "statusmessage", "") or ""
+        # db.execute() returns the asyncpg status string directly ("UPDATE N").
+        status = result if isinstance(result, str) else (getattr(result, "statusmessage", "") or "")
         try:
             return int(status.rsplit(" ", 1)[-1])
         except (TypeError, ValueError):

--- a/packages/creator-service/tests/test_artifact_download_service.py
+++ b/packages/creator-service/tests/test_artifact_download_service.py
@@ -509,13 +509,13 @@ async def test_sweep_expired_marks_rows_for_deletion(
     """sweep_expired sets delete_requested_at on rows past expires_at (#587)."""
     captured: dict[str, object] = {}
 
-    class _Result:
-        statusmessage = "UPDATE 7"
-
-    async def _execute(query: str, *args: object) -> object:
+    # db.execute() returns the asyncpg status string (e.g. "UPDATE 7").
+    # The previous test invented a fake _Result.statusmessage class that
+    # did not match the real contract — that's how #596 slipped through.
+    async def _execute(query: str, *args: object) -> str:
         captured["query"] = query
         captured["batch_size"] = args[0] if args else None
-        return _Result()
+        return "UPDATE 7"
 
     monkeypatch.setattr("creator_service.artifact_download_service.execute", _execute)
 
@@ -534,11 +534,8 @@ async def test_sweep_expired_marks_rows_for_deletion(
 async def test_sweep_expired_returns_zero_when_nothing_matched(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class _Result:
-        statusmessage = "UPDATE 0"
-
-    async def _execute(query: str, *args: object) -> object:
-        return _Result()
+    async def _execute(query: str, *args: object) -> str:
+        return "UPDATE 0"
 
     monkeypatch.setattr("creator_service.artifact_download_service.execute", _execute)
 


### PR DESCRIPTION
## Summary

`sweep_expired()` always returned 0 because `db.execute()` returns a plain `str` (`"UPDATE 7"`) but the code read `getattr(result, "statusmessage", "")` — `str` has no `statusmessage`, so it got `""` → `int("")` → `ValueError` → `return 0`.

Same failure class as #583: the test invented a fake `_Result` class with `.statusmessage` instead of using the real `db.execute` contract.

## Fix

- Handle both `str` (current contract) and object-with-`statusmessage` (defensive) return types.
- Fix tests to return plain `str`, matching `db.execute`'s actual signature.

Closes #596.

## Verification

- `cd packages/creator-service && python -m pytest tests/test_artifact_download_service.py` → 19/19 pass.
- New test `test_sweep_expired_marks_rows_for_deletion` now uses `return "UPDATE 7"` (real contract); fails before fix (`assert 0 == 7`), passes after.
- basedpyright + ruff clean.