### PR TITLE
fix(dockerfile): include scripts/ + fix dev stage USER root (#597)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -21,6 +21,7 @@ COPY --chown=appuser:appuser apps/api/migrations ./migrations
 # Worker task modules needed by API for Celery task dispatch (import_module)
 COPY --chown=appuser:appuser apps/worker-orchestrator/tasks ./tasks
 COPY --chown=appuser:appuser apps/worker-orchestrator/celery_app.py ./celery_app.py
+COPY --chown=appuser:appuser scripts ./scripts
 ENV PYTHONPATH=/app/src:/app
 USER appuser
 EXPOSE 8000
@@ -28,5 +29,7 @@ CMD ["uvicorn", "shorts_api.main:app", "--host", "0.0.0.0", "--port", "8000"]
 
 # --- dev stage ---
 FROM runtime AS dev
+USER root
 RUN pip install --no-cache-dir watchfiles
+USER appuser
 CMD ["uvicorn", "shorts_api.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]


### PR DESCRIPTION
## Summary

Two API Dockerfile fixes:

1. **`scripts/` missing** — `create_api_key.py` (first-key bootstrap) was absent from the runtime image. Fresh container deployments returned 401 for everything with no way to create the first key. CI smoke and Makefile both call `docker compose exec api python scripts/create_api_key.py ...` but the file wasn't in the image.
2. **Dev stage `USER appuser` inheritance** — `FROM runtime AS dev` inherited `USER appuser`, then `RUN pip install watchfiles` failed without write permission. Added `USER root` before install, `USER appuser` after — matching the worker Dockerfile pattern (P2-2.3 from #602).

Closes #597.

## Verification

- `docker build --target runtime -f apps/api/Dockerfile .` → succeeds.
- `docker run --rm <image> ls /app/scripts/` → shows `create_api_key.py` and others.
- `docker build --target dev -f apps/api/Dockerfile .` → succeeds (pip install no longer permission-denied).