### PR TITLE
fix(migration): compute expires_at at INSERT time, not in DDL (#599)

### DIFF
--- a/apps/api/migrations/versions/032_artifact_retention_app_side.py
+++ b/apps/api/migrations/versions/032_artifact_retention_app_side.py
@@ -1,0 +1,62 @@
+"""Move artifact retention computation from DDL to application.
+
+Revision ID: 032
+Revises: 031
+Create Date: 2026-08-09 01:00:00.000000
+
+Migration 031 baked ARTIFACT_RETENTION_DAYS into the DDL default, making the
+schema non-deterministic (depends on environment at apply time). This breaks
+reproducibility: two databases with the same schema version may have different
+default expressions.
+
+This migration reverts the DDL default to a constant 90 days. Retention is now
+computed at INSERT time in application code (``packages/creator-service``),
+which:
+
+1. Makes the schema deterministic (same for all deployments)
+2. Lets operators tune retention per-deployment without schema changes
+3. Keeps all configuration in the runtime environment
+
+The DDL default (90 days) serves as a fallback only. The application always
+computes ``expires_at`` explicitly at INSERT, so the default is never used for
+new rows created by the app. Existing rows created before this migration retain
+their current ``expires_at`` values.
+
+Companion changes:
+- ``packages/creator-service/creator_service/postgres_render_storage.py``
+- ``packages/creator-service/creator_service/postgres_audio_storage.py``
+- ``packages/creator-service/creator_service/postgres_subtitle_storage.py``
+
+All three files now compute ``expires_at`` from ARTIFACT_RETENTION_DAYS at
+INSERT time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "032"
+down_revision: str | None = "031"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Revert to a constant DDL default (same as 030).
+    # Retention is now computed at INSERT time in application code.
+    op.execute(
+        "ALTER TABLE creator_artifacts "
+        "ALTER COLUMN expires_at SET DEFAULT (NOW() + INTERVAL '90 days')"
+    )
+
+
+def downgrade() -> None:
+    # This would restore the environment-dependent default from 031,
+    # but doing so would require reading ARTIFACT_RETENTION_DAYS at downgrade time.
+    # For safety, we just restore a constant 90-day default here.
+    op.execute(
+        "ALTER TABLE creator_artifacts "
+        "ALTER COLUMN expires_at SET DEFAULT (NOW() + INTERVAL '90 days')"
+    )

--- a/packages/creator-service/creator_service/postgres_audio_storage.py
+++ b/packages/creator-service/creator_service/postgres_audio_storage.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .db import fetch_all, fetch_one
@@ -38,6 +40,15 @@ class PostgresAudioStorage:
             row.get("size_bytes") or row.get("file_size_bytes") or metadata_dict.get("size_bytes")
         )
 
+        # Compute expires_at from ARTIFACT_RETENTION_DAYS (default 90)
+        retention_days = int(os.getenv('ARTIFACT_RETENTION_DAYS', '90'))
+        retention_days = retention_days if retention_days > 0 else 90
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(days=retention_days)
+            if retention_days > 0
+            else None
+        )
+
         saved = await fetch_one(
             """
             INSERT INTO creator_artifacts (
@@ -52,9 +63,10 @@ class PostgresAudioStorage:
                 storage_backend,
                 storage_key,
                 content_type,
-                size_bytes
+                size_bytes,
+                expires_at
             )
-            VALUES ($1, 'audio', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            VALUES ($1, 'audio', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
             ON CONFLICT (idempotency_key) DO NOTHING
             RETURNING *
             """,
@@ -69,6 +81,7 @@ class PostgresAudioStorage:
             storage_key,
             content_type,
             size_bytes,
+            expires_at,
         )
         if saved is None and isinstance(idempotency_key, str):
             existing = await fetch_one(

--- a/packages/creator-service/creator_service/postgres_render_storage.py
+++ b/packages/creator-service/creator_service/postgres_render_storage.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .db import fetch_all, fetch_one
@@ -38,6 +40,15 @@ class PostgresRenderStorage:
             row.get("size_bytes") or row.get("file_size_bytes") or metadata_dict.get("size_bytes")
         )
 
+        # Compute expires_at from ARTIFACT_RETENTION_DAYS (default 90)
+        retention_days = int(os.getenv('ARTIFACT_RETENTION_DAYS', '90'))
+        retention_days = retention_days if retention_days > 0 else 90
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(days=retention_days)
+            if retention_days > 0
+            else None
+        )
+
         saved = await fetch_one(
             """
             INSERT INTO creator_artifacts (
@@ -52,9 +63,10 @@ class PostgresRenderStorage:
                 storage_backend,
                 storage_key,
                 content_type,
-                size_bytes
+                size_bytes,
+                expires_at
             )
-            VALUES ($1, 'video', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            VALUES ($1, 'video', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
             ON CONFLICT (idempotency_key) DO NOTHING
             RETURNING *
             """,
@@ -69,6 +81,7 @@ class PostgresRenderStorage:
             storage_key,
             content_type,
             size_bytes,
+            expires_at,
         )
         if saved is None and isinstance(idempotency_key, str):
             existing = await fetch_one(

--- a/packages/creator-service/creator_service/postgres_subtitle_storage.py
+++ b/packages/creator-service/creator_service/postgres_subtitle_storage.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .db import fetch_all, fetch_one
@@ -38,6 +40,15 @@ class PostgresSubtitleStorage:
             row.get("size_bytes") or row.get("file_size_bytes") or metadata_dict.get("size_bytes")
         )
 
+        # Compute expires_at from ARTIFACT_RETENTION_DAYS (default 90)
+        retention_days = int(os.getenv('ARTIFACT_RETENTION_DAYS', '90'))
+        retention_days = retention_days if retention_days > 0 else 90
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(days=retention_days)
+            if retention_days > 0
+            else None
+        )
+
         saved = await fetch_one(
             """
             INSERT INTO creator_artifacts (
@@ -52,9 +63,10 @@ class PostgresSubtitleStorage:
                 storage_backend,
                 storage_key,
                 content_type,
-                size_bytes
+                size_bytes,
+                expires_at
             )
-            VALUES ($1, 'subtitle', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            VALUES ($1, 'subtitle', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
             ON CONFLICT (idempotency_key) DO NOTHING
             RETURNING *
             """,
@@ -69,6 +81,7 @@ class PostgresSubtitleStorage:
             storage_key,
             content_type,
             size_bytes,
+            expires_at,
         )
         if saved is None and isinstance(idempotency_key, str):
             existing = await fetch_one(


### PR DESCRIPTION
## Summary

Move artifact retention computation from environment-dependent DDL default to runtime application code. This ensures the schema is deterministic and reproducible across all deployments.

**Problem:** Migration 031 bakes ARTIFACT_RETENTION_DAYS into the DDL default at apply time, making the schema non-deterministic. Two databases with the same schema version may have different default expressions depending on the environment.

**Solution:** Revert DDL default to a constant 90 days. The application computes expires_at at INSERT time from ARTIFACT_RETENTION_DAYS, making the schema deterministic while keeping retention tunable per deployment.

## Changes

- **Migration 032**: Reverts `expires_at` DDL default to constant `90 days` (fallback only)
- **postgres_render_storage.py**: Compute `expires_at` from `ARTIFACT_RETENTION_DAYS` at INSERT
- **postgres_audio_storage.py**: Compute `expires_at` from `ARTIFACT_RETENTION_DAYS` at INSERT
- **postgres_subtitle_storage.py**: Compute `expires_at` from `ARTIFACT_RETENTION_DAYS` at INSERT

## Testing

- Creator-service tests: 492 passed (pre-existing failures: test_render_profile, test_run_service)
- Alembic heads: single head 032 confirmed
- Ruff checks: all passed

## Impact

- **Schema determinism**: The DDL default is now constant across all deployments
- **Retention tunability**: Operators can adjust `ARTIFACT_RETENTION_DAYS` per deployment without schema changes
- **Fallback safety**: DDL default (90 days) serves as fallback for rows created outside the app