### PR TITLE
fix: replace RLIMIT_AS with cgroup memory limits (#611)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,12 @@ ARTIFACT_ROOT=./data/artifacts
 # Default: 90
 # ARTIFACT_RETENTION_DAYS=90
 
+# OPTIONAL: Memory limit for API and worker containers (MB).
+# Enforced via Docker cgroup (deploy.resources.limits.memory), NOT RLIMIT_AS.
+# RLIMIT_AS caused MemoryError on CUDA/torch/ffmpeg which reserve large
+# virtual address ranges. API default: 1024, worker default: 4096.
+# MAX_MEMORY_MB=4096
+
 # OPTIONAL: Object storage backend. Default 'local' stores on filesystem.
 STORAGE_BACKEND=local           # 'local', 's3', or 'azure_blob'
 # CONDITIONAL: Required when STORAGE_BACKEND=s3

--- a/apps/api/src/shorts_api/lifecycle.py
+++ b/apps/api/src/shorts_api/lifecycle.py
@@ -54,16 +54,16 @@ ENABLE_PROCESS_RESOURCE_GUARD = os.getenv("ENABLE_PROCESS_RESOURCE_GUARD", "fals
 
 
 def _apply_resource_limits() -> None:
-    memory_limit_bytes = MAX_MEMORY_MB * 1024 * 1024
-    try:
-        resource.setrlimit(resource.RLIMIT_AS, (memory_limit_bytes, memory_limit_bytes))
-    except (OSError, ValueError):
-        logger.error(
-            "Failed to set RLIMIT_AS to %d bytes during startup",
-            memory_limit_bytes,
-            exc_info=True,
-        )
-        raise
+    """Memory limits are now enforced via cgroup (Docker deploy.resources.limits.memory).
+
+    RLIMIT_AS was previously used but caused MemoryError on processes that
+    reserve large virtual address ranges (CUDA/torch/ffmpeg) even when RSS
+    is low (#611). Kept as a no-op for backward compatibility.
+    """
+    logger.info(
+        "Memory limit: MAX_MEMORY_MB=%d (enforced via cgroup, not RLIMIT_AS)",
+        MAX_MEMORY_MB,
+    )
 
 
 def _cpu_usage_percent(

--- a/apps/api/tests/test_production_safety_limits.py
+++ b/apps/api/tests/test_production_safety_limits.py
@@ -25,7 +25,13 @@ def _load_worker_module(monkeypatch: pytest.MonkeyPatch, module_name: str):
     return module
 
 
-def test_worker_applies_memory_setrlimit_from_env(monkeypatch: pytest.MonkeyPatch):
+def test_worker_does_not_call_setrlimit(monkeypatch: pytest.MonkeyPatch):
+    """RLIMIT_AS was replaced by cgroup memory limits (#611).
+
+    The worker's _apply_resource_limits() must NOT call setrlimit, because
+    RLIMIT_AS causes MemoryError on CUDA/torch/ffmpeg which reserve large
+    virtual address ranges.
+    """
     setrlimit_mock = Mock()
     monkeypatch.setenv("MAX_MEMORY_MB", "2048")
 
@@ -34,14 +40,10 @@ def test_worker_applies_memory_setrlimit_from_env(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(resource, "setrlimit", setrlimit_mock)
     module = _load_worker_module(monkeypatch, "worker_orchestrator_celery_app_test")
 
-    # Resource limits are now applied inside _apply_resource_limits(), not at import
     module._apply_resource_limits()
 
-    expected_bytes = 2048 * 1024 * 1024
-    setrlimit_mock.assert_called_once_with(
-        resource.RLIMIT_AS,
-        (expected_bytes, expected_bytes),
-    )
+    # setrlimit must NOT be called — memory is enforced via cgroup.
+    setrlimit_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -70,16 +72,15 @@ async def test_cpu_monitor_triggers_shutdown_flag(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.asyncio
-async def test_api_startup_fails_when_setrlimit_fails(monkeypatch: pytest.MonkeyPatch):
+async def test_api_startup_does_not_call_setrlimit(monkeypatch: pytest.MonkeyPatch):
+    """RLIMIT_AS was replaced by cgroup memory limits (#611)."""
     from shorts_api import lifecycle
 
-    def fail_setrlimit(_limit, _values):
-        raise OSError("setrlimit failed")
+    setrlimit_mock = Mock()
+    monkeypatch.setattr(lifecycle.resource, "setrlimit", setrlimit_mock)
 
-    monkeypatch.setattr(lifecycle, "ENABLE_PROCESS_RESOURCE_GUARD", True)
-    monkeypatch.setattr(lifecycle.resource, "setrlimit", fail_setrlimit)
+    from shorts_api.main import app
+    async with lifecycle.lifespan(app):
+        pass
 
-    with pytest.raises(OSError, match="setrlimit failed"):
-        from shorts_api.main import app
-        async with lifecycle.lifespan(app):
-            pass
+    setrlimit_mock.assert_not_called()

--- a/apps/worker-orchestrator/celery_app.py
+++ b/apps/worker-orchestrator/celery_app.py
@@ -86,9 +86,14 @@ def is_shutting_down() -> bool:
     return _SHUTDOWN_REQUESTED
 
 def _apply_resource_limits() -> None:
-    """Apply memory limits. Only call from worker process startup."""
-    memory_limit_bytes = MAX_MEMORY_MB * 1024 * 1024
-    resource.setrlimit(resource.RLIMIT_AS, (memory_limit_bytes, memory_limit_bytes))
+    """Memory limits are now enforced via cgroup (Docker deploy.resources.limits.memory).
+
+    RLIMIT_AS was previously used but caused MemoryError on CUDA/torch/ffmpeg
+    which reserve large virtual address ranges even when RSS is low (#611).
+    The function is kept as a no-op for backward compatibility — callers still
+    invoke it during startup.
+    """
+    logging.getLogger(__name__).info("Memory limit: MAX_MEMORY_MB=%d (enforced via cgroup, not RLIMIT_AS)", MAX_MEMORY_MB)
 
 
 redis_url = os.getenv("REDIS_URL", "redis://redis:6379/0")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,10 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: ${MAX_MEMORY_MB:-1024}M
 
   worker:
     build:
@@ -67,6 +71,12 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: ${MAX_MEMORY_MB:-4096}M
+
+  # Celery Beat scheduler
 
   # Celery Beat scheduler — required for any beat_schedule entry to actually fire.
   # Without this, reconcile_stale_dispatches / retry_failed_artifact_deletions never run (#585).


### PR DESCRIPTION
## Summary

`RLIMIT_AS` limits virtual address space, not actual memory. CUDA/torch/ffmpeg reserve large virtual ranges at init (2-3GB+), causing `MemoryError` under 4GB `RLIMIT_AS` even when RSS is well under physical RAM.

### Changes

- **Worker `celery_app.py`**: `_apply_resource_limits()` is now a no-op that logs the config. No more `setrlimit(RLIMIT_AS)`.
- **API `lifecycle.py`**: same — no-op, no `setrlimit`.
- **`docker-compose.yml`**: `deploy.resources.limits.memory` added to `api` (`${MAX_MEMORY_MB:-1024}M`) and `worker` (`${MAX_MEMORY_MB:-4096}M`).
- **Tests**: updated to assert `setrlimit` is NOT called.
- **`.env.example`**: `MAX_MEMORY_MB` documented as cgroup-enforced.

Closes #611.

## Verification

- `test_production_safety_limits.py`: 3/3 pass (assert no setrlimit call).
- Full API suite: 579 passed, 5 pre-existing errors.
- `docker compose config --quiet` valid; memory limits present (1GB API, 4GB worker).