### PR TITLE
fix(nginx): use X-Forwarded-Proto for CSRF scheme behind TLS proxy (#598)

### DIFF
--- a/apps/studio-web/nginx.conf.template
+++ b/apps/studio-web/nginx.conf.template
@@ -1,3 +1,12 @@
+# Recover the client-visible scheme from X-Forwarded-Proto so the CSRF
+# origin check works behind a TLS-terminating reverse proxy (#598).
+# When no proxy sets the header, fall back to the connection scheme.
+map $http_x_forwarded_proto $client_scheme {
+    default $scheme;
+    https   https;
+    http    http;
+}
+
 server {
     listen 8080;
     root /usr/share/nginx/html;
@@ -16,7 +25,7 @@ server {
     # Proxy API requests to the backend
     location /api/ {
         set $csrf_check 0;
-        if ($http_origin = "$scheme://$http_host") {
+        if ($http_origin = "$client_scheme://$http_host") {
             set $csrf_check 1;
         }
         if ($request_method !~ ^(GET|HEAD|OPTIONS)$) {


### PR DESCRIPTION
## Summary

`$scheme` reflects the connection nginx sees, not the client-visible scheme. Behind a TLS-terminating reverse proxy (standard production setup), nginx receives plain HTTP → `$scheme = http`, but the browser Origin is `https://...` → mismatch → all writes 403. Same failure mode as #586 (port mismatch), on the protocol.

Added a `map` that recovers the client scheme from `X-Forwarded-Proto` (defaults to `$scheme` when unset), and the CSRF check now compares against `$client_scheme://$http_host`.

Closes #598.

## Verification

- `docker compose config --quiet` → valid.
- `nginx -t` parses the template (verified via `docker run nginx:alpine` — `map` block is syntactically valid; only `${API_KEY}` envsubst and `api` upstream resolution fail outside the compose network, both expected).